### PR TITLE
Add data discovery utility

### DIFF
--- a/Code/data_discovery.py
+++ b/Code/data_discovery.py
@@ -1,0 +1,60 @@
+"""Utilities for discovering processed data files based on a config."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Iterator, Any
+
+
+def _template_to_regex(template: str) -> re.Pattern:
+    pattern = re.escape(template)
+    pattern = pattern.replace(r"\{", "{").replace(r"\}", "}")
+    pattern = re.sub(r"{(\w+)}", r"(?P<\1>[^/]+)", pattern)
+    return re.compile(f"^{pattern}$")
+
+
+def discover_processed_data(cfg: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+    """Yield discovered run information from processed data directories.
+
+    Parameters
+    ----------
+    cfg : dict
+        Analysis configuration dictionary loaded via :func:`load_analysis_config`.
+
+    Yields
+    ------
+    dict
+        Dictionary with keys ``path``, ``metadata``, and ``config`` (optional).
+    """
+    base_dirs = cfg.get("data_paths", {}).get("processed_base_dirs", [])
+    template = cfg.get("metadata_extraction", {}).get(
+        "directory_template",
+        "{plume}_{mode}/agent_{agent_id}/seed_{seed}",
+    )
+    load_run_cfg = cfg.get("load_run_config", False)
+
+    regex = _template_to_regex(template)
+
+    for base in base_dirs:
+        root = Path(base)
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if path.is_dir():
+                rel = path.relative_to(root)
+                m = regex.match(str(rel))
+                if m:
+                    record = {
+                        "path": str(path),
+                        "metadata": m.groupdict(),
+                    }
+                    if load_run_cfg:
+                        cfg_file = path / "config_used.yaml"
+                        if cfg_file.is_file():
+                            try:
+                                record["config"] = json.loads(cfg_file.read_text())
+                            except Exception:
+                                record["config"] = {}
+                    yield record

--- a/tests/test_discover_processed_data.py
+++ b/tests/test_discover_processed_data.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Code.load_analysis_config import load_analysis_config
+from Code.data_discovery import discover_processed_data
+
+
+def test_discover_processed_data(tmp_path):
+    base = tmp_path / "processed"
+    run_dir = base / "gaussian_bilateral" / "agent_1" / "seed_0"
+    run_dir.mkdir(parents=True)
+    # create a dummy config_used.yaml in JSON format
+    (run_dir / "config_used.yaml").write_text('{"frame_rate": 100, "px_per_mm": 5}')
+    (run_dir / "results.mat").write_text("dummy")
+
+    cfg_dict = {
+        "data_paths": {"processed_base_dirs": [str(base)]},
+        "metadata_extraction": {"directory_template": "{plume}_{mode}/agent_{agent_id}/seed_{seed}"},
+        "load_run_config": True,
+    }
+    cfg_path = tmp_path / "analysis_config.yaml"
+    cfg_path.write_text(json.dumps(cfg_dict))
+    cfg = load_analysis_config(cfg_path)
+
+    records = list(discover_processed_data(cfg))
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["metadata"]["plume"] == "gaussian"
+    assert rec["metadata"]["mode"] == "bilateral"
+    assert rec["metadata"]["agent_id"] == "1"
+    assert rec["metadata"]["seed"] == "0"
+    assert rec["config"]["frame_rate"] == 100
+


### PR DESCRIPTION
## Summary
- add `discover_processed_data` helper for locating run directories
- test data discovery parsing with run configs

## Testing
- `pytest tests/test_discover_processed_data.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*