### PR TITLE
Add config save before running simulation

### DIFF
--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -19,6 +19,7 @@ function out = run_navigation_cfg(cfg)
 %
 %   Optional fields:
 %       bilateral   - true to run the bilateral model
+%       outputDir   - directory where config_used.yaml is written
 %
 %   When using video plumes, triallength is determined from the video unless
 %   CFG specifies a triallength to override.
@@ -26,6 +27,20 @@ function out = run_navigation_cfg(cfg)
 model_fn = @navigation_model_vec;
 if isfield(cfg, 'bilateral') && cfg.bilateral
     model_fn = @Elifenavmodel_bilateral;
+end
+
+if isfield(cfg, 'outputDir')
+    if ~exist(cfg.outputDir, 'dir')
+        mkdir(cfg.outputDir);
+    end
+    cfgPath = fullfile(cfg.outputDir, 'config_used.yaml');
+    if exist('yamlwrite', 'file') == 2
+        yamlwrite(cfgPath, cfg);
+    else
+        fid = fopen(cfgPath, 'w');
+        fwrite(fid, jsonencode(cfg));
+        fclose(fid);
+    end
 end
 
 if isfield(cfg, 'plume_metadata')

--- a/tests/test_config_file_written.m
+++ b/tests/test_config_file_written.m
@@ -1,0 +1,25 @@
+function tests = test_config_file_written
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    testDir = tempname;
+    mkdir(testDir);
+    testCase.TestData.outputDir = testDir;
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.outputDir, 's');
+end
+
+function testConfigIsSaved(testCase)
+    cfg.environment = 'gaussian';
+    cfg.triallength = 10;
+    cfg.plotting = 0;
+    cfg.ntrials = 1;
+    cfg.outputDir = testCase.TestData.outputDir;
+    run_navigation_cfg(cfg);
+    filePath = fullfile(cfg.outputDir, 'config_used.yaml');
+    verifyEqual(testCase, exist(filePath, 'file'), 2);
+end


### PR DESCRIPTION
## Summary
- add failing test for saving the configuration to `config_used.yaml`
- implement config persistence in `run_navigation_cfg`

## Testing
- `matlab -batch "runtests('tests/test_config_file_written.m')"` *(fails: command not found)*
- `matlab -batch "runtests('tests')"` *(fails: command not found)*