### PR TITLE
Fix dead MATLAB_CMD loop in batch driver

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -102,35 +102,7 @@ echo "============================"
 # Create a temporary MATLAB script to run all agents for this job
 MATLAB_SCRIPT=$(mktemp /tmp/batch_job_XXXX.m)
 
-for ((i=0; i<${#RANDOM_SEEDS[@]}; i++)); do
-    AGENT_INDEX=$((START_AGENT + i))
-    SEED=${RANDOM_SEEDS[$i]}
-    AGENT_DIR="data/raw/${CONDITION_NAME}/${AGENT_INDEX}_${SEED}"
-
-    mkdir -p "$AGENT_DIR"
-    
-    # Add command to run this agent
-    MATLAB_CMD+="config = struct(); "
-    MATLAB_CMD+="config.bilateral = $BILATERAL; "
-    MATLAB_CMD+="config.randomSeed = $SEED; "
-    MATLAB_CMD+="config.outputDir = '$AGENT_DIR'; "
-    MATLAB_CMD+="config.condition = $CONDITION; "
-    MATLAB_CMD+="config.agentIndex = $AGENT_INDEX; "
-    MATLAB_CMD+="fprintf('Running agent %d with seed %d\\n', $AGENT_INDEX, $SEED); "
-    MATLAB_CMD+="run_navigation_cfg(config); "
-    
-    # Add error handling for this agent
-    if [ $i -eq 0 ]; then
-        MATLAB_CMD+="try, "
-    fi
-    
-    # Add separator between agents
-    if [ $i -lt $(( ${#RANDOM_SEEDS[@]} - 1 )) ]; then
-        MATLAB_CMD+="try, "
-    fi
-done
-
-    cat >> "$MATLAB_SCRIPT" <<EOF
+cat >> "$MATLAB_SCRIPT" <<EOF
 config = struct();
 config.bilateralSensing = $BILATERAL;
 config.randomSeed = $SEED;
@@ -145,7 +117,6 @@ catch e
     exit(1);
 end
 EOF
-done
 
 echo "exit(0);" >> "$MATLAB_SCRIPT"
 


### PR DESCRIPTION
## Summary
- clean up `run_batch_job.sh`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*