### PR TITLE
Fix Code path handling

### DIFF
--- a/Code/run_my_simulation.m
+++ b/Code/run_my_simulation.m
@@ -1,3 +1,11 @@
-addpath(fullfile(pwd, 'Code'));
-cfg = load_config(fullfile('configs', 'my_complex_plume_config.yaml'));
+% RUN_MY_SIMULATION Run the navigation model using the default configuration.
+%
+% This script adds the Code directory to the MATLAB path based on its own
+% location so it works even when MATLAB is launched from another directory,
+% for example within SLURM batch jobs.
+
+thisDir = fileparts(mfilename('fullpath'));
+addpath(thisDir);
+
+cfg = load_config(fullfile(thisDir, '..', 'configs', 'my_complex_plume_config.yaml'));
 run_navigation_cfg(cfg);

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ remains untouched and configuration files can refer to them reliably.
 
 ## Running Simulations
 
-Add the `Code` directory to your MATLAB path and call `navigation_model_vec`:
+When MATLAB starts in this repository it automatically executes `startup.m`,
+which adds the `Code` directory to your path. You can then call
+`navigation_model_vec` directly:
 
 ```matlab
 triallength = 3500;       % number of timesteps

--- a/startup.m
+++ b/startup.m
@@ -1,0 +1,10 @@
+function startup
+% STARTUP Configure MATLAB path for the Elementary Transformations project.
+%
+% This file adds the Code directory to the MATLAB path automatically when
+% MATLAB starts in this project. It uses the location of this startup file
+% so that it works regardless of the current working directory.
+
+rootDir = fileparts(mfilename('fullpath'));
+addpath(fullfile(rootDir, 'Code'));
+end

--- a/tests/test_run_my_simulation.m
+++ b/tests/test_run_my_simulation.m
@@ -3,7 +3,7 @@ function tests = test_run_my_simulation
 end
 
 function setupOnce(testCase)
-    addpath(fullfile(pwd, 'Code'));
+    testCase.TestData.rootDir = pwd;
     cfgFile = fullfile('configs', 'my_complex_plume_config.yaml');
     fid = fopen(cfgFile, 'w');
     fprintf(fid, 'environment: gaussian\n');
@@ -21,4 +21,14 @@ end
 function testRunScript(~)
     run_my_simulation;
     assert(true); % ensure no error
+end
+
+function testRunScriptInDifferentDir(testCase)
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    oldDir = cd(tmpDir);
+    run(fullfile(testCase.TestData.rootDir, 'Code', 'run_my_simulation.m'));
+    cd(oldDir);
+    rmdir(tmpDir, 's');
+    assert(true);
 end


### PR DESCRIPTION
## Summary
- add regression test for running `run_my_simulation` from another folder
- ensure `run_my_simulation` uses its own location when adding paths
- add a `startup.m` that puts `Code/` on the MATLAB path
- document automatic path setup in the README

## Testing
- `matlab -batch "runtests('tests'); exit"` *(fails: `matlab: command not found`)*