### PR TITLE
Add RNG seeding via config

### DIFF
--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -28,6 +28,10 @@ if isfield(cfg, 'bilateral') && cfg.bilateral
     model_fn = @Elifenavmodel_bilateral;
 end
 
+if isfield(cfg, 'randomSeed')
+    rng(cfg.randomSeed, 'twister');
+end
+
 if isfield(cfg, 'plume_metadata')
     plume = load_custom_plume(cfg.plume_metadata);
     if isfield(cfg, 'triallength')

--- a/startup.m
+++ b/startup.m
@@ -1,0 +1,3 @@
+%% Project startup script
+projectRoot = fileparts(mfilename('fullpath'));
+addpath(fullfile(projectRoot, 'Code'));

--- a/tests/test_random_seed_determinism.m
+++ b/tests/test_random_seed_determinism.m
@@ -1,0 +1,16 @@
+function tests = test_random_seed_determinism
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testSameSeedReproducible(testCase)
+    cfg = load_config(fullfile('tests','sample_config.yaml'));
+    cfg.randomSeed = 123;
+    out1 = run_navigation_cfg(cfg);
+    out2 = run_navigation_cfg(cfg);
+    verifyEqual(testCase, out1.x, out2.x);
+    verifyEqual(testCase, out1.y, out2.y);
+end


### PR DESCRIPTION
## Summary
- add reproducibility test for randomSeed
- add startup.m for path setup
- seed RNG inside `run_navigation_cfg`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*