### PR TITLE
Add MATLAB config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ The spatial scale (pixels per millimeter) and frame rate are supplied when
 loading the movie so that the simulation can handle different resolutions and
 durations.
 
+### Loading simulation parameters from JSON
+
+Common simulation options can be stored in a JSON configuration file and loaded
+with `load_config.m`:
+
+```matlab
+cfg = load_config('tests/sample_config.json');
+result = navigation_model_vec(cfg.triallength, cfg.environment, ...
+    cfg.plotting, cfg.ntrials);
+```
+
 
 ## Repository Layout
 

--- a/load_config.m
+++ b/load_config.m
@@ -1,0 +1,8 @@
+function cfg = load_config(path)
+%LOAD_CONFIG Load simulation parameters from a JSON file
+%   CFG = LOAD_CONFIG(PATH) reads the JSON file specified by PATH and
+%   returns a struct with the parameters.
+
+jsonText = fileread(path);
+cfg = jsondecode(jsonText);
+end

--- a/tests/sample_config.json
+++ b/tests/sample_config.json
@@ -1,0 +1,6 @@
+{
+  "environment": "gaussian",
+  "triallength": 100,
+  "plotting": 0,
+  "ntrials": 5
+}

--- a/tests/test_load_config.m
+++ b/tests/test_load_config.m
@@ -1,0 +1,11 @@
+classdef test_load_config < matlab.unittest.TestCase
+    methods(Test)
+        function testSampleConfig(testCase)
+            cfg = load_config('tests/sample_config.json');
+            testCase.verifyEqual(cfg.environment, 'gaussian');
+            testCase.verifyEqual(cfg.triallength, 100);
+            testCase.verifyEqual(cfg.plotting, 0);
+            testCase.verifyEqual(cfg.ntrials, 5);
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add a MATLAB-only `load_config.m`
- test the JSON loader with MATLAB unit tests
- document JSON configuration usage in the README

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*