### PR TITLE
Fix run_batch_new wrapper invocation

### DIFF
--- a/Code/run_batch_job_wrapper.m
+++ b/Code/run_batch_job_wrapper.m
@@ -1,0 +1,24 @@
+function run_batch_job_wrapper(job_id, config_file)
+%RUN_BATCH_JOB_WRAPPER Thin wrapper to call RUN_BATCH_JOB
+%   RUN_BATCH_JOB_WRAPPER(JOB_ID, CONFIG_FILE) calculates the agent range for the
+%   given JOB_ID using the configuration and then calls RUN_BATCH_JOB with the
+%   expanded arguments.
+
+arguments
+    job_id (1,1) {mustBeInteger, mustBeNonnegative}
+    config_file (1,:) char
+end
+
+% Ensure Code directory is on the path
+if isempty(which('calculateJobParams'))
+    addpath(fullfile(pwd, 'Code'));
+end
+
+cfg = load_experiment_config(config_file);
+params = calculateJobParams(job_id + 1, ...
+    cfg.experiment.num_conditions, ...
+    cfg.experiment.agents_per_condition, ...
+    cfg.experiment.agents_per_job);
+
+run_batch_job(config_file, job_id + 1, params.startAgent, params.endAgent);
+end

--- a/run_batch_new.sh
+++ b/run_batch_new.sh
@@ -45,7 +45,7 @@ echo "Starting job $SLURM_ARRAY_TASK_ID"
 matlab -nodisplay -nosplash -r \
     "addpath('Code'); "\
     "try, "\
-    "  run_batch_job($SLURM_ARRAY_TASK_ID, '$CONFIG_FILE'); "\
+    "  run_batch_job_wrapper($SLURM_ARRAY_TASK_ID, '$CONFIG_FILE'); "\
     "catch ME, "\
     "  disp(getReport(ME)); "\
     "  exit(1); "\

--- a/tests/test_run_batch_new_wrapper.py
+++ b/tests/test_run_batch_new_wrapper.py
@@ -1,0 +1,14 @@
+import re
+import unittest
+
+class TestRunBatchNewWrapper(unittest.TestCase):
+    def test_uses_wrapper(self):
+        with open('run_batch_new.sh') as f:
+            content = f.read()
+        self.assertIn('run_batch_job_wrapper(', content,
+                      'run_batch_new.sh should call run_batch_job_wrapper')
+        self.assertNotIn('run_batch_job($SLURM_ARRAY_TASK_ID', content,
+                         'run_batch_new.sh should not call run_batch_job with missing args')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `run_batch_job_wrapper` helper to calculate job parameters
- call the wrapper from `run_batch_new.sh`
- add regression test for wrapper usage

## Testing
- `python tests/test_run_batch_new_wrapper.py`
- `for f in tests/test_*.py; do echo "--- $f"; python $f; done | head`
- `python tests/test_sbatch_array.py`
- `python tests/test_slurm_env_vars.py`
