### PR TITLE
Switch plume metadata to YAML

### DIFF
--- a/Code/load_custom_plume.m
+++ b/Code/load_custom_plume.m
@@ -1,8 +1,8 @@
 function plume = load_custom_plume(metadata_path)
-%LOAD_CUSTOM_PLUME Load plume video based on metadata JSON.
-%   PLUME = LOAD_CUSTOM_PLUME(METADATA_PATH) reads the metadata JSON file
+%LOAD_CUSTOM_PLUME Load plume video based on metadata YAML.
+%   PLUME = LOAD_CUSTOM_PLUME(METADATA_PATH) reads the metadata YAML file
 %   and loads the corresponding plume video using LOAD_PLUME_VIDEO.
-%   The metadata structure must contain the fields:
+%   The metadata file must contain the fields:
 %       output_directory - directory containing the video file
 %       output_filename  - name of the video file
 %       vid_mm_per_px    - millimeters per pixel for the video
@@ -10,7 +10,7 @@ function plume = load_custom_plume(metadata_path)
 %
 %   The returned structure is the same as produced by LOAD_PLUME_VIDEO.
 
-info = jsondecode(fileread(metadata_path));
+info = load_config(metadata_path);
 
 video_path = fullfile(info.output_directory, info.output_filename);
 px_per_mm = 1 / info.vid_mm_per_px;

--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -3,7 +3,8 @@ function out = run_navigation_cfg(cfg)
 %   OUT = RUN_NAVIGATION_CFG(CFG) runs the navigation model according to the
 %   fields of CFG. If CFG contains a field `plume_video` or `plume_metadata`,
 %   the corresponding video file is loaded using `load_plume_video` or
-%   `load_custom_plume` and the model is invoked with the 'video' environment.
+%   `load_custom_plume` (for YAML metadata) and the model is invoked with the
+%   'video' environment.
 %   Otherwise the environment specified in CFG.environment is used directly.
 %
 %   Required fields:

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ The spatial scale (pixels per millimeter) and frame rate are supplied when
 loading the movie so that the simulation can handle different resolutions and
 durations.
 
-Alternatively, if you have a metadata JSON file describing the processed
+Alternatively, if you have a metadata YAML file describing the processed
 video, you can load the plume directly using `load_custom_plume` and run the
 simulation via `run_navigation_cfg`:
 
 ```matlab
-plume = load_custom_plume('my_plume_metadata.json');
-cfg.plume_metadata = 'my_plume_metadata.json';
+plume = load_custom_plume('my_plume_metadata.yaml');
+cfg.plume_metadata = 'my_plume_metadata.yaml';
 cfg.plotting = 0;
 cfg.ntrials = 1;
 result = run_navigation_cfg(cfg);

--- a/tests/test_load_custom_plume.m
+++ b/tests/test_load_custom_plume.m
@@ -10,15 +10,15 @@ function setupOnce(testCase)
     open(vw);
     writeVideo(vw, uint8(zeros(2,2,3)));
     close(vw);
-    meta.output_directory = tmpDir;
-    meta.output_filename = 'dummy.avi';
-    meta.vid_mm_per_px = 0.5;
-    meta.fps = 30;
-    fid = fopen(fullfile(tmpDir, 'meta.json'), 'w');
-    fwrite(fid, jsonencode(meta));
+    meta_path = fullfile(tmpDir, 'meta.yaml');
+    fid = fopen(meta_path, 'w');
+    fprintf(fid, 'output_directory: %s\n', tmpDir);
+    fprintf(fid, 'output_filename: dummy.avi\n');
+    fprintf(fid, 'vid_mm_per_px: 0.5\n');
+    fprintf(fid, 'fps: 30\n');
     fclose(fid);
     testCase.TestData.tmpDir = tmpDir;
-    testCase.TestData.metaFile = fullfile(tmpDir, 'meta.json');
+    testCase.TestData.metaFile = meta_path;
 end
 
 function teardownOnce(testCase)

--- a/tests/test_run_navigation_metadata.m
+++ b/tests/test_run_navigation_metadata.m
@@ -10,15 +10,15 @@ function setupOnce(testCase)
     open(vw);
     writeVideo(vw, uint8(zeros(2,2,3)));
     close(vw);
-    meta.output_directory = tmpDir;
-    meta.output_filename = 'dummy.avi';
-    meta.vid_mm_per_px = 0.2;
-    meta.fps = 40;
-    fid = fopen(fullfile(tmpDir, 'meta.json'), 'w');
-    fwrite(fid, jsonencode(meta));
+    meta_path = fullfile(tmpDir, 'meta.yaml');
+    fid = fopen(meta_path, 'w');
+    fprintf(fid, 'output_directory: %s\n', tmpDir);
+    fprintf(fid, 'output_filename: dummy.avi\n');
+    fprintf(fid, 'vid_mm_per_px: 0.2\n');
+    fprintf(fid, 'fps: 40\n');
     fclose(fid);
     testCase.TestData.tmpDir = tmpDir;
-    testCase.TestData.metaFile = fullfile(tmpDir, 'meta.json');
+    testCase.TestData.metaFile = meta_path;
 end
 
 function teardownOnce(testCase)


### PR DESCRIPTION
## Summary
- parse plume metadata from YAML instead of JSON
- update README to reference YAML metadata
- modify tests to create YAML metadata files

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*
- `octave --eval "runtests('tests')"` *(fails: command not found)*