### PR TITLE
Prefer streaming on SLURM cluster

### DIFF
--- a/Code/isSlurmCluster.m
+++ b/Code/isSlurmCluster.m
@@ -1,0 +1,7 @@
+function tf = isSlurmCluster()
+%ISSLURMCLUSTER  Detect SLURM cluster environment.
+%   TF = ISSLURMCLUSTER() returns true if the SLURM_JOB_ID environment
+%   variable is set, indicating execution under a SLURM scheduler.
+
+tf = ~isempty(getenv('SLURM_JOB_ID'));
+end

--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -83,6 +83,11 @@ elseif isfield(cfg,'plume_video')
     assert(all(isfield(cfg,{'px_per_mm','frame_rate'})), ...
         'px_per_mm and frame_rate are required for video plumes');
 
+    % Auto-enable streaming on SLURM clusters when not specified
+    if ~isfield(cfg,'use_streaming') && isSlurmCluster()
+        cfg.use_streaming = true;
+    end
+
     if isfield(cfg,'use_streaming') && cfg.use_streaming
         % ~~~ streaming mode (placeholder implementation) ~~~
         vr = VideoReader(cfg.plume_video);

--- a/tests/test_auto_streaming_on_slurm.m
+++ b/tests/test_auto_streaming_on_slurm.m
@@ -1,0 +1,39 @@
+function tests = test_auto_streaming_on_slurm
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function teardownEach(~)
+    unsetenv('SLURM_JOB_ID');
+end
+
+function testStreamingEnabledByDefault(~)
+    % Create a temporary video file
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir,'dummy.avi'));
+    open(vw);
+    writeVideo(vw, uint8(zeros(2,2,1)));
+    close(vw);
+
+    setenv('SLURM_JOB_ID','123');
+    cfg.environment = 'video';
+    cfg.plume_video = fullfile(tmpDir,'dummy.avi');
+    cfg.px_per_mm = 1;
+    cfg.frame_rate = 1;
+    cfg.plotting = 0;
+    cfg.ntrials = 1;
+
+    try
+        run_navigation_cfg(cfg);
+        assert(false, 'Expected streaming error not thrown');
+    catch ME
+        assert(contains(ME.message,'navigation_model_vec_stream not yet implemented'), ...
+               'Unexpected error message');
+    end
+
+    rmdir(tmpDir,'s');
+end


### PR DESCRIPTION
## Summary
- automatically enable streaming when running on SLURM
- add `isSlurmCluster` helper
- test automatic streaming behaviour on SLURM environments

## Testing
- `python3 -m pytest -q tests/test_navigation_model_vec_stream_file.py` *(fails: No module named pytest)*