### PR TITLE
Enable bilateral config and video looping

### DIFF
--- a/Code/navigation_model_vec.m
+++ b/Code/navigation_model_vec.m
@@ -166,7 +166,6 @@ switch environment
         y(1,:) = 20*rand(1,ntrials)-10;
     case {'video'}
         x(1,:) = 0; y(1,:) = 0;
-        triallength = size(plume.data,3);
 end
 heading = 360*rand(1,ntrials); % starts with a random heading
 
@@ -223,7 +222,7 @@ for i = 1:triallength
             ws = 0;
             p(i,:) = odor(i,:);
         case {'video'}
-            tind = min(i, size(plume.data,3));
+            tind = mod(i-1, size(plume.data,3)) + 1;
             xind = round(10*x(i,:)*plume.px_per_mm)+1;
             yind = round(-10*y(i,:)*plume.px_per_mm)+1;
             out_of_plume = union(union(find(xind<1),find(xind>size(plume.data,2))),union(find(yind<1),find(yind>size(plume.data,1))));

--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -17,8 +17,16 @@ function out = run_navigation_cfg(cfg)
 %       px_per_mm   - pixels per millimeter for the video
 %       frame_rate  - frame rate (Hz)
 %
+%   Optional fields:
+%       bilateral   - true to run the bilateral model
+%
 %   When using video plumes, triallength is determined from the video unless
 %   CFG specifies a triallength to override.
+
+model_fn = @navigation_model_vec;
+if isfield(cfg, 'bilateral') && cfg.bilateral
+    model_fn = @Elifenavmodel_bilateral;
+end
 
 if isfield(cfg, 'plume_metadata')
     plume = load_custom_plume(cfg.plume_metadata);
@@ -27,7 +35,7 @@ if isfield(cfg, 'plume_metadata')
     else
         tl = size(plume.data, 3);
     end
-    out = navigation_model_vec(tl, 'video', cfg.plotting, cfg.ntrials, plume);
+    out = model_fn(tl, 'video', cfg.plotting, cfg.ntrials, plume);
 
 elseif isfield(cfg, 'plume_video')
     if ~isfield(cfg, 'px_per_mm') || ~isfield(cfg, 'frame_rate')
@@ -39,10 +47,10 @@ elseif isfield(cfg, 'plume_video')
     else
         tl = size(plume.data, 3);
     end
-    out = navigation_model_vec(tl, 'video', cfg.plotting, cfg.ntrials, plume);
+    out = model_fn(tl, 'video', cfg.plotting, cfg.ntrials, plume);
 
 else
-    out = navigation_model_vec(cfg.triallength, cfg.environment, ...
+    out = model_fn(cfg.triallength, cfg.environment, ...
         cfg.plotting, cfg.ntrials);
 end
 end

--- a/README.md
+++ b/README.md
@@ -58,9 +58,13 @@ MATLAB structure using `load_plume_video.m`:
 
 ```matlab
 plume = load_plume_video('my_plume.avi', 20, 40); % 20 px/mm, 40 Hz
-triallength = size(plume.data, 3);
+triallength = 3500; % can exceed movie length to loop the plume
 result = navigation_model_vec(triallength, 'video', 1, 1, plume);
 ```
+
+When `triallength` is longer than the number of frames in the plume movie, the
+video frames automatically repeat so that the simulation continues for the full
+duration.
 
 The spatial scale (pixels per millimeter) and frame rate are supplied when
 loading the movie so that the simulation can handle different resolutions and
@@ -95,6 +99,12 @@ configuration and invoke `run_navigation_cfg`:
 
 ```matlab
 cfg = load_config('tests/sample_config_bilateral.json');
+result = run_navigation_cfg(cfg);
+```
+The same options are available in YAML format:
+
+```matlab
+cfg = load_config('tests/sample_config_bilateral.yaml');
 result = run_navigation_cfg(cfg);
 ```
 

--- a/tests/sample_config_bilateral.yaml
+++ b/tests/sample_config_bilateral.yaml
@@ -1,0 +1,5 @@
+environment: gaussian
+triallength: 100
+plotting: 0
+ntrials: 5
+bilateral: true

--- a/tests/test_run_navigation_cfg.m
+++ b/tests/test_run_navigation_cfg.m
@@ -31,3 +31,14 @@ function testGaussianConfig(~)
     end
 
 end
+
+function testBilateralConfig(~)
+    cfg = load_config(fullfile('tests','sample_config_bilateral.yaml'));
+    try
+        run_navigation_cfg(cfg);
+        assert(true);
+    catch
+        assert(false, 'run_navigation_cfg failed on bilateral config');
+    end
+
+end

--- a/tests/test_video_looping.m
+++ b/tests/test_video_looping.m
@@ -1,0 +1,35 @@
+function tests = test_video_looping
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmpDir = fullfile(tempname);
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir, 'loop.avi'));
+    open(vw);
+    writeVideo(vw, uint8(zeros(2,2,1)));
+    close(vw);
+    meta = fullfile(tmpDir, 'meta.yaml');
+    fid = fopen(meta, 'w');
+    fprintf(fid, 'output_directory: %s\n', tmpDir);
+    fprintf(fid, 'output_filename: loop.avi\n');
+    fprintf(fid, 'vid_mm_per_px: 1\n');
+    fprintf(fid, 'fps: 1\n');
+    fclose(fid);
+    testCase.TestData.meta = meta;
+    testCase.TestData.tmpDir = tmpDir;
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir, 's');
+end
+
+function testLongTrial(testCase)
+    cfg.plume_metadata = testCase.TestData.meta;
+    cfg.plotting = 0;
+    cfg.ntrials = 1;
+    cfg.triallength = 5; % longer than 1 frame
+    run_navigation_cfg(cfg);
+    assert(true); % ensure no error
+end


### PR DESCRIPTION
## Summary
- add YAML bilateral sample config
- support `bilateral` flag in `run_navigation_cfg`
- loop video frames in `navigation_model_vec`
- document looping and YAML bilateral config in README
- add tests covering new config and video looping

## Testing
- `octave --version` *(fails: command not found)*