### PR TITLE
Remove duplicate config loader

### DIFF
--- a/load_config.m
+++ b/load_config.m
@@ -1,8 +1,0 @@
-function cfg = load_config(path)
-%LOAD_CONFIG Load simulation parameters from a JSON file
-%   CFG = LOAD_CONFIG(PATH) reads the JSON file specified by PATH and
-%   returns a struct with the parameters.
-
-jsonText = fileread(path);
-cfg = jsondecode(jsonText);
-end

--- a/tests/test_load_config.m
+++ b/tests/test_load_config.m
@@ -1,5 +1,10 @@
+
 function tests = test_load_config
     tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
 end
 
 function testLoadSampleConfig(testCase)


### PR DESCRIPTION
## Summary
- drop duplicate `load_config.m` in repository root
- update MATLAB test to add Code directory to the path

## Testing
- `matlab -batch "runtests('tests/test_load_config.m')"` *(fails: command not found)*