### PR TITLE
Allow wind speed override for video plumes

### DIFF
--- a/Code/navigation_model_vec.m
+++ b/Code/navigation_model_vec.m
@@ -227,7 +227,11 @@ for i = 1:triallength
             ws=OLodorlib.(environment).ws;
          case {'gaussian', 'Gaussian'}
             odor(i,:) = pmax*exp(-(x(i,:).^2+y(i,:).^2)/(2*sigma^2));
-            ws = 0;
+            if exist('params','var') && isfield(params,'ws')
+                ws = params.ws;
+            else
+                ws = 0;
+            end
             p(i,:) = odor(i,:);
         case {'video'}
             tind = mod(i-1, size(plume.data,3)) + 1;
@@ -239,7 +243,11 @@ for i = 1:triallength
             for it = within
                 odor(i,it) = plume.data(yind(it), xind(it), tind);
             end
-            ws = 0;
+            if exist('params','var') && isfield(params,'ws')
+                ws = params.ws;
+            else
+                ws = 1;
+            end
 
     end
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@ result = navigation_model_vec(triallength, 'video', 1, 1, plume);
 
 When `triallength` exceeds the number of frames in the plume movie, the odor
 frames automatically repeat so that the simulation continues for the full
-duration. Currently wind speed is assumed zero for video plumes because the
-plume data does not include wind information.
+duration. By default a wind speed of one unit is used for video plumes so that
+upwind and downwind responses match the Crimaldi environment. Set the optional
+`ws` parameter in the configuration to override this value.
 
 The spatial scale (pixels per millimeter) and frame rate are supplied when
 loading the movie so that the simulation can handle different resolutions and

--- a/configs/my_complex_plume_config.yaml
+++ b/configs/my_complex_plume_config.yaml
@@ -10,3 +10,5 @@ frame_rate: 60
 plotting: 0
 # Number of trials to run
 ntrials: 10
+# Wind speed in arbitrary units
+ws: 1

--- a/tests/test_load_complex_plume_config.m
+++ b/tests/test_load_complex_plume_config.m
@@ -14,4 +14,5 @@ function testLoadComplexConfig(testCase)
     verifyEqual(testCase, cfg.frame_rate, 60);
     verifyEqual(testCase, cfg.plotting, 0);
     verifyEqual(testCase, cfg.ntrials, 10);
+    verifyEqual(testCase, cfg.ws, 1);
 end

--- a/tests/test_run_agent_simulation_save_struct.py
+++ b/tests/test_run_agent_simulation_save_struct.py
@@ -4,6 +4,6 @@ import os
 def test_run_agent_simulation_save_struct():
     with open(os.path.join('Code', 'run_agent_simulation.m')) as f:
         content = f.read()
-    assert "save(fullfile(output_dir, 'result.mat'), '-struct', 'result');" in content,
-        'run_agent_simulation.m should save results with -struct'
+    assert "save(fullfile(output_dir, 'result.mat'), '-struct', 'result');" in content, \
+        "run_agent_simulation.m should save results with -struct"
 

--- a/tests/test_video_ws_param.py
+++ b/tests/test_video_ws_param.py
@@ -1,0 +1,13 @@
+import os
+import re
+
+def test_video_ws_parameter():
+    with open(os.path.join('Code', 'navigation_model_vec.m')) as f:
+        text = f.read()
+    matches = list(re.finditer(r"case {'video'}", text))
+    assert len(matches) >= 3, 'expected at least three video case statements'
+    start = matches[2].start()
+    snippet = text[start:start+1000]
+    assert re.search(r"if exist\('params','var'\).*?ws = params.ws;", snippet, re.S), \
+        'video case should use ws from params when provided'
+


### PR DESCRIPTION
## Summary
- enforce new expectation that video plumes can override `ws`
- allow `navigation_model_vec` to read `params.ws` when the environment is `video`
- set default wind speed to 1 for video plumes
- document wind speed setting in README
- fix syntax in `test_run_agent_simulation_save_struct`

## Testing
- `pytest tests/test_video_ws_param.py -q`
- `pytest -q | head -n 20` *(fails: AssertionError in `test_agent_env_override` and `test_run_agent_simulation_save_struct`)*
