### PR TITLE
Fix variable substitution for SLURM batch scripts

### DIFF
--- a/run_test_batch.sh
+++ b/run_test_batch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Submit a batch script after expanding SBATCH variables with envsubst.
+# Usage: ./run_test_batch.sh [script]
+# Defaults to run_batch_job.sh if no script is given.
+
+SCRIPT="${1:-run_batch_job.sh}"
+
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "ERROR: Script $SCRIPT not found" >&2
+    exit 1
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+
+envsubst < "$SCRIPT" > "$tmp"
+
+sbatch "$tmp"

--- a/tests/test_run_test_batch_envsubst.py
+++ b/tests/test_run_test_batch_envsubst.py
@@ -1,0 +1,12 @@
+import os
+import unittest
+
+class TestRunTestBatchEnvsubst(unittest.TestCase):
+    def test_wrapper_uses_envsubst(self):
+        self.assertTrue(os.path.isfile('run_test_batch.sh'), 'run_test_batch.sh should exist')
+        with open('run_test_batch.sh') as f:
+            content = f.read()
+        self.assertIn('envsubst', content, 'run_test_batch.sh should use envsubst to expand variables')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add failing test checking `run_test_batch.sh` uses `envsubst`
- add wrapper script `run_test_batch.sh` to expand SBATCH variables before submitting

## Testing
- `python -m unittest tests/test_run_test_batch_envsubst.py -v`
- `python -m unittest discover tests`