### PR TITLE
Switch config to YAML

### DIFF
--- a/Code/load_config.m
+++ b/Code/load_config.m
@@ -1,14 +1,32 @@
 function cfg = load_config(path)
-%LOAD_CONFIG Load simulation parameters from a JSON file.
-%   CFG = LOAD_CONFIG(PATH) reads the JSON file specified by PATH and
+%LOAD_CONFIG Load simulation parameters from a YAML file.
+%   CFG = LOAD_CONFIG(PATH) reads the YAML file specified by PATH and
 %   returns a struct with the decoded parameters.
 
 fid = fopen(path, 'r');
 if fid == -1
     error('Could not open configuration file: %s', path);
 end
-raw = fread(fid, '*char')';
+lines = textscan(fid, '%s', 'Delimiter', '\n');
 fclose(fid);
 
-cfg = jsondecode(raw);
+cfg = struct();
+for i = 1:numel(lines{1})
+    line = strtrim(lines{1}{i});
+    if isempty(line) || startsWith(line, '#')
+        continue
+    end
+    tokens = strsplit(line, ':', 2);
+    if numel(tokens) < 2
+        continue
+    end
+    key = strtrim(tokens{1});
+    value = strtrim(tokens{2});
+    numval = str2double(value);
+    if ~isnan(numval)
+        cfg.(key) = numval;
+    else
+        cfg.(key) = value;
+    end
+end
 end

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ For parameter sweeps, use `runmodel.m` to systematically vary model parameters a
 
 ### Loading parameters from a configuration file
 
-You can also store simulation parameters in a JSON file and load them in MATLAB
+You can also store simulation parameters in a YAML file and load them in MATLAB
 using the `load_config` helper:
 
 ```matlab
-cfg = load_config(fullfile('tests', 'sample_config.json'));
+cfg = load_config(fullfile('tests', 'sample_config.yaml'));
 result = navigation_model_vec(cfg.triallength, cfg.environment, cfg.plotting, cfg.ntrials);
 ```
 
@@ -59,13 +59,13 @@ The spatial scale (pixels per millimeter) and frame rate are supplied when
 loading the movie so that the simulation can handle different resolutions and
 durations.
 
-### Loading simulation parameters from JSON
+### Loading simulation parameters from YAML
 
-Common simulation options can be stored in a JSON configuration file and loaded
+Common simulation options can be stored in a YAML configuration file and loaded
 with `load_config.m`:
 
 ```matlab
-cfg = load_config('tests/sample_config.json');
+cfg = load_config('tests/sample_config.yaml');
 result = navigation_model_vec(cfg.triallength, cfg.environment, ...
     cfg.plotting, cfg.ntrials);
 ```

--- a/load_config.m
+++ b/load_config.m
@@ -1,8 +1,0 @@
-function cfg = load_config(path)
-%LOAD_CONFIG Load simulation parameters from a JSON file
-%   CFG = LOAD_CONFIG(PATH) reads the JSON file specified by PATH and
-%   returns a struct with the parameters.
-
-jsonText = fileread(path);
-cfg = jsondecode(jsonText);
-end

--- a/tests/sample_config.json
+++ b/tests/sample_config.json
@@ -1,6 +1,0 @@
-{
-  "environment": "gaussian",
-  "triallength": 100,
-  "plotting": 0,
-  "ntrials": 5
-}

--- a/tests/sample_config.yaml
+++ b/tests/sample_config.yaml
@@ -1,0 +1,4 @@
+environment: gaussian
+triallength: 100
+plotting: 0
+ntrials: 5

--- a/tests/test_load_config.m
+++ b/tests/test_load_config.m
@@ -1,9 +1,14 @@
+
 function tests = test_load_config
     tests = functiontests(localfunctions);
 end
 
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
 function testLoadSampleConfig(testCase)
-    cfg = load_config(fullfile('tests','sample_config.json'));
+    cfg = load_config(fullfile('tests','sample_config.yaml'));
     verifyEqual(testCase, cfg.environment, "gaussian");
     verifyEqual(testCase, cfg.triallength, 100);
     verifyEqual(testCase, cfg.plotting, 0);


### PR DESCRIPTION
## Summary
- update tests to use `sample_config.yaml`
- add YAML parsing logic in `load_config.m`
- document YAML config usage in README

## Testing
- `matlab -batch "runtests('tests/test_load_config.m')"` *(fails: command not found)*