### PR TITLE
Fix variable expansion in batch job

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -103,7 +103,14 @@ echo "============================"
 # Create a temporary MATLAB script to run all agents for this job
 MATLAB_SCRIPT=$(mktemp /tmp/batch_job_XXXX.m)
 
-cat >> "$MATLAB_SCRIPT" <<EOF
+# Loop over each seed and agent assigned to this job
+for i in "${!RANDOM_SEEDS[@]}"; do
+    AGENT_INDEX=$((START_AGENT + i))
+    SEED=${RANDOM_SEEDS[$i]}
+    AGENT_DIR="data/raw/${CONDITION_NAME}/${AGENT_INDEX}_${SEED}"
+    mkdir -p "$AGENT_DIR"
+
+    cat >> "$MATLAB_SCRIPT" <<EOF
 config = struct();
 config.bilateralSensing = $BILATERAL;
 config.randomSeed = $SEED;
@@ -117,7 +124,9 @@ catch e
     disp(getReport(e));
     exit(1);
 end
+
 EOF
+done
 
 echo "exit(0);" >> "$MATLAB_SCRIPT"
 

--- a/tests/test_run_batch_job_variable_expansion.py
+++ b/tests/test_run_batch_job_variable_expansion.py
@@ -1,0 +1,12 @@
+import os
+import re
+
+
+def test_variables_expanded_in_loop():
+    with open('run_batch_job.sh') as f:
+        content = f.read()
+    # Expect a loop that sets SEED and AGENT_DIR for each agent
+    loop_pattern = re.compile(r'for .*in.*RANDOM_SEEDS')
+    assert loop_pattern.search(content), 'run_batch_job.sh should loop over RANDOM_SEEDS'
+    assert 'AGENT_DIR=' in content, 'AGENT_DIR should be defined within the loop'
+    assert 'SEED=' in content, 'SEED should be defined within the loop'


### PR DESCRIPTION
## Summary
- ensure random seed and agent directory variables are expanded inside a loop in `run_batch_job.sh`
- add regression test for loop-based variable expansion
- revert intermediate change as part of TDD

## Testing
- `python3 -m pytest tests/test_run_batch_job_variable_expansion.py -q` *(fails: No module named pytest)*