### PR TITLE
Fix SLURM email placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ result = run_navigation_cfg(cfg);
 The batch script `run_batch_job.sh` also accepts this `bilateral` flag when
 creating configuration structures for large simulation runs.
 
+> **Important**: `run_batch_job.sh` contains a `--mail-user` directive for
+> SLURM job notifications. Replace the placeholder email address with your own,
+> or comment out the line to disable email alerts before submitting jobs.
+
 
 
 ## Repository Layout

--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -14,7 +14,8 @@
 #SBATCH --output=slurm_out/%A_%a.out
 #SBATCH --error=slurm_err/%A_%a.err
 #SBATCH --time=6:00:00
-#SBATCH --mail-user=samuel.brudner@yale.edu
+# Set email for job notifications. Replace with your address or comment out to disable
+#SBATCH --mail-user=your_email@example.com
 #SBATCH --mail-type=ALL
 
 # Create output directories if they don't exist


### PR DESCRIPTION
## Summary
- use placeholder email in run_batch_job.sh
- document the need to update or disable the email in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*