### PR TITLE
Fix filtering path and add analyzer test

### DIFF
--- a/startup.m
+++ b/startup.m
@@ -11,6 +11,12 @@ if isfolder(codeDir)
     addpath(codeDir);
 end
 
+% Include data import utilities
+importDir = fullfile(codeDir,'import functions feb2017');
+if isfolder(importDir)
+    addpath(importDir);
+end
+
 % ── YAML-Matlab toolbox ───────────────────────────────────────
 yamlDir = fullfile(rootDir,'external','yamlmatlab');
 if isfolder(yamlDir)

--- a/tests/test_analyzer_filtering.m
+++ b/tests/test_analyzer_filtering.m
@@ -1,0 +1,17 @@
+function tests = test_analyzer_filtering
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    startup; % add paths via startup script
+end
+
+function testFilteringAvailable(testCase)
+    data(1).x = zeros(5,1);
+    data(1).y = zeros(5,1);
+    data(1).theta = zeros(5,1);
+    res = analyzer(data);
+    verifyTrue(testCase, isfield(res, 'xfilt'));
+    verifyTrue(testCase, isfield(res, 'yfilt'));
+    verifyTrue(testCase, isfield(res, 'thetafilt'));
+end


### PR DESCRIPTION
## Summary
- add unit test showing analyzer depends on filtering
- update startup.m to include import utilities path

## Testing
- `matlab -batch "runtests('tests')"` *(fails: `matlab` not found)*
- `pytest -q` *(fails: `pytest` not found)*