### PR TITLE
Fix output dir naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cfg = load_config('tests/sample_config.yaml');
 result = run_navigation_cfg(cfg);
 
 % Export results to CSV and JSON
-export_results('data/raw/bilateral/1_1/result.mat', 'data/processed');
+export_results('data/raw/gaussian_bilateral/1_1/result.mat', 'data/processed');
 ```
 
 This will:
@@ -45,7 +45,7 @@ Model parameters are defined in `Code/navigation_model_vec.m`. Data import funct
 - `data/raw/` - Store raw plume files here
 - `data/processed/` - Store processed outputs here
 - `logs/` - Log files for each batch job
-- `data/raw/<condition>/<agentIndex>_<seed>/` - Simulation results (auto-created)
+- `data/raw/<plume>_<sensing>/<agentIndex>_<seed>/` - Simulation results (auto-created)
   - `config_used.yaml` - Exact configuration used for the run
   - `result.mat` - Simulation output (see below)
 
@@ -83,7 +83,8 @@ Every model call returns a structure with these fields:
 
 ### Naming Conventions
 
-- `<condition>`: `bilateral` or `unilateral` (from `cfg.bilateral`)
+- `<plume>`: Name of the plume configuration (from `PLUME_CONFIG`)
+- `<sensing>`: `bilateral` or `unilateral` (from `cfg.bilateral`)
 - `<agentIndex>`: 1-based index for agent grouping
 - `<seed>`: PRNG seed for reproducible simulations
 
@@ -91,7 +92,7 @@ Every model call returns a structure with these fields:
 
 ```matlab
 % Load a single agent result
-r = load('data/raw/bilateral/17_17/result.mat');
+r = load('data/raw/gaussian_bilateral/17_17/result.mat');
 x = r.out.x;          % trajectories
 pars = r.out.params;  % model parameters
 

--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -38,8 +38,12 @@ trap cleanup EXIT INT TERM
 
 # Centralized configuration file and output base. These can be overridden
 # by exporting the variables before calling sbatch.
+# Configuration for plume type
 : ${PLUME_CONFIG:="configs/my_complex_plume_config.yaml"}
 : ${OUTPUT_BASE:="data/raw"}
+
+# Derive plume name from configuration file path (without extension)
+PLUME_NAME="$(basename "${PLUME_CONFIG%.*}")"
 
 # Create output directories if they don't exist
 mkdir -p slurm_out slurm_err data/raw data/processed logs
@@ -133,6 +137,7 @@ done
 
 echo "=== Simulation Parameters ===" | tee -a "$JOB_LOG"
 echo "Job ID: $SLURM_ARRAY_TASK_ID" | tee -a "$JOB_LOG"
+echo "Plume: $PLUME_NAME" | tee -a "$JOB_LOG"
 echo "Condition: $CONDITION_NAME ($CONDITION)" | tee -a "$JOB_LOG"
 echo "Agents: $START_AGENT to $END_AGENT" | tee -a "$JOB_LOG"
 echo "Random seeds: ${RANDOM_SEEDS[*]}" | tee -a "$JOB_LOG"
@@ -146,7 +151,7 @@ MATLAB_SCRIPT=$(mktemp /tmp/batch_job_XXXX.m)
 for ((i=0; i<${#RANDOM_SEEDS[@]}; i++)); do
     AGENT_INDEX=$((START_AGENT+i))
     SEED=${RANDOM_SEEDS[$i]}
-    AGENT_DIR="${OUTPUT_BASE}/${CONDITION_NAME}/${AGENT_INDEX}_${SEED}"
+    AGENT_DIR="${OUTPUT_BASE}/${PLUME_NAME}_${CONDITION_NAME}/${AGENT_INDEX}_${SEED}"
 
     mkdir -p "$AGENT_DIR"
 

--- a/tests/test_output_directory_pattern.py
+++ b/tests/test_output_directory_pattern.py
@@ -4,5 +4,5 @@ import re
 def test_output_directory_pattern():
     with open('run_batch_job.sh') as f:
         content = f.read()
-    pattern = r'AGENT_DIR="\${OUTPUT_BASE}/\${CONDITION_NAME}/\${AGENT_INDEX}_\${SEED}"'
+    pattern = r'AGENT_DIR="\${OUTPUT_BASE}/\${PLUME_NAME}_\${CONDITION_NAME}/\${AGENT_INDEX}_\${SEED}"'
     assert re.search(pattern, content), 'Output directory pattern not updated'

--- a/tests/test_run_batch_job.py
+++ b/tests/test_run_batch_job.py
@@ -11,5 +11,5 @@ def test_run_batch_job_contents():
     assert '#SBATCH --partition=' in content
     assert ': ${PLUME_CONFIG:="' in content
     assert ': ${OUTPUT_BASE:="' in content
-    assert 'AGENT_DIR="${OUTPUT_BASE}/${CONDITION_NAME}/${AGENT_INDEX}_${SEED}"' in content
+    assert 'AGENT_DIR="${OUTPUT_BASE}/${PLUME_NAME}_${CONDITION_NAME}/${AGENT_INDEX}_${SEED}"' in content
 


### PR DESCRIPTION
## Summary
- update docs for new plume+sensing folder format
- ensure batch script names directories `<plume>_<sensing>/<agent>_<seed>`
- adjust tests to match new output path pattern

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*