### PR TITLE
Add recursive path support in startup

### DIFF
--- a/startup.m
+++ b/startup.m
@@ -6,9 +6,10 @@ function startup
 rootDir = fileparts(mfilename('fullpath'));
 
 % ── Code directory ─────────────────────────────────────────────
-codeDir = fullfile(rootDir,'Code');
+codeDir = fullfile(rootDir, 'Code');
 if isfolder(codeDir)
-    addpath(codeDir);
+    addpath(genpath(codeDir));
+    path(path); % remove potential duplicates
 end
 
 % ── YAML-Matlab toolbox ───────────────────────────────────────

--- a/tests/test_startup_adds_subfolders.m
+++ b/tests/test_startup_adds_subfolders.m
@@ -1,0 +1,30 @@
+function tests = test_startup_adds_subfolders
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    testCase.TestData.rootDir = pwd;
+end
+
+function teardownOnce(testCase)
+    codeDir = fullfile(testCase.TestData.rootDir, 'Code');
+    paths = strsplit(genpath(codeDir), pathsep);
+    for i = 1:numel(paths)
+        p = paths{i};
+        if isempty(p)
+            continue
+        end
+        while any(strcmp(strsplit(path, pathsep), p))
+            rmpath(p);
+        end
+    end
+end
+
+function testAddsSubfolderToPath(testCase)
+    rootDir = testCase.TestData.rootDir;
+    startup; %#ok<NOPRT>
+    subDir = fullfile(rootDir, 'Code', 'import functions feb2017');
+    entries = strsplit(path, pathsep);
+    verifyTrue(testCase, any(strcmp(entries, subDir)), ...
+        'Startup should add Code subfolders to path');
+end


### PR DESCRIPTION
## Summary
- recursively add Code subfolders to MATLAB path in `startup.m`
- ensure startup adds subfolders with a new unit test

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`