### PR TITLE
Add batch job script

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#SBATCH --partition=<partition>
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=2G
+#SBATCH -t 00:30:00
+
+# plotting should be disabled for batch jobs
+export plotting=0
+
+module load matlab  # or load octave
+conda activate .env
+matlab -batch "run_my_simulation"

--- a/tests/test_run_batch_job.py
+++ b/tests/test_run_batch_job.py
@@ -1,0 +1,15 @@
+import os
+import re
+
+def test_run_batch_job_exists():
+    assert os.path.isfile('run_batch_job.sh'), 'run_batch_job.sh does not exist'
+
+
+def test_run_batch_job_contents():
+    with open('run_batch_job.sh') as f:
+        content = f.read()
+    assert '#SBATCH --partition=' in content
+    assert 'conda activate .env' in content
+    assert re.search(r"matlab .*run_my_simulation", content)
+    assert 'plotting' in content.lower()
+


### PR DESCRIPTION
## Summary
- add failing tests for new batch job helper
- add batch job script for running simulations

## Testing
- `python -m pytest -k run_batch_job -q` *(fails: No module named pytest)*