### PR TITLE
Add statistic support in table generation

### DIFF
--- a/Code/comparative_analysis.py
+++ b/Code/comparative_analysis.py
@@ -69,8 +69,10 @@ def generate_tables(records: List[Record], cfg: Dict[str, Any]) -> List[Path]:
                     vals = [r[m] for r in recs if m in r]
                     if stat == "mean":
                         row.append(_mean(vals))
+                    elif stat == "sem":
+                        row.append(_sem(vals))
                     else:
-                        row.append(_mean(vals))
+                        raise ValueError(f"Unsupported statistic: {stat}")
                 writer.writerow(row)
         output_files.append(outfile)
     return output_files

--- a/tests/test_comparative_analysis.py
+++ b/tests/test_comparative_analysis.py
@@ -2,6 +2,7 @@ import os
 import sys
 import json
 import tempfile
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -18,7 +19,7 @@ def create_sample_data():
     ]
 
 
-def sample_config(tmp_path):
+def sample_config(tmp_path, stat="mean"):
     cfg_dict = {
         "plotting_tasks": [
             {
@@ -36,7 +37,7 @@ def sample_config(tmp_path):
             {
                 "metrics": ["success_rate", "latency"],
                 "group_by_keys": ["plume_type", "sensing_mode"],
-                "statistic_to_report": "mean",
+                "statistic_to_report": stat,
                 "output_filename": "summary.csv",
             }
         ],
@@ -81,3 +82,47 @@ def test_generate_plots_placeholder(tmp_path):
     plot_files = generate_plots(data, cfg)
     assert len(plot_files) == 1
     assert plot_files[0].exists()
+
+
+def read_table(path):
+    import csv
+    with path.open() as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+    return rows
+
+
+def test_generate_tables_mean(tmp_path):
+    cfg_path = sample_config(tmp_path, stat="mean")
+    cfg = load_analysis_config(cfg_path)
+    data = create_sample_data()
+
+    table_files = generate_tables(data, cfg)
+    rows = read_table(table_files[0])
+    assert float(rows[1][2]) == pytest.approx(0.85, rel=1e-6)
+    assert float(rows[1][3]) == pytest.approx(2.1, rel=1e-6)
+    assert float(rows[2][2]) == pytest.approx(0.55, rel=1e-6)
+    assert float(rows[2][3]) == pytest.approx(3.05, rel=1e-6)
+
+
+def test_generate_tables_sem(tmp_path):
+    cfg_path = sample_config(tmp_path, stat="sem")
+    cfg = load_analysis_config(cfg_path)
+    data = create_sample_data()
+
+    table_files = generate_tables(data, cfg)
+    rows = read_table(table_files[0])
+    assert float(rows[1][2]) == pytest.approx(0.05, rel=1e-6)
+    assert float(rows[1][3]) == pytest.approx(0.1, rel=1e-6)
+    assert float(rows[2][2]) == pytest.approx(0.05, rel=1e-6)
+    assert float(rows[2][3]) == pytest.approx(0.05, rel=1e-6)
+
+
+def test_generate_tables_invalid_stat(tmp_path):
+    cfg_path = sample_config(tmp_path, stat="median")
+    cfg = load_analysis_config(cfg_path)
+    data = create_sample_data()
+
+    with pytest.raises(ValueError):
+        generate_tables(data, cfg)
+


### PR DESCRIPTION
## Summary
- extend `generate_tables` to handle `mean` and `sem`
- raise an error for unsupported statistics
- verify table generation for mean and sem statistics
- ensure invalid statistic handling through tests

## Testing
- `pytest tests/test_comparative_analysis.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: numpy, pandas)*