### PR TITLE
Add per-job logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Model parameters are defined in `Code/navigation_model_vec.m`. Data import funct
 
 - `data/raw/` - Store raw plume files here
 - `data/processed/` - Store processed outputs here
+- `logs/` - Log files for each batch job
 - `data/raw/<condition>/<agentIndex>_<seed>/` - Simulation results (auto-created)
   - `config_used.yaml` - Exact configuration used for the run
   - `result.mat` - Simulation output (see below)

--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -19,7 +19,11 @@
 #SBATCH --mail-type=ALL
 
 # Create output directories if they don't exist
-mkdir -p slurm_out slurm_err data/raw data/processed
+mkdir -p slurm_out slurm_err data/raw data/processed logs
+
+# Log file for this job
+JOB_LOG="logs/${SLURM_ARRAY_TASK_ID:-0}.log"
+echo "Starting job ${SLURM_ARRAY_TASK_ID:-0}" > "$JOB_LOG"
 
 # Disable GUI and plotting for batch jobs
 export DISPLAY=
@@ -91,14 +95,14 @@ done
 # Run Simulation
 # ============================================
 
-echo "=== Simulation Parameters ==="
-echo "Job ID: $SLURM_ARRAY_TASK_ID"
-echo "Condition: $CONDITION_NAME ($CONDITION)"
-echo "Agents: $START_AGENT to $END_AGENT"
-echo "Random seeds: ${RANDOM_SEEDS[*]}"
-echo "Total agents per condition: $AGENTS_PER_CONDITION"
-echo "Agents per job: $AGENTS_PER_JOB"
-echo "============================"
+echo "=== Simulation Parameters ===" | tee -a "$JOB_LOG"
+echo "Job ID: $SLURM_ARRAY_TASK_ID" | tee -a "$JOB_LOG"
+echo "Condition: $CONDITION_NAME ($CONDITION)" | tee -a "$JOB_LOG"
+echo "Agents: $START_AGENT to $END_AGENT" | tee -a "$JOB_LOG"
+echo "Random seeds: ${RANDOM_SEEDS[*]}" | tee -a "$JOB_LOG"
+echo "Total agents per condition: $AGENTS_PER_CONDITION" | tee -a "$JOB_LOG"
+echo "Agents per job: $AGENTS_PER_JOB" | tee -a "$JOB_LOG"
+echo "============================" | tee -a "$JOB_LOG"
 
 # Create a temporary MATLAB script to run all agents for this job
 MATLAB_SCRIPT=$(mktemp /tmp/batch_job_XXXX.m)
@@ -133,6 +137,9 @@ rm "$MATLAB_SCRIPT"
 
 # Optional: Post-processing steps could be added here
 # For example, to process the raw data after simulation completes
+
+# Mark completion in log
+echo "Job ${SLURM_ARRAY_TASK_ID:-0} completed" >> "$JOB_LOG"
 
 # Exit with success code
 exit 0

--- a/tests/test_run_batch_job_logging.py
+++ b/tests/test_run_batch_job_logging.py
@@ -1,0 +1,13 @@
+import os
+
+
+def test_logging_directory_created():
+    with open('run_batch_job.sh') as f:
+        content = f.read()
+    assert 'mkdir -p logs' in content, 'run_batch_job.sh should create logs directory'
+
+
+def test_log_file_variable():
+    with open('run_batch_job.sh') as f:
+        content = f.read()
+    assert 'JOB_LOG=' in content, 'run_batch_job.sh should define JOB_LOG variable'


### PR DESCRIPTION
## Summary
- add failing tests for job logging
- add per-job log file creation in batch script
- document the new logs directory in the README

## Testing
- `pytest -q tests/test_run_batch_job_logging.py` *(fails: command not found)*