### PR TITLE
Implement parameter overrides and video reset

### DIFF
--- a/Code/Elifenavmodel_bilateral.m
+++ b/Code/Elifenavmodel_bilateral.m
@@ -1,6 +1,6 @@
 
 
-function out = Elifenavmodel_bilateral(triallength, environment, plotting, ntrials) 
+function out = Elifenavmodel_bilateral(triallength, environment, plotting, ntrials, params)
 
 
 
@@ -82,6 +82,14 @@ pxscale = 0.74; %mm/pixel ratio to convert pixels from the plume data to actual 
                     % gets set to 0 below for Gaussian environment
  if (nargin<=3)
      ntrials=1;
+ end
+ if nargin < 5
+     params = struct();
+ end
+
+ fields = intersect(fieldnames(params), who);
+ for f = fields'
+     eval([f{1} ' = params.(f{1});']);
  end
   switch environment % If we are using environments at 15 Hz, converts the time constants to 15 Hz
      

--- a/Code/navigation_model_vec.m
+++ b/Code/navigation_model_vec.m
@@ -1,6 +1,6 @@
 
 
-function out = navigation_model_vec(triallength, environment, plotting, ntrials, plume)
+function out = navigation_model_vec(triallength, environment, plotting, ntrials, plume, params)
 
 % [x,y,heading,odor,successrate,latency,start,odorON,odorOFF]...
 %     = navigation_model_vec(triallength, environment, plotting,ntrials)
@@ -81,6 +81,14 @@ if (nargin<=3)
 end
 if nargin < 5
     plume = struct([]);
+end
+if nargin < 6
+    params = struct();
+end
+
+fields = intersect(fieldnames(params), who);
+for f = fields'
+    eval([f{1} ' = params.(f{1});']);
 end
 switch environment % If we are using environments at 15 Hz, converts the time constants to 15 Hz
 
@@ -232,7 +240,15 @@ for i = 1:triallength
                 odor(i,it) = plume.data(yind(it), xind(it), tind);
             end
             ws = 0;
-        
+
+    end
+
+    if strcmp(environment,'video') && tind == 1 && i > 1
+        Aon(i,:) = 0;
+        Aoff(i,:) = 0;
+        ON(i,:) = 0;
+        R(i,:) = 0;
+        Rh(i,:) = 0;
     end
 
     % Adaptation
@@ -354,6 +370,12 @@ switch environment
         out.successrate = [];
         out.latency = [];
 end
+
+out.params = struct('beta', beta, 'tau_Aon', tau_Aon, 'tau_Aoff', tau_Aoff, ...
+    'tau_ON', tau_ON, 'tau_OFF1', tau_OFF1, 'tau_OFF2', tau_OFF2, ...
+    'scaleON', scaleON, 'scaleOFF', scaleOFF, 'turnbase', turnbase, ...
+    'tsigma', tsigma, 'vbase', vbase, 'tmodON', tmodON, 'tmodOFF', tmodOFF, ...
+    'vmodON', vmodON, 'vmodOFF', vmodOFF, 'kup', kup, 'kdown', kdown);
 
 
 toc

--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -35,7 +35,7 @@ if isfield(cfg, 'plume_metadata')
     else
         tl = size(plume.data, 3);
     end
-    out = model_fn(tl, 'video', cfg.plotting, cfg.ntrials, plume);
+    out = model_fn(tl, 'video', cfg.plotting, cfg.ntrials, plume, cfg);
 
 elseif isfield(cfg, 'plume_video')
     if ~isfield(cfg, 'px_per_mm') || ~isfield(cfg, 'frame_rate')
@@ -47,10 +47,10 @@ elseif isfield(cfg, 'plume_video')
     else
         tl = size(plume.data, 3);
     end
-    out = model_fn(tl, 'video', cfg.plotting, cfg.ntrials, plume);
+    out = model_fn(tl, 'video', cfg.plotting, cfg.ntrials, plume, cfg);
 
 else
     out = model_fn(cfg.triallength, cfg.environment, ...
-        cfg.plotting, cfg.ntrials);
+        cfg.plotting, cfg.ntrials, struct(), cfg);
 end
 end

--- a/tests/parameter_override.yaml
+++ b/tests/parameter_override.yaml
@@ -1,0 +1,5 @@
+environment: gaussian
+triallength: 20
+plotting: 0
+ntrials: 1
+turnbase: 0.5

--- a/tests/test_parameter_override.m
+++ b/tests/test_parameter_override.m
@@ -1,0 +1,13 @@
+function tests = test_parameter_override
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testOverride(~)
+    cfg = load_config(fullfile('tests','parameter_override.yaml'));
+    out = run_navigation_cfg(cfg);
+    assert(abs(out.params.turnbase - 0.5) < 1e-6, 'turnbase parameter not overridden');
+end

--- a/tests/test_video_adaptation_reset.m
+++ b/tests/test_video_adaptation_reset.m
@@ -1,0 +1,18 @@
+function tests = test_video_adaptation_reset
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testReset(~)
+    plume.data = zeros(1,1,2);
+    plume.data(1,1,1) = 1;
+    plume.px_per_mm = 1;
+    plume.frame_rate = 1;
+    out = navigation_model_vec(4,'video',0,1,plume);
+    on1 = out.ON(2); % response to first odor frame
+    on2 = out.ON(4); % response after loop restart
+    assert(abs(on1 - on2) < 1e-3, 'ON response should reset when video loops');
+end


### PR DESCRIPTION
## Summary
- add failing tests for parameter overrides and video adaptation reset
- allow passing a parameter struct to `navigation_model_vec` and reset adaptation when video loops
- enable the same parameter override mechanism in `Elifenavmodel_bilateral`
- pass the configuration struct to the model from `run_navigation_cfg`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*