### PR TITLE
fix: close outputDir block in run_navigation_cfg

### DIFF
--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -46,6 +46,8 @@ if isfield(cfg, 'outputDir')
         fclose(fid);
     end
 
+end
+
 if isfield(cfg, 'randomSeed')
     rng(cfg.randomSeed, 'twister');
 end


### PR DESCRIPTION
## Summary
- add missing `end` for `outputDir` handling in `run_navigation_cfg`

## Testing
- `pytest` *(fails: command not found)*
