### PR TITLE
Fix duplicated startup

### DIFF
--- a/startup.m
+++ b/startup.m
@@ -6,6 +6,12 @@ function startup
 % so that it works regardless of the current working directory.
 
 rootDir = fileparts(mfilename('fullpath'));
-addpath(fullfile(rootDir, 'Code'));
+codeDir = fullfile(rootDir, 'Code');
+if isfolder(codeDir)
+    entries = strsplit(path, pathsep);
+    if ~any(strcmp(entries, codeDir))
+        addpath(codeDir);
+    end
+end
 end
 

--- a/tests/test_startup_idempotent.m
+++ b/tests/test_startup_idempotent.m
@@ -1,0 +1,29 @@
+function tests = test_startup_idempotent
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    testCase.TestData.rootDir = pwd;
+end
+
+function teardownOnce(testCase)
+    codeDir = fullfile(testCase.TestData.rootDir, 'Code');
+    while any(strcmp(strsplit(path, pathsep), codeDir))
+        rmpath(codeDir);
+    end
+end
+
+function testSinglePathAddition(testCase)
+    rootDir = testCase.TestData.rootDir;
+    codeDir = fullfile(rootDir, 'Code');
+    startup; %#ok<NOPRT>
+    startup; %#ok<NOPRT>
+    entries = strsplit(path, pathsep);
+    numMatches = sum(strcmp(entries, codeDir));
+    verifyEqual(testCase, numMatches, 1);
+end
+
+function testNoStartupInCode(testCase)
+    rootDir = testCase.TestData.rootDir;
+    assert(~isfile(fullfile(rootDir, 'Code', 'startup.m')));
+end


### PR DESCRIPTION
## Summary
- add unit test for startup path idempotency
- make `startup.m` avoid duplicating `Code` on the MATLAB path

## Testing
- `matlab -batch "runtests('tests/test_startup_idempotent.m')"` *(fails: `matlab` not found)*
- `pytest -q` *(fails: `pytest` not found)*