### PR TITLE
Fix random seed handling in batch job script

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -74,8 +74,11 @@ else
     CONDITION_NAME="unilateral"
 fi
 
-# Set random seed based on replicate for reproducibility
-RANDOM_SEED=$((REPLICATE + 1))  # +1 to avoid seed 0
+# Set random seeds for each agent in this job
+RANDOM_SEEDS=()
+for s in $(seq $START_AGENT $END_AGENT); do
+    RANDOM_SEEDS+=($s)
+done
 
 # ============================================
 # Run Simulation


### PR DESCRIPTION
## Summary
- initialize random seeds for agents in `run_batch_job.sh`

## Testing
- `bash -n run_batch_job.sh`