### PR TITLE
Fix export_results for loose .mat files

### DIFF
--- a/tests/test_export_results_loose_variable.m
+++ b/tests/test_export_results_loose_variable.m
@@ -1,0 +1,36 @@
+function tests = test_export_results_loose_variable
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testLooseVariable(testCase)
+    T = 3;
+    x = (1:T)';
+    y = (1:T)';
+    theta = zeros(T,1);
+    odor = zeros(T,1);
+    ON = zeros(0,1); % empty due to short trial
+    OFF = zeros(0,1); % empty due to short trial
+    turn = zeros(T,1);
+    params = struct();
+    successrate = 1;
+    latency = T;
+
+    matfile = fullfile(tempdir, 'loose.mat');
+    save(matfile, 'x', 'y', 'theta', 'odor', 'ON', 'OFF', 'turn', 'params', 'successrate', 'latency');
+    outdir = fullfile(tempdir, 'export_loose');
+    if exist(outdir, 'dir')
+        rmdir(outdir, 's');
+    end
+    export_results(matfile, outdir);
+
+    tbl = readtable(fullfile(outdir, 'trajectories.csv'));
+    expected_t = (0:T-1)';
+    verifyEqual(testCase, tbl.t, expected_t);
+
+    rmdir(outdir, 's');
+    delete(matfile);
+end

--- a/tests/test_export_results_missing_field.m
+++ b/tests/test_export_results_missing_field.m
@@ -1,0 +1,18 @@
+function tests = test_export_results_missing_field
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testMissingXErrors(testCase)
+    y = 1;
+    matfile = fullfile(tempdir, 'nofield.mat');
+    save(matfile, 'y');
+    outdir = fullfile(tempdir, 'export_missing');
+    if exist(outdir, 'dir'); rmdir(outdir, 's'); end
+    f = @() export_results(matfile, outdir);
+    verifyError(testCase, f, 'export_results:NoTrajectories');
+    delete(matfile);
+end


### PR DESCRIPTION
## Summary
- add tests ensuring `export_results` handles loose-variable `.mat` files and errors when `x` is missing
- handle loading results saved without an `out` struct
- guard against empty ON/OFF filters when trial length is short

## Testing
- `pytest -q` *(fails: command not found)*
- `matlab -batch "exit"` *(fails: command not found)*