### PR TITLE
Add metadata video support

### DIFF
--- a/Code/load_custom_plume.m
+++ b/Code/load_custom_plume.m
@@ -1,0 +1,20 @@
+function plume = load_custom_plume(metadata_path)
+%LOAD_CUSTOM_PLUME Load plume video based on metadata JSON.
+%   PLUME = LOAD_CUSTOM_PLUME(METADATA_PATH) reads the metadata JSON file
+%   and loads the corresponding plume video using LOAD_PLUME_VIDEO.
+%   The metadata structure must contain the fields:
+%       output_directory - directory containing the video file
+%       output_filename  - name of the video file
+%       vid_mm_per_px    - millimeters per pixel for the video
+%       fps              - frame rate of the processed video
+%
+%   The returned structure is the same as produced by LOAD_PLUME_VIDEO.
+
+info = jsondecode(fileread(metadata_path));
+
+video_path = fullfile(info.output_directory, info.output_filename);
+px_per_mm = 1 / info.vid_mm_per_px;
+frame_rate = info.fps;
+
+plume = load_plume_video(video_path, px_per_mm, frame_rate);
+end

--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -1,10 +1,10 @@
 function out = run_navigation_cfg(cfg)
 %RUN_NAVIGATION_CFG Wrapper around navigation_model_vec with config struct.
 %   OUT = RUN_NAVIGATION_CFG(CFG) runs the navigation model according to the
-%   fields of CFG. If CFG contains a field `plume_video`, the video file is
-%   loaded using `load_plume_video` and the model is invoked with the 'video'
-%   environment. Otherwise the environment specified in CFG.environment is
-%   used directly.
+%   fields of CFG. If CFG contains a field `plume_video` or `plume_metadata`,
+%   the corresponding video file is loaded using `load_plume_video` or
+%   `load_custom_plume` and the model is invoked with the 'video' environment.
+%   Otherwise the environment specified in CFG.environment is used directly.
 %
 %   Required fields:
 %       environment - plume type name or 'video'
@@ -19,7 +19,16 @@ function out = run_navigation_cfg(cfg)
 %   When using video plumes, triallength is determined from the video unless
 %   CFG specifies a triallength to override.
 
-if isfield(cfg, 'plume_video')
+if isfield(cfg, 'plume_metadata')
+    plume = load_custom_plume(cfg.plume_metadata);
+    if isfield(cfg, 'triallength')
+        tl = cfg.triallength;
+    else
+        tl = size(plume.data, 3);
+    end
+    out = navigation_model_vec(tl, 'video', cfg.plotting, cfg.ntrials, plume);
+
+elseif isfield(cfg, 'plume_video')
     if ~isfield(cfg, 'px_per_mm') || ~isfield(cfg, 'frame_rate')
         error('px_per_mm and frame_rate must be specified for video plumes');
     end

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ The spatial scale (pixels per millimeter) and frame rate are supplied when
 loading the movie so that the simulation can handle different resolutions and
 durations.
 
+Alternatively, if you have a metadata JSON file describing the processed
+video, you can load the plume directly using `load_custom_plume` and run the
+simulation via `run_navigation_cfg`:
+
+```matlab
+plume = load_custom_plume('my_plume_metadata.json');
+cfg.plume_metadata = 'my_plume_metadata.json';
+cfg.plotting = 0;
+cfg.ntrials = 1;
+result = run_navigation_cfg(cfg);
+```
+
 ### Loading simulation parameters from YAML
 
 Common simulation options can be stored in a YAML configuration file and loaded

--- a/tests/test_load_custom_plume.m
+++ b/tests/test_load_custom_plume.m
@@ -1,0 +1,33 @@
+function tests = test_load_custom_plume
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmpDir = fullfile(tempname);
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir, 'dummy.avi'));
+    open(vw);
+    writeVideo(vw, uint8(zeros(2,2,3)));
+    close(vw);
+    meta.output_directory = tmpDir;
+    meta.output_filename = 'dummy.avi';
+    meta.vid_mm_per_px = 0.5;
+    meta.fps = 30;
+    fid = fopen(fullfile(tmpDir, 'meta.json'), 'w');
+    fwrite(fid, jsonencode(meta));
+    fclose(fid);
+    testCase.TestData.tmpDir = tmpDir;
+    testCase.TestData.metaFile = fullfile(tmpDir, 'meta.json');
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir, 's');
+end
+
+function testLoadCustomPlumeStruct(testCase)
+    plume = load_custom_plume(testCase.TestData.metaFile);
+    verifyEqual(testCase, plume.frame_rate, 30);
+    verifyEqual(testCase, plume.px_per_mm, 1/0.5);
+    verifySize(testCase, plume.data, [2,2,1]);
+end

--- a/tests/test_run_navigation_metadata.m
+++ b/tests/test_run_navigation_metadata.m
@@ -1,0 +1,34 @@
+function tests = test_run_navigation_metadata
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmpDir = fullfile(tempname);
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir, 'dummy.avi'));
+    open(vw);
+    writeVideo(vw, uint8(zeros(2,2,3)));
+    close(vw);
+    meta.output_directory = tmpDir;
+    meta.output_filename = 'dummy.avi';
+    meta.vid_mm_per_px = 0.2;
+    meta.fps = 40;
+    fid = fopen(fullfile(tmpDir, 'meta.json'), 'w');
+    fwrite(fid, jsonencode(meta));
+    fclose(fid);
+    testCase.TestData.tmpDir = tmpDir;
+    testCase.TestData.metaFile = fullfile(tmpDir, 'meta.json');
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir, 's');
+end
+
+function testRunNavigationCfg(testCase)
+    cfg.plume_metadata = testCase.TestData.metaFile;
+    cfg.plotting = 0;
+    cfg.ntrials = 1;
+    run_navigation_cfg(cfg);
+    assert(true); % ensure no error
+end


### PR DESCRIPTION
## Summary
- allow loading plume videos from metadata JSON
- support `plume_metadata` in `run_navigation_cfg`
- document new helper usage
- add unit tests for custom plume metadata

## Testing
- `npm test` *(fails: could not read package.json)*