### PR TITLE
Clarify video plume looping in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ triallength = 3500; % can exceed movie length to loop the plume
 result = navigation_model_vec(triallength, 'video', 1, 1, plume);
 ```
 
-When `triallength` is longer than the number of frames in the plume movie, the
-video frames automatically repeat so that the simulation continues for the full
-duration.
+When `triallength` exceeds the number of frames in the plume movie, the odor
+frames automatically repeat so that the simulation continues for the full
+duration. The video plume does not contain wind information, so wind speed
+remains zero throughout the simulation.
 
 The spatial scale (pixels per millimeter) and frame rate are supplied when
 loading the movie so that the simulation can handle different resolutions and


### PR DESCRIPTION
## Summary
- update README details on plume video looping behavior

## Testing
- `pytest` *(fails: command not found)*