### PR TITLE
Add output collision skip

### DIFF
--- a/Code/run_agent_simulation.m
+++ b/Code/run_agent_simulation.m
@@ -42,6 +42,12 @@ output_dir = cfg.get_output_dir(plume_name, sensing_name, agent_id, seed);
 if ~exist(output_dir, 'dir')
     mkdir(output_dir);
 end
+% Skip simulation if result already exists
+result_file = fullfile(output_dir, 'result.mat');
+if exist(result_file, 'file')
+    warning('Result exists, skipping: %s', output_dir);
+    return;
+end
 
 fprintf('Starting simulation for job %d, agent %d (%s, %s)\n', ...
         job_id, agent_id, plume_name, sensing_name);

--- a/tests/test_run_agent_simulation_skip_existing.m
+++ b/tests/test_run_agent_simulation_skip_existing.m
@@ -1,0 +1,39 @@
+function tests = test_run_agent_simulation_skip_existing
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmpDir = fullfile(tempname);
+    mkdir(tmpDir);
+    cfgPath = fullfile(tmpDir, 'experiment_config.yaml');
+    fid = fopen(cfgPath, 'w');
+    fprintf(fid, 'experiment:\n');
+    fprintf(fid, '  output_base: %s\n', tmpDir);
+    fprintf(fid, '  agents_per_condition: 1\n');
+    fprintf(fid, '  agents_per_job: 1\n');
+    fprintf(fid, '  plume_types: [dummy]\n');
+    fprintf(fid, '  sensing_modes: [bilateral]\n');
+    fprintf(fid, 'plume_config: tests/sample_config.yaml\n');
+    fprintf(fid, 'matlab: {}\n');
+    fprintf(fid, 'slurm: {}\n');
+    fclose(fid);
+    testCase.TestData.tmpDir = tmpDir;
+    testCase.TestData.cfgFile = cfgPath;
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir, 's');
+end
+
+function testSkipExistingResult(testCase)
+    job_id = 1;
+    agent_id = 1;
+    run_agent_simulation(job_id, agent_id, testCase.TestData.cfgFile);
+    outputDir = fullfile(testCase.TestData.tmpDir, 'dummy_bilateral', '1_1');
+    resultFile = fullfile(outputDir, 'result.mat');
+    info1 = dir(resultFile);
+    run_agent_simulation(job_id, agent_id, testCase.TestData.cfgFile);
+    info2 = dir(resultFile);
+    verifyEqual(testCase, info1.datenum, info2.datenum);
+end


### PR DESCRIPTION
## Summary
- skip completed simulations when result.mat already exists
- cover skip logic with a new MATLAB unit test

## Testing
- `pytest -q` *(fails: command not found)*
- `matlab -batch \"cd tests; run_all_tests\"` *(fails: command not found)*