### PR TITLE
Fix per-agent directory creation

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -96,6 +96,8 @@ for ((i=0; i<${#RANDOM_SEEDS[@]}; i++)); do
     AGENT_INDEX=$((START_AGENT + i))
     SEED=${RANDOM_SEEDS[$i]}
     AGENT_DIR="data/raw/${CONDITION_NAME}_${AGENT_INDEX}"
+    # Ensure the output directory exists for each agent
+    mkdir -p "$AGENT_DIR"
     
     # Add command to run this agent
     MATLAB_CMD+="config = struct(); "


### PR DESCRIPTION
## Summary
- prevent race conditions in `run_batch_job.sh` by creating each agent's output directory inside the loop

## Testing
- `pytest -q` *(fails: command not found)*
- `matlab -batch "addpath('tests'); results=runtests('tests'); exit(any([results.Failed]));"` *(fails: command not found)*