### PR TITLE
Centralize agents_per_job validation

### DIFF
--- a/Code/load_config.m
+++ b/Code/load_config.m
@@ -39,4 +39,8 @@ for i = 1:numel(lines)
         end
     end
 end
+
+if isfield(cfg, 'agents_per_job')
+    validateAgentsPerJob(cfg.agents_per_job);
+end
 end

--- a/Code/load_experiment_config.m
+++ b/Code/load_experiment_config.m
@@ -143,9 +143,7 @@ if ~isnumeric(cfg.experiment.agents_per_condition) || cfg.experiment.agents_per_
     error('agents_per_condition must be a positive number');
 end
 
-if ~isnumeric(cfg.experiment.agents_per_job) || cfg.experiment.agents_per_job <= 0
-    error('agents_per_job must be a positive number');
-end
+validateAgentsPerJob(cfg.experiment.agents_per_job);
 
 % Ensure output directory exists
 if ~exist(cfg.experiment.output_base, 'dir')

--- a/Code/validateAgentsPerJob.m
+++ b/Code/validateAgentsPerJob.m
@@ -1,0 +1,14 @@
+function validateAgentsPerJob(value)
+%VALIDATEAGENTSPERJOB Ensure agents_per_job is a positive integer.
+%   VALIDATEAGENTSPERJOB(VALUE) throws an error if VALUE is not a positive integer.
+
+arguments
+    value
+end
+
+if ~(isnumeric(value) && isscalar(value) && isfinite(value) && ...
+        value > 0 && mod(value,1) == 0)
+    error('common:InvalidAgentsPerJob', ...
+        'agents_per_job must be a positive integer');
+end
+end

--- a/tests/test_agents_per_job_validation.m
+++ b/tests/test_agents_per_job_validation.m
@@ -1,0 +1,23 @@
+function tests = test_agents_per_job_validation
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testInvalidExperimentValue(testCase)
+    cfgPath = fullfile('configs','batch_job_config.yaml');
+    f = @() load_experiment_config(cfgPath, 'agents_per_job', 0);
+    verifyError(testCase, f, 'common:InvalidAgentsPerJob');
+end
+
+function testInvalidConfigValue(testCase)
+    tmp = [tempname '.yaml'];
+    fid = fopen(tmp,'w');
+    fprintf(fid,'agents_per_job: -1\n');
+    fclose(fid);
+    cleanup = onCleanup(@() delete(tmp));
+    f = @() load_config(tmp);
+    verifyError(testCase, f, 'common:InvalidAgentsPerJob');
+end


### PR DESCRIPTION
## Summary
- add regression tests for `agents_per_job` validation
- create `validateAgentsPerJob` helper
- validate `agents_per_job` in `load_config` and `load_experiment_config`

## Testing
- `pytest -q tests/test_agents_per_job_validation.m` *(fails: `pytest` not installed)*