### PR TITLE
Remove no-op repmat in export_results

### DIFF
--- a/Code/export_results.m
+++ b/Code/export_results.m
@@ -45,7 +45,8 @@ t = (1:T)' - 1;  % 0-based time indices
 % Create a table for trajectory data
 trajectories = table();
 for i = 1:N
-    trial_data = table(repmat(t, 1, 1), ...  % Time
+    % Each trial shares the same time vector, so repmat is unnecessary
+    trial_data = table(t, ...                 % Time
                       repmat(i-1, T, 1), ... % 0-based trial index
                       result.x(:,i), ...     % X position
                       result.y(:,i), ...     % Y position

--- a/tests/test_export_results_time_column.m
+++ b/tests/test_export_results_time_column.m
@@ -1,0 +1,36 @@
+function tests = test_export_results_time_column
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testTimeColumn(testCase)
+    T = 3;
+    out.x = (1:T)';
+    out.y = (1:T)';
+    out.theta = zeros(T,1);
+    out.odor = zeros(T,1);
+    out.ON = zeros(T,1);
+    out.OFF = zeros(T,1);
+    out.turn = zeros(T,1);
+    out.params = struct();
+    out.successrate = 1;
+    out.latency = T;
+
+    matfile = fullfile(tempdir, 'out.mat');
+    save(matfile, 'out');
+    outdir = fullfile(tempdir, 'export_out');
+    if exist(outdir, 'dir')
+        rmdir(outdir, 's');
+    end
+    export_results(matfile, outdir);
+
+    tbl = readtable(fullfile(outdir, 'trajectories.csv'));
+    expected_t = (0:T-1)';
+    verifyEqual(testCase, tbl.t, expected_t);
+
+    rmdir(outdir, 's');
+    delete(matfile);
+end


### PR DESCRIPTION
## Summary
- add failing test for `export_results` time column
- simplify time column creation in `export_results`

## Testing
- `pytest -q` *(fails: command not found)*
- `matlab -batch "exit"` *(fails: command not found)*