### PR TITLE
Add warning for default video trial length

### DIFF
--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -24,6 +24,10 @@ function out = run_navigation_cfg(cfg)
 %   CFG specifies a triallength to override.
 
 model_fn = @navigation_model_vec;
+if isfield(cfg, 'environment') && strcmp(cfg.environment, 'video') && ...
+        ~isfield(cfg, 'triallength') && ~isfield(cfg, 'loop')
+    warning('Trial truncated to movie length; set cfg.loop=true to repeat.');
+end
 if isfield(cfg, 'bilateral') && cfg.bilateral
     model_fn = @Elifenavmodel_bilateral;
 end

--- a/tests/test_video_triallength_warning.m
+++ b/tests/test_video_triallength_warning.m
@@ -1,0 +1,33 @@
+function tests = test_video_triallength_warning
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmp = tempname;
+    mkdir(tmp);
+    vw = VideoWriter(fullfile(tmp, 'short.avi'));
+    open(vw);
+    writeVideo(vw, uint8(zeros(2,2,1)));
+    close(vw);
+    testCase.TestData.tmp = tmp;
+    testCase.TestData.video = fullfile(tmp, 'short.avi');
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmp, 's');
+end
+
+function testWarningEmitted(testCase)
+    cfg.environment = 'video';
+    cfg.plume_video = testCase.TestData.video;
+    cfg.px_per_mm = 10;
+    cfg.frame_rate = 50;
+    cfg.plotting = 0;
+    cfg.ntrials = 1;
+    lastwarn('');
+    run_navigation_cfg(cfg);
+    [msg,~] = lastwarn;
+    verifyEqual(testCase, msg, ...
+        'Trial truncated to movie length; set cfg.loop=true to repeat.');
+end


### PR DESCRIPTION
## Summary
- add failing test expecting warning when video config omits triallength
- warn user when triallength defaults to movie length

## Testing
- `matlab -batch "disp('running tests');"` *(fails: command not found)*
- `pytest -q tests/test_run_batch_job.py` *(fails: command not found)*