### PR TITLE
Fix sbatch array comment

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -7,9 +7,9 @@
 #SBATCH --partition=day
 # ============================================
 # SLURM Configuration - DO NOT MODIFY
-# The array size is calculated automatically below
+# Array size is set when submitting the job
+# See example below for sbatch syntax
 # ============================================
-# Array will be set after calculating required jobs
 #SBATCH --open-mode=append
 #SBATCH --output=slurm_out/%A_%a.out
 #SBATCH --error=slurm_err/%A_%a.err


### PR DESCRIPTION
## Summary
- clarify how to set SLURM array size in `run_batch_job.sh`

## Testing
- `./setup_env.sh --dev` *(fails: No such file or directory)*
- `pytest -q` *(fails: command not found)*