### PR TITLE
Add YAML loader helper

### DIFF
--- a/Code/load_config.m
+++ b/Code/load_config.m
@@ -1,42 +1,11 @@
 function cfg = load_config(path)
 %LOAD_CONFIG Load simulation parameters from a YAML file.
-%   CFG = LOAD_CONFIG(PATH) reads the YAML file specified by PATH and
-%   returns a struct with the decoded parameters. The parser supports simple
-%   key:value pairs where values are numeric or strings.
+%   CFG = LOAD_CONFIG(PATH) reads the YAML file specified by PATH and returns
+%   a struct with the decoded parameters using the YAML toolbox.
 
-
-fid = fopen(path, 'r');
-if fid == -1
-    error('Could not open configuration file: %s', path);
-end
-lines = textscan(fid, '%s', 'Delimiter', '\n', 'Whitespace', '');
-fclose(fid);
-lines = lines{1};
-
-cfg = struct();
-for i = 1:numel(lines)
-    line = strtrim(lines{i});
-    if isempty(line) || startsWith(line, '#')
-        continue;
-    end
-    tokens = split(line, ':');
-    if numel(tokens) < 2
-        continue;
-    end
-    key = strtrim(tokens{1});
-    value = strtrim(strjoin(tokens(2:end), ':'));
-    num = str2double(value);
-    if ~isnan(num)
-        cfg.(key) = num;
-    else
-        lowerVal = lower(value);
-        if strcmp(lowerVal, 'true')
-            cfg.(key) = true;
-        elseif strcmp(lowerVal, 'false')
-            cfg.(key) = false;
-        else
-            cfg.(key) = value;
-        end
-    end
+% Add YAML toolbox path if available via load_yaml
+cfg = load_yaml(path);
+if ~isstruct(cfg)
+    cfg = struct(cfg);
 end
 end

--- a/Code/load_yaml.m
+++ b/Code/load_yaml.m
@@ -1,0 +1,16 @@
+function s = load_yaml(path)
+%LOAD_YAML Load a YAML file using the YAML toolbox.
+%   S = LOAD_YAML(PATH) reads the YAML file specified by PATH and returns
+%   a struct with the decoded contents. The YAML toolbox is added to the
+%   path automatically if a 'yaml' folder exists next to this function.
+
+% Add YAML toolbox path if needed
+thisDir = fileparts(mfilename('fullpath'));
+rootDir = fileparts(thisDir);
+yamlDir = fullfile(rootDir, 'yaml');
+if exist(yamlDir, 'dir') && isempty(which('yaml.ReadYaml'))
+    addpath(yamlDir);
+end
+
+s = yaml.ReadYaml(path);
+end

--- a/tests/test_load_yaml.m
+++ b/tests/test_load_yaml.m
@@ -1,0 +1,13 @@
+function tests = test_load_yaml
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testLoadYaml(testCase)
+    cfg = load_yaml(fullfile('tests', 'sample_config.yaml'));
+    verifyEqual(testCase, cfg.environment, 'gaussian');
+    verifyEqual(testCase, cfg.triallength, 100);
+end


### PR DESCRIPTION
## Summary
- replace manual config parser with YAML toolbox
- introduce `load_yaml` helper that adds toolbox path automatically
- test YAML loader functionality

## Testing
- `pytest -q` *(fails: command not found)*