### PR TITLE
feat: avoid output collisions between agent configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ Model parameters are defined in `Code/navigation_model_vec.m`. Data import funct
 ## Data Directory
 
 Place raw plume files in `data/raw/` and store any processed outputs in
-`data/processed/`. Keeping these folders separate ensures the original data
-remains untouched and configuration files can refer to them reliably.
+`data/processed/`. Simulation results for each agent are written to
+`data/raw/<condition>/<agentIndex>_<seed>/` to avoid collisions when rerunning
+the same agent under different conditions. Keeping these folders separate
+ensures the original data remains untouched and configuration files can refer
+to them reliably.
 
 ## Running Simulations
 

--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -95,7 +95,8 @@ MATLAB_CMD=""
 for ((i=0; i<${#RANDOM_SEEDS[@]}; i++)); do
     AGENT_INDEX=$((START_AGENT + i))
     SEED=${RANDOM_SEEDS[$i]}
-    AGENT_DIR="data/raw/${CONDITION_NAME}_${AGENT_INDEX}"
+    AGENT_DIR="data/raw/${CONDITION_NAME}/${AGENT_INDEX}_${SEED}"
+    mkdir -p "$AGENT_DIR"
     
     # Add command to run this agent
     MATLAB_CMD+="config = struct(); "

--- a/tests/test_output_directory_pattern.py
+++ b/tests/test_output_directory_pattern.py
@@ -1,0 +1,8 @@
+import re
+
+
+def test_output_directory_pattern():
+    with open('run_batch_job.sh') as f:
+        content = f.read()
+    pattern = r'AGENT_DIR="data/raw/\${CONDITION_NAME}/\${AGENT_INDEX}_\${SEED}"'
+    assert re.search(pattern, content), 'Output directory pattern not updated'


### PR DESCRIPTION
## Summary
- test output directory naming
- ensure batch job writes results to `data/raw/<condition>/<agentIndex>_<seed>`
- document new output folder scheme

## Testing
- `pytest tests/test_output_directory_pattern.py -q` *(fails: command not found)*