### PR TITLE
Add complex plume configuration

### DIFF
--- a/configs/my_complex_plume_config.yaml
+++ b/configs/my_complex_plume_config.yaml
@@ -1,0 +1,12 @@
+# Type of environment used for simulation
+environment: video
+# Path to the plume video file
+plume_video: data/my_complex_plume.avi
+# Pixels per millimeter conversion factor
+px_per_mm: 6.536
+# Frame rate of the video in Hz
+frame_rate: 60
+# Disable plotting during simulation
+plotting: 0
+# Number of trials to run
+ntrials: 10

--- a/tests/test_load_complex_plume_config.m
+++ b/tests/test_load_complex_plume_config.m
@@ -1,0 +1,17 @@
+function tests = test_load_complex_plume_config
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testLoadComplexConfig(testCase)
+    cfg = load_config(fullfile('configs', 'my_complex_plume_config.yaml'));
+    verifyEqual(testCase, cfg.environment, 'video');
+    verifyEqual(testCase, cfg.plume_video, 'data/my_complex_plume.avi');
+    verifyEqual(testCase, cfg.px_per_mm, 6.536, 'AbsTol', 1e-8);
+    verifyEqual(testCase, cfg.frame_rate, 60);
+    verifyEqual(testCase, cfg.plotting, 0);
+    verifyEqual(testCase, cfg.ntrials, 10);
+end


### PR DESCRIPTION
## Summary
- add a test for loading a complex plume config
- define a new YAML configuration with comments for each field

## Testing
- `octave --eval "runtests('tests')"` *(fails: command not found)*
- `pre-commit run --files configs/my_complex_plume_config.yaml tests/test_load_complex_plume_config.m` *(fails: command not found)*