### PR TITLE
Add env overrides for agent count in batch script

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -37,11 +37,12 @@ module load matlab/R2021a
 NUM_CONDITIONS=2
 
 # Number of agents per condition (total agents = NUM_CONDITIONS * AGENTS_PER_CONDITION)
-AGENTS_PER_CONDITION=50  # e.g., 50 agents per condition = 100 total agents
+# Allow override via environment variable
+: "${AGENTS_PER_CONDITION:=50}"  # e.g., 50 agents per condition = 100 total agents
 
 # Agents to run per job (for parallelization)
 # Each agent will get a unique random seed
-AGENTS_PER_JOB=1  # Set higher to run multiple agents per job
+: "${AGENTS_PER_JOB:=1}"  # Set higher to run multiple agents per job
 
 # Calculate derived values
 JOBS_PER_CONDITION=$(( (AGENTS_PER_CONDITION + AGENTS_PER_JOB - 1) / AGENTS_PER_JOB ))

--- a/tests/test_agent_env_override.py
+++ b/tests/test_agent_env_override.py
@@ -1,0 +1,8 @@
+import re
+
+def test_agent_env_override():
+    with open('run_batch_job.sh') as f:
+        content = f.read()
+    assert re.search(r': \${AGENTS_PER_CONDITION:=', content), 'AGENTS_PER_CONDITION should be environment overridable'
+    assert re.search(r': \${AGENTS_PER_JOB:=', content), 'AGENTS_PER_JOB should be environment overridable'
+


### PR DESCRIPTION
## Summary
- allow `AGENTS_PER_CONDITION` and `AGENTS_PER_JOB` to be overridden via environment variables
- add regression test to ensure these overrides exist

## Testing
- `python -m pytest tests/test_agent_env_override.py -q` *(fails: No module named pytest)*