### PR TITLE
Add experiment name to batch output paths

### DIFF
--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -230,7 +230,7 @@ EOL
 # Add agent-specific code for each agent
 for AGENT_ID in $(seq $START_AGENT $END_AGENT); do
   SEED=$AGENT_ID                       # reproducible 1-to-1 seed
-  OUT_DIR="${OUTPUT_BASE}/${PLUME_NAME}_${SENSING_NAME}/${AGENT_ID}_${SEED}"
+  OUT_DIR="${OUTPUT_BASE}/${EXPERIMENT_NAME}/${PLUME_NAME}_${SENSING_NAME}/${AGENT_ID}_${SEED}"
   mkdir -p "$OUT_DIR"
 
   # Add agent simulation code to MATLAB script

--- a/tests/test_run_batch_job_4000_experiment_name.py
+++ b/tests/test_run_batch_job_4000_experiment_name.py
@@ -1,0 +1,7 @@
+import re
+
+def test_output_path_includes_experiment_name():
+    with open('run_batch_job_4000.sh') as f:
+        content = f.read()
+    pattern = r'OUT_DIR="\\${OUTPUT_BASE}/\\${EXPERIMENT_NAME}/\\${PLUME_NAME}_\\${SENSING_NAME}/\\${AGENT_ID}_\\${SEED}"'
+    assert re.search(pattern, content), 'Output path should include EXPERIMENT_NAME'


### PR DESCRIPTION
## Summary
- test for experiment name usage in batch script
- include `EXPERIMENT_NAME` when building output directory

## Testing
- `pytest tests/test_run_batch_job_4000_experiment_name.py -q` *(fails: command not found)*