### PR TITLE
Fix disk usage estimate for movie results

### DIFF
--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -115,8 +115,8 @@ NUM_CONDITIONS=$((NUM_PLUMES * NUM_SENSING))
 JOBS_PER_CONDITION=$(( (AGENTS_PER_CONDITION + AGENTS_PER_JOB - 1) / AGENTS_PER_JOB ))
 TOTAL_JOBS=$((NUM_CONDITIONS * JOBS_PER_CONDITION))
 
-# Calculate required disk space (400KB per agent with 20% buffer)
-BYTES_PER_AGENT=400000  # 400KB per agent
+# Calculate required disk space (50MB per agent with 20% buffer)
+BYTES_PER_AGENT=50000000  # 50MB per agent
 REQUIRED_SPACE_KB=$(( (AGENTS_PER_CONDITION * NUM_CONDITIONS * BYTES_PER_AGENT * 12 / 10) / 1024 ))
 
 # ───────────────────────────────────────────────────────────

--- a/tests/test_run_batch_job_bytes_per_agent.py
+++ b/tests/test_run_batch_job_bytes_per_agent.py
@@ -1,0 +1,9 @@
+import re
+
+def test_bytes_per_agent_increased():
+    with open('run_batch_job_4000.sh') as f:
+        content = f.read()
+    match = re.search(r'BYTES_PER_AGENT=(\d+)', content)
+    assert match, 'BYTES_PER_AGENT should be defined'
+    value = int(match.group(1))
+    assert value >= 5000000, 'BYTES_PER_AGENT should account for raw .mat file size'


### PR DESCRIPTION
## Summary
- add test for disk space constant in run_batch_job_4000.sh
- increase BYTES_PER_AGENT to 50MB to cover raw `.mat` files

## Testing
- `python3 -m pytest tests/test_run_batch_job_bytes_per_agent.py -q` *(fails: No module named pytest)*