### PR TITLE
Improve unified plume interface

### DIFF
--- a/Code/load_config.m
+++ b/Code/load_config.m
@@ -1,14 +1,34 @@
 function cfg = load_config(path)
-%LOAD_CONFIG Load simulation parameters from a JSON file.
-%   CFG = LOAD_CONFIG(PATH) reads the JSON file specified by PATH and
-%   returns a struct with the decoded parameters.
+%LOAD_CONFIG Load simulation parameters from a YAML file.
+%   CFG = LOAD_CONFIG(PATH) reads the YAML file specified by PATH and
+%   returns a struct with the decoded parameters. The parser supports simple
+%   key:value pairs where values are numeric or strings.
 
 fid = fopen(path, 'r');
 if fid == -1
     error('Could not open configuration file: %s', path);
 end
-raw = fread(fid, '*char')';
+lines = textscan(fid, '%s', 'Delimiter', '\n', 'Whitespace', '');
 fclose(fid);
+lines = lines{1};
 
-cfg = jsondecode(raw);
+cfg = struct();
+for i = 1:numel(lines)
+    line = strtrim(lines{i});
+    if isempty(line) || startsWith(line, '#')
+        continue;
+    end
+    tokens = split(line, ':');
+    if numel(tokens) < 2
+        continue;
+    end
+    key = strtrim(tokens{1});
+    value = strtrim(strjoin(tokens(2:end), ':'));
+    num = str2double(value);
+    if ~isnan(num)
+        cfg.(key) = num;
+    else
+        cfg.(key) = value;
+    end
+end
 end

--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -1,0 +1,37 @@
+function out = run_navigation_cfg(cfg)
+%RUN_NAVIGATION_CFG Wrapper around navigation_model_vec with config struct.
+%   OUT = RUN_NAVIGATION_CFG(CFG) runs the navigation model according to the
+%   fields of CFG. If CFG contains a field `plume_video`, the video file is
+%   loaded using `load_plume_video` and the model is invoked with the 'video'
+%   environment. Otherwise the environment specified in CFG.environment is
+%   used directly.
+%
+%   Required fields:
+%       environment - plume type name or 'video'
+%       plotting    - 0 or 1
+%       ntrials     - number of trials
+%
+%   Additional fields for video plumes:
+%       plume_video - path to AVI file
+%       px_per_mm   - pixels per millimeter for the video
+%       frame_rate  - frame rate (Hz)
+%
+%   When using video plumes, triallength is determined from the video unless
+%   CFG specifies a triallength to override.
+
+if isfield(cfg, 'plume_video')
+    if ~isfield(cfg, 'px_per_mm') || ~isfield(cfg, 'frame_rate')
+        error('px_per_mm and frame_rate must be specified for video plumes');
+    end
+    plume = load_plume_video(cfg.plume_video, cfg.px_per_mm, cfg.frame_rate);
+    if isfield(cfg, 'triallength')
+        tl = cfg.triallength;
+    else
+        tl = size(plume.data, 3);
+    end
+    out = navigation_model_vec(tl, 'video', cfg.plotting, cfg.ntrials, plume);
+else
+    out = navigation_model_vec(cfg.triallength, cfg.environment, ...
+        cfg.plotting, cfg.ntrials);
+end
+end

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ For parameter sweeps, use `runmodel.m` to systematically vary model parameters a
 
 ### Loading parameters from a configuration file
 
-You can also store simulation parameters in a JSON file and load them in MATLAB
+You can also store simulation parameters in a YAML file and load them in MATLAB
 using the `load_config` helper:
 
 ```matlab
-cfg = load_config(fullfile('tests', 'sample_config.json'));
-result = navigation_model_vec(cfg.triallength, cfg.environment, cfg.plotting, cfg.ntrials);
+cfg = load_config(fullfile('tests', 'sample_config.yaml'));
+result = run_navigation_cfg(cfg);
 ```
 
 ### Using custom plume videos
@@ -59,15 +59,14 @@ The spatial scale (pixels per millimeter) and frame rate are supplied when
 loading the movie so that the simulation can handle different resolutions and
 durations.
 
-### Loading simulation parameters from JSON
+### Loading simulation parameters from YAML
 
-Common simulation options can be stored in a JSON configuration file and loaded
-with `load_config.m`:
+Common simulation options can be stored in a YAML configuration file and loaded
+with `load_config.m` or passed directly to `run_navigation_cfg`:
 
 ```matlab
-cfg = load_config('tests/sample_config.json');
-result = navigation_model_vec(cfg.triallength, cfg.environment, ...
-    cfg.plotting, cfg.ntrials);
+cfg = load_config('tests/sample_config.yaml');
+result = run_navigation_cfg(cfg);
 ```
 
 
@@ -76,6 +75,7 @@ result = navigation_model_vec(cfg.triallength, cfg.environment, ...
 ```
 Code/                            MATLAB scripts for simulations and analysis
    navigation_model_vec.m        Main navigation model
+   run_navigation_cfg.m          Wrapper for running simulations from configs
    runmodel.m                    Run batches of simulations
    load_plume_video.m            Convert .avi movies for custom plumes
 

--- a/load_config.m
+++ b/load_config.m
@@ -1,8 +1,0 @@
-function cfg = load_config(path)
-%LOAD_CONFIG Load simulation parameters from a JSON file
-%   CFG = LOAD_CONFIG(PATH) reads the JSON file specified by PATH and
-%   returns a struct with the parameters.
-
-jsonText = fileread(path);
-cfg = jsondecode(jsonText);
-end

--- a/tests/sample_config.json
+++ b/tests/sample_config.json
@@ -1,6 +1,0 @@
-{
-  "environment": "gaussian",
-  "triallength": 100,
-  "plotting": 0,
-  "ntrials": 5
-}

--- a/tests/sample_config.yaml
+++ b/tests/sample_config.yaml
@@ -1,0 +1,4 @@
+environment: gaussian
+triallength: 100
+plotting: 0
+ntrials: 5

--- a/tests/test_load_config.m
+++ b/tests/test_load_config.m
@@ -1,9 +1,14 @@
+
 function tests = test_load_config
     tests = functiontests(localfunctions);
 end
 
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
 function testLoadSampleConfig(testCase)
-    cfg = load_config(fullfile('tests','sample_config.json'));
+    cfg = load_config(fullfile('tests','sample_config.yaml'));
     verifyEqual(testCase, cfg.environment, "gaussian");
     verifyEqual(testCase, cfg.triallength, 100);
     verifyEqual(testCase, cfg.plotting, 0);

--- a/tests/test_run_navigation_cfg.m
+++ b/tests/test_run_navigation_cfg.m
@@ -1,0 +1,32 @@
+function tests = test_run_navigation_cfg
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testVideoConfig(~)
+    cfg.environment = 'video';
+    cfg.plume_video = 'video.avi';
+    cfg.px_per_mm = 10;
+    cfg.frame_rate = 50;
+    cfg.plotting = 0;
+    cfg.ntrials = 1;
+    try
+        run_navigation_cfg(cfg);
+        assert(true); % if no error
+    catch
+        assert(false, 'run_navigation_cfg threw an error');
+    end
+end
+
+function testGaussianConfig(~)
+    cfg = load_config(fullfile('tests','sample_config.yaml'));
+    try
+        run_navigation_cfg(cfg);
+        assert(true);
+    catch
+        assert(false, 'run_navigation_cfg failed on gaussian config');
+    end
+end


### PR DESCRIPTION
## Summary
- parse simple YAML files in `load_config`
- add `run_navigation_cfg` wrapper for built-in and video plumes
- convert sample config to YAML and update tests
- document YAML configuration usage and new wrapper in the README

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*