### PR TITLE
Remove nested streaming stub

### DIFF
--- a/Code/chooseTrialLength.m
+++ b/Code/chooseTrialLength.m
@@ -1,0 +1,12 @@
+function tl = chooseTrialLength(cfg, defaultTL)
+%CHOOSETRIALLENGTH Return cfg.triallength if present, otherwise default.
+%
+%   TL = CHOOSETRIALLENGTH(CFG, DEFAULTTL) returns CFG.triallength when
+%   it exists and is non-empty; otherwise returns DEFAULTTL.
+
+if isfield(cfg,'triallength') && ~isempty(cfg.triallength)
+    tl = cfg.triallength;
+else
+    tl = defaultTL;
+end
+end

--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -106,26 +106,3 @@ else
 end
 end
 % ===== end main function =================================================
-
-
-% ──────────────────────────────────────────────────────────────────────────
-function tl = chooseTrialLength(cfg, defaultTL)
-% Return cfg.triallength if present, otherwise fall back to defaultTL.
-    if isfield(cfg,'triallength') && ~isempty(cfg.triallength)
-        tl = cfg.triallength;
-    else
-        tl = defaultTL;
-    end
-end
-
-% ──────────────────────────────────────────────────────────────────────────
-function out = navigation_model_vec_stream(~,~,~,~,~,~) %#ok<INUSD>
-%NAVIGATION_MODEL_VEC_STREAM  Placeholder for future streaming backend.
-%
-%   Replace this stub with an implementation that consumes frames from a
-%   VideoReader object on-the-fly (to save memory with very large, lossless
-%   plume movies).  For the moment we raise a readable error so users know
-%   what to do.
-    error(['navigation_model_vec_stream not yet implemented. ' ...
-           'Set cfg.use_streaming = false or add the implementation.']);
-end

--- a/tests/test_video_streaming_backend.m
+++ b/tests/test_video_streaming_backend.m
@@ -1,0 +1,36 @@
+function tests = test_video_streaming_backend
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd,'Code'));
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir,'stream.avi'));
+    open(vw);
+    writeVideo(vw,uint8(zeros(2,2,1)));
+    close(vw);
+    testCase.TestData.video = fullfile(tmpDir,'stream.avi');
+    testCase.TestData.tmpDir = tmpDir;
+end
+
+function teardownOnce(testCase)
+    if exist(testCase.TestData.tmpDir,'dir')
+        rmdir(testCase.TestData.tmpDir,'s');
+    end
+end
+
+function testStreaming(testCase)
+    cfg.plume_video = testCase.TestData.video;
+    cfg.px_per_mm = 1;
+    cfg.frame_rate = 1;
+    cfg.plotting = 0;
+    cfg.use_streaming = true;
+    cfg.ntrials = 1;
+    try
+        run_navigation_cfg(cfg);
+        assert(true);
+    catch ME
+        assert(false,["streaming backend failed: " ME.message]);
+    end
+end


### PR DESCRIPTION
## Summary
- add streaming backend test
- remove nested stub from `run_navigation_cfg`
- add a standalone `chooseTrialLength` helper

## Testing
- `pytest -q` *(fails: command not found)*
- `matlab -batch "cd tests; results=runtests; exit(any([results.Failed]));"` *(fails: command not found)*