### PR TITLE
Add custom plume test script

### DIFF
--- a/Code/run_custom_plume_test.m
+++ b/Code/run_custom_plume_test.m
@@ -1,0 +1,30 @@
+function result = run_custom_plume_test(cfgFile)
+%RUN_CUSTOM_PLUME_TEST Run the navigation model with a custom plume and log odor values.
+%
+%   RESULT = RUN_CUSTOM_PLUME_TEST(CFGFILE) runs the navigation model using
+%   the configuration specified by CFGFILE. The script logs the odor(i,it)
+%   values produced by the model. If CFGFILE is not provided, the default
+%   configuration 'configs/my_complex_plume_config.yaml' is used.
+%
+%   Example:
+%       run_custom_plume_test; % uses the default configuration
+%       run_custom_plume_test('my_cfg.yaml');
+
+if nargin < 1 || isempty(cfgFile)
+    cfgFile = fullfile('configs','my_complex_plume_config.yaml');
+end
+
+% Ensure the project paths are set up
+if isempty(which('run_navigation_cfg'))
+    startup;
+end
+
+cfg = load_config(cfgFile);
+result = run_navigation_cfg(cfg);
+
+for it = 1:size(result.odor,2)
+    for i = 1:size(result.odor,1)
+        fprintf('odor(%d,%d) = %.4f\n', i, it, result.odor(i,it));
+    end
+end
+end

--- a/tests/test_run_agent_simulation_save_struct.py
+++ b/tests/test_run_agent_simulation_save_struct.py
@@ -4,6 +4,6 @@ import os
 def test_run_agent_simulation_save_struct():
     with open(os.path.join('Code', 'run_agent_simulation.m')) as f:
         content = f.read()
-    assert "save(fullfile(output_dir, 'result.mat'), '-struct', 'result');" in content,
+    assert "save(fullfile(output_dir, 'result.mat'), '-struct', 'result');" in content, \
         'run_agent_simulation.m should save results with -struct'
 

--- a/tests/test_run_custom_plume_test.m
+++ b/tests/test_run_custom_plume_test.m
@@ -1,0 +1,38 @@
+function tests = test_run_custom_plume_test
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd,'Code'));
+    tmpDir = fullfile(tempname);
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir,'plume.avi'));
+    open(vw);
+    writeVideo(vw,uint8(zeros(2,2,1)));
+    close(vw);
+    meta = fullfile(tmpDir,'meta.yaml');
+    fid = fopen(meta,'w');
+    fprintf(fid,'output_directory: %s\n',tmpDir);
+    fprintf(fid,'output_filename: plume.avi\n');
+    fprintf(fid,'vid_mm_per_px: 1\n');
+    fprintf(fid,'fps: 1\n');
+    fclose(fid);
+    cfg = fullfile(tmpDir,'cfg.yaml');
+    fid = fopen(cfg,'w');
+    fprintf(fid,'environment: video\n');
+    fprintf(fid,'plume_metadata: %s\n',meta);
+    fprintf(fid,'plotting: 0\n');
+    fprintf(fid,'ntrials: 1\n');
+    fclose(fid);
+    testCase.TestData.tmpDir = tmpDir;
+    testCase.TestData.cfg = cfg;
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir,'s');
+end
+
+function testRun(testCase)
+    run_custom_plume_test(testCase.TestData.cfg);
+    assert(true); % ensure script runs without error
+end


### PR DESCRIPTION
## Summary
- add `run_custom_plume_test` helper for running a normalized video plume and logging `odor(i,it)` values
- add MATLAB test for the new helper
- fix syntax in `test_run_agent_simulation_save_struct.py`

## Testing
- `pytest -k custom -q`
- `pytest tests/test_run_agent_simulation_save_struct.py -q` *(fails: run_agent_simulation.m should save results with -struct)*
