### PR TITLE
Add configurable CSV loader

### DIFF
--- a/Code/data_loading.py
+++ b/Code/data_loading.py
@@ -1,0 +1,40 @@
+"""Utilities for loading exported simulation data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+
+
+def load_trajectories(path: str | Path, cfg: Dict[str, Any] | None = None) -> pd.DataFrame:
+    """Load trajectories from a CSV file.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the trajectories CSV file.
+    cfg : dict, optional
+        Analysis configuration dictionary. If provided and it contains the key
+        ``trajectory_processing.required_columns``, only those columns are
+        returned.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame of trajectory data.
+    """
+    csv_path = Path(path)
+    df = pd.read_csv(csv_path)
+
+    if cfg is not None:
+        proc_cfg = cfg.get("trajectory_processing", {})
+        columns = proc_cfg.get("required_columns")
+        if columns:
+            missing = [c for c in columns if c not in df.columns]
+            if missing:
+                raise KeyError(f"Missing required columns: {missing}")
+            df = df[columns]
+
+    return df

--- a/configs/analysis_config.yaml
+++ b/configs/analysis_config.yaml
@@ -12,6 +12,9 @@
     "velocity_threshold": 1.0,
     "smoothing_window": 5
   },
+  "trajectory_processing": {
+    "required_columns": ["t", "x", "y", "theta", "turn"]
+  },
   "aggregation_groups": ["plume_type", "sensing_mode"],
   "plotting_parameters": {
     "colors": {"gaussian": "blue", "smoke": "orange"},

--- a/tests/test_load_trajectories.py
+++ b/tests/test_load_trajectories.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import json
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Code.load_analysis_config import load_analysis_config
+from Code.data_loading import load_trajectories
+
+
+def test_load_trajectories_required_columns(tmp_path):
+    csv_path = tmp_path / "trajectories.csv"
+    csv_path.write_text(
+        "t,trial,x,y,theta,odor,ON,OFF,turn\n"
+        "0,0,1,2,3,0.1,0.1,0.1,0\n"
+        "1,0,1.1,2.1,3.1,0.2,0.2,0.2,1\n"
+    )
+
+    cfg_dict = {
+        "trajectory_processing": {
+            "required_columns": ["t", "x", "y", "theta", "turn"]
+        }
+    }
+    cfg_path = tmp_path / "analysis_config.yaml"
+    cfg_path.write_text(json.dumps(cfg_dict))
+
+    cfg = load_analysis_config(cfg_path)
+    df = load_trajectories(csv_path, cfg)
+    assert list(df.columns) == ["t", "x", "y", "theta", "turn"]


### PR DESCRIPTION
## Summary
- add failing test covering loading of trajectories
- implement `load_trajectories` to read CSVs with configurable columns
- extend `analysis_config.yaml` with `trajectory_processing` section

## Testing
- `pytest tests/test_load_trajectories.py -q` *(fails: No module named 'pandas')*
- `pytest -q` *(fails: No module named 'numpy', No module named 'pandas')*