### PR TITLE
Replace Python loader with MATLAB helper

### DIFF
--- a/Code/load_config.m
+++ b/Code/load_config.m
@@ -1,0 +1,14 @@
+function cfg = load_config(path)
+%LOAD_CONFIG Load simulation parameters from a JSON file.
+%   CFG = LOAD_CONFIG(PATH) reads the JSON file specified by PATH and
+%   returns a struct with the decoded parameters.
+
+fid = fopen(path, 'r');
+if fid == -1
+    error('Could not open configuration file: %s', path);
+end
+raw = fread(fid, '*char')';
+fclose(fid);
+
+cfg = jsondecode(raw);
+end

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ result = navigation_model_vec(triallength, environment, plotting, ntrials);
 
 For parameter sweeps, use `runmodel.m` to systematically vary model parameters across trials.
 
+### Loading parameters from a configuration file
+
+You can also store simulation parameters in a JSON file and load them in MATLAB
+using the `load_config` helper:
+
+```matlab
+cfg = load_config(fullfile('tests', 'sample_config.json'));
+result = navigation_model_vec(cfg.triallength, cfg.environment, cfg.plotting, cfg.ntrials);
+```
+
 ### Using custom plume videos
 
 To run the model with your own plume movies, convert the `.avi` file to a

--- a/tests/sample_config.json
+++ b/tests/sample_config.json
@@ -1,0 +1,6 @@
+{
+  "environment": "gaussian",
+  "triallength": 100,
+  "plotting": 0,
+  "ntrials": 5
+}

--- a/tests/test_load_config.m
+++ b/tests/test_load_config.m
@@ -1,0 +1,11 @@
+function tests = test_load_config
+    tests = functiontests(localfunctions);
+end
+
+function testLoadSampleConfig(testCase)
+    cfg = load_config(fullfile('tests','sample_config.json'));
+    verifyEqual(testCase, cfg.environment, "gaussian");
+    verifyEqual(testCase, cfg.triallength, 100);
+    verifyEqual(testCase, cfg.plotting, 0);
+    verifyEqual(testCase, cfg.ntrials, 5);
+end


### PR DESCRIPTION
## Summary
- add MATLAB `load_config` helper
- document `load_config` in README
- add MATLAB unit test for `load_config`

## Testing
- `matlab -batch "runtests('tests')"` *(fails: `matlab` not found)*
