### PR TITLE
Remove redundant path setup in run_my_simulation

### DIFF
--- a/Code/run_my_simulation.m
+++ b/Code/run_my_simulation.m
@@ -1,11 +1,10 @@
 % RUN_MY_SIMULATION Run the navigation model using the default configuration.
 %
-% This script adds the Code directory to the MATLAB path based on its own
-% location so it works even when MATLAB is launched from another directory,
-% for example within SLURM batch jobs.
+% This script relies on `startup.m` to add the Code directory to the MATLAB
+% path.  It simply loads the default configuration and runs the navigation
+% model.
 
 thisDir = fileparts(mfilename('fullpath'));
-addpath(thisDir);
 
 cfg = load_config(fullfile(thisDir, '..', 'configs', 'my_complex_plume_config.yaml'));
 run_navigation_cfg(cfg);

--- a/tests/test_run_my_simulation_no_addpath.py
+++ b/tests/test_run_my_simulation_no_addpath.py
@@ -1,0 +1,12 @@
+import os
+import unittest
+
+class TestRunMySimulationNoAddpath(unittest.TestCase):
+    def test_run_my_simulation_has_no_addpath(self):
+        with open(os.path.join('Code', 'run_my_simulation.m')) as f:
+            content = f.read()
+        self.assertNotIn('addpath', content,
+                         'run_my_simulation.m should rely on startup.m for path setup')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure `run_my_simulation.m` relies on `startup.m` for path setup
- add regression test for absence of `addpath`

## Testing
- `python tests/test_run_my_simulation_no_addpath.py`
- `python tests/test_run_batch_job_heredoc.py`