### PR TITLE
Add Crimaldi statistics analyzer

### DIFF
--- a/Code/analyze_crimaldi_data.py
+++ b/Code/analyze_crimaldi_data.py
@@ -1,0 +1,72 @@
+"""Utility to compute statistics from the Crimaldi plume dataset.
+
+This module provides a function :func:`analyze_crimaldi_data` that loads the
+``10302017_10cms_bounded.hdf5`` file and returns summary statistics of the
+``/dataset_1`` dataset. It can also be executed as a script to print the
+statistics in a human‑readable form.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Dict
+
+try:
+    import numpy as np
+    import h5py
+except ImportError as exc:  # pragma: no cover - dependencies missing
+    raise ImportError(
+        "analyze_crimaldi_data requires numpy and h5py to be installed"
+    ) from exc
+
+
+def analyze_crimaldi_data(path: str) -> Dict[str, float | dict]:
+    """Return basic statistics for the ``/dataset_1`` array.
+
+    Parameters
+    ----------
+    path : str
+        Path to the HDF5 file containing ``/dataset_1``.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``min``, ``max``, ``mean``, ``std``, and
+        ``percentiles`` keys.
+    """
+    with h5py.File(path, "r") as f:
+        data = f["/dataset_1"][:]
+
+    stats = {
+        "min": float(data.min()),
+        "max": float(data.max()),
+        "mean": float(data.mean()),
+        "std": float(data.std()),
+        "percentiles": {
+            1: float(np.percentile(data, 1)),
+            5: float(np.percentile(data, 5)),
+            95: float(np.percentile(data, 95)),
+            99: float(np.percentile(data, 99)),
+        },
+    }
+    return stats
+
+
+def main() -> None:  # pragma: no cover - CLI wrapper
+    parser = argparse.ArgumentParser(description="Analyze Crimaldi data range")
+    parser.add_argument(
+        "path",
+        help="Path to 10302017_10cms_bounded.hdf5",
+    )
+    args = parser.parse_args()
+    stats = analyze_crimaldi_data(args.path)
+    print("Min:", stats["min"])
+    print("Max:", stats["max"])
+    print("Mean:", stats["mean"])
+    print("Std:", stats["std"])
+    for p, v in stats["percentiles"].items():
+        print(f"{p}th percentile: {v}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_analyze_crimaldi_data.py
+++ b/tests/test_analyze_crimaldi_data.py
@@ -1,0 +1,29 @@
+import os
+import numpy as np
+import h5py
+import unittest
+
+from Code.analyze_crimaldi_data import analyze_crimaldi_data
+
+class TestAnalyzeCrimaldiData(unittest.TestCase):
+    def setUp(self):
+        self.tmpfile = 'tests/sample_crimaldi.hdf5'
+        data = np.arange(27, dtype=np.float32).reshape(3,3,3)
+        with h5py.File(self.tmpfile, 'w') as f:
+            f.create_dataset('dataset_1', data=data)
+        self.data = data
+
+    def tearDown(self):
+        if os.path.isfile(self.tmpfile):
+            os.remove(self.tmpfile)
+
+    def test_statistics(self):
+        stats = analyze_crimaldi_data(self.tmpfile)
+        self.assertEqual(stats['min'], float(self.data.min()))
+        self.assertEqual(stats['max'], float(self.data.max()))
+        self.assertAlmostEqual(stats['mean'], float(self.data.mean()))
+        self.assertAlmostEqual(stats['std'], float(self.data.std()))
+        self.assertAlmostEqual(stats['percentiles'][5], np.percentile(self.data, 5))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_run_agent_simulation_save_struct.py
+++ b/tests/test_run_agent_simulation_save_struct.py
@@ -4,6 +4,5 @@ import os
 def test_run_agent_simulation_save_struct():
     with open(os.path.join('Code', 'run_agent_simulation.m')) as f:
         content = f.read()
-    assert "save(fullfile(output_dir, 'result.mat'), '-struct', 'result');" in content,
+    assert "save(fullfile(output_dir, 'result.mat'), '-struct', 'result');" in content, \
         'run_agent_simulation.m should save results with -struct'
-


### PR DESCRIPTION
## Summary
- add Python utility `analyze_crimaldi_data.py` to compute stats from the Crimaldi plume file
- test Crimaldi analyzer on a temporary sample dataset
- fix syntax in `test_run_agent_simulation_save_struct.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*