### PR TITLE
Seed RNG using config option

### DIFF
--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -28,6 +28,11 @@ if isfield(cfg, 'bilateral') && cfg.bilateral
     model_fn = @Elifenavmodel_bilateral;
 end
 
+% Set RNG for reproducibility if a seed is provided
+if isfield(cfg, 'randomSeed')
+    rng(cfg.randomSeed);
+end
+
 if isfield(cfg, 'plume_metadata')
     plume = load_custom_plume(cfg.plume_metadata);
     if isfield(cfg, 'triallength')

--- a/tests/test_navigation_random_seed.m
+++ b/tests/test_navigation_random_seed.m
@@ -1,0 +1,27 @@
+function tests = test_navigation_random_seed
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testSeedReproducibility(testCase)
+    cfg = load_config(fullfile('tests','sample_config.yaml'));
+    cfg.randomSeed = 123;
+    out1 = run_navigation_cfg(cfg);
+    out2 = run_navigation_cfg(cfg);
+    verifyEqual(testCase, out1.x, out2.x);
+    verifyEqual(testCase, out1.y, out2.y);
+    verifyEqual(testCase, out1.theta, out2.theta);
+end
+
+function testDifferentSeeds(testCase)
+    cfg = load_config(fullfile('tests','sample_config.yaml'));
+    cfg.randomSeed = 1;
+    out1 = run_navigation_cfg(cfg);
+    cfg.randomSeed = 2;
+    out2 = run_navigation_cfg(cfg);
+    % At least one field should differ
+    testCase.assertFalse(isequal(out1.x, out2.x) && isequal(out1.y, out2.y) && isequal(out1.theta, out2.theta));
+end


### PR DESCRIPTION
## Summary
- add failing test for reproducible navigation model results
- seed RNG from `randomSeed` field in `run_navigation_cfg`

## Testing
- `matlab -batch runtests` *(fails: command not found)*