### PR TITLE
Add test verifying run_agent_simulation saves struct

### DIFF
--- a/tests/test_run_agent_simulation_save_struct.py
+++ b/tests/test_run_agent_simulation_save_struct.py
@@ -1,0 +1,9 @@
+import os
+
+
+def test_run_agent_simulation_save_struct():
+    with open(os.path.join('Code', 'run_agent_simulation.m')) as f:
+        content = f.read()
+    assert "save(fullfile(output_dir, 'result.mat'), '-struct', 'result');" in content,
+        'run_agent_simulation.m should save results with -struct'
+


### PR DESCRIPTION
## Summary
- add regression test for run_agent_simulation saving results via `-struct`

## Testing
- `pytest -q tests/test_run_agent_simulation_save_struct.py` *(fails: command not found)*