### PR TITLE
Fix warnings for plume configs

### DIFF
--- a/Code/load_config.m
+++ b/Code/load_config.m
@@ -86,11 +86,16 @@ function config = load_simple_config(config_path)
 end
 
 function validate_config(config)
-% VALIDATE_CONFIG Check for required fields
-    required_fields = {'experiment_name', 'plume_type', 'sensing_mode'};
-    for i = 1:length(required_fields)
-        if ~isfield(config, required_fields{i})
-            warning('Missing recommended field in config: %s', required_fields{i});
+% VALIDATE_CONFIG Check for recommended experiment fields
+%   Only warn about missing fields if any of them are present.
+    recommended_fields = {'experiment_name', 'plume_type', 'sensing_mode'};
+
+    has_any = any(isfield(config, recommended_fields));
+    if has_any
+        for i = 1:numel(recommended_fields)
+            if ~isfield(config, recommended_fields{i})
+                warning('Missing recommended field in config: %s', recommended_fields{i});
+            end
         end
     end
 end

--- a/tests/test_plume_config_warning_free.m
+++ b/tests/test_plume_config_warning_free.m
@@ -1,0 +1,13 @@
+function tests = test_plume_config_warning_free
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testNoWarningForPlumeConfig(testCase)
+    cfgPath = fullfile('configs', 'my_complex_plume_config.yaml');
+    f = @() load_config(cfgPath);
+    verifyWarningFree(testCase, f);
+end


### PR DESCRIPTION
## Summary
- add regression test for plume config warnings
- show no warnings when plume-specific configs are loaded

## Testing
- `matlab -batch "runtests('tests/test_plume_config_warning_free.m')"` *(fails: command not found)*
- `python3 -m pytest tests/test_agent_env_override.py -q` *(fails: No module named pytest)*