### PR TITLE
Fix runmodel bilateral function call

### DIFF
--- a/Code/runmodel.m
+++ b/Code/runmodel.m
@@ -16,9 +16,9 @@ n = 1;
 for i = range1 % Iterates through each pair of parameters
     for j = range2
            
-        % Calls the model to run one simulation with the current pair of
-        % parameters. Make sure it calls your desired model function.
-        results = Elifenavmodel_binaral_local(triallength, environment,0,ntrials,i,j);
+        % Calls the bilateral navigation model with the current parameter pair.
+        params = struct('OFF', i, 'Kbin', j);
+        results = Elifenavmodel_bilateral(triallength, environment,0,ntrials, params);
         
         % It saves the current values of the two parameters in the results
         % structure.

--- a/tests/test_runmodel.m
+++ b/tests/test_runmodel.m
@@ -1,0 +1,16 @@
+function tests = test_runmodel
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testRunmodelExecutes(testCase)
+    tl = 50;
+    env = 'gaussian';
+    nt = 1;
+    [out, matrix] = runmodel(tl, env, nt, 1, 1);
+    verifyEqual(testCase, size(matrix), [1 1]);
+    verifyTrue(testCase, isfield(out, 'successrate'));
+end


### PR DESCRIPTION
## Summary
- call `Elifenavmodel_bilateral` from `runmodel.m`
- capture parameter sweep output in new test

## Testing
- `pytest -q` *(fails: command not found)*
- `matlab -batch "exit"` *(fails: command not found)*