### PR TITLE
Fix boolean parsing and flag naming

### DIFF
--- a/Code/load_config.m
+++ b/Code/load_config.m
@@ -29,7 +29,14 @@ for i = 1:numel(lines)
     if ~isnan(num)
         cfg.(key) = num;
     else
-        cfg.(key) = value;
+        lowerVal = lower(value);
+        if strcmp(lowerVal, 'true')
+            cfg.(key) = true;
+        elseif strcmp(lowerVal, 'false')
+            cfg.(key) = false;
+        else
+            cfg.(key) = value;
+        end
     end
 end
 end

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ cfg = load_config('tests/sample_config_bilateral.yaml');
 result = run_navigation_cfg(cfg);
 ```
 
+The batch script `run_batch_job.sh` also accepts this `bilateral` flag when
+creating configuration structures for large simulation runs.
+
 
 
 ## Repository Layout

--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -99,7 +99,7 @@ for ((i=0; i<${#RANDOM_SEEDS[@]}; i++)); do
     
     # Add command to run this agent
     MATLAB_CMD+="config = struct(); "
-    MATLAB_CMD+="config.bilateralSensing = $BILATERAL; "
+    MATLAB_CMD+="config.bilateral = $BILATERAL; "
     MATLAB_CMD+="config.randomSeed = $SEED; "
     MATLAB_CMD+="config.outputDir = '$AGENT_DIR'; "
     MATLAB_CMD+="config.condition = $CONDITION; "

--- a/tests/test_load_config.m
+++ b/tests/test_load_config.m
@@ -22,3 +22,8 @@ function testLoadPaperConfig(testCase)
     verifyEqual(testCase, cfg.tau_Aon, 490);
     verifyEqual(testCase, cfg.kdown, 0.5);
 end
+
+function testBooleanParsing(testCase)
+    cfg = load_config(fullfile('tests','sample_config_bilateral.yaml'));
+    verifyTrue(testCase, cfg.bilateral);
+end


### PR DESCRIPTION
## Summary
- support true/false strings in `load_config`
- accept `bilateral` flag in `run_batch_job.sh`
- document `bilateral` flag usage in README
- test boolean parsing in `test_load_config`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `which matlab` *(returns nothing, MATLAB not installed)*