### PR TITLE
Enable YAML config loading

### DIFF
--- a/Code/load_analysis_config.py
+++ b/Code/load_analysis_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+import yaml
 from typing import Any, Dict
 from pathlib import Path
 
@@ -25,4 +25,4 @@ def load_analysis_config(path: str | Path) -> Dict[str, Any]:
         raise FileNotFoundError(f"Config file not found: {file_path}")
 
     content = file_path.read_text()
-    return json.loads(content)
+    return yaml.safe_load(content)

--- a/README.md
+++ b/README.md
@@ -314,6 +314,9 @@ from Code.load_analysis_config import load_analysis_config
 cfg = load_analysis_config('configs/analysis_config.yaml')
 ```
 
+`load_analysis_config` uses `yaml.safe_load` under the hood, so the
+configuration must be valid YAML rather than JSON.
+
 The configuration file includes a `data_loading_options` section that controls
 which files are loaded for each discovered run. For example:
 

--- a/configs/analysis_config.yaml
+++ b/configs/analysis_config.yaml
@@ -1,63 +1,83 @@
-{
-  "data_paths": {
-    "raw_data_dir": "data/raw",
-    "processed_data_dir": "data/processed",
-    "metadata_file": "data/metadata.csv"
-  },
-  "data_loading_options": {
-    "load_summary_json": true,
-    "load_trajectories_csv": false,
-    "load_params_json": false,
-    "load_config_used_yaml": true
-  },
-  "metadata_extraction": {
-    "plume_regex": "(gaussian|smoke)_([a-z]+)",
-    "mode_regex": "(bilateral|unilateral)"
-  },
-  "metrics_calculation": {
-    "velocity_threshold": 1.0,
-    "smoothing_window": 5
-  },
-  "metrics_to_compute": [
-    "success_rate",
-    "latency",
-    "path_length",
-    "average_speed",
-    "net_upwind_displacement",
-    "straightness",
-    "turning_rate"
-  ],
-  "metric_parameters": {
-    "average_speed": {
-      "dt_source": "from_config_used_yaml",
-      "dt_fixed_value": 0.02,
-      "framerate_field_in_config_used": "frame_rate"
-    },
-    "net_upwind_displacement": {
-      "upwind_axis": "y",
-      "upwind_positive_direction": true
-    }
-  },
-  "trajectory_processing": {
-    "required_columns": ["t", "x", "y", "theta", "turn"]
-  },
-  "aggregation_groups": ["plume_type", "sensing_mode"],
-  "aggregation_options": {
-    "group_by_keys": ["plume_type", "sensing_mode"],
-    "statistics_to_compute": ["mean", "std", "sem", "count", "median", "min", "max"]
-  },
-  "plotting_parameters": {
-    "colors": {"gaussian": "blue", "smoke": "orange"},
-    "output_format": "png",
-    "metrics": ["velocity", "turning_rate"]
-  },
-  "statistical_tests": {
-    "significance_level": 0.05,
-    "tests": ["ttest", "anova"]
-  },
-  "output_paths": {
-    "figures": "figures",
-    "tables": "tables",
-    "processed": "analysis_results"
-  }
-}
+# Example analysis configuration in YAML
+
+data_paths:
+  raw_data_dir: data/raw
+  processed_data_dir: data/processed
+  metadata_file: data/metadata.csv
+
+data_loading_options:
+  load_summary_json: true
+  load_trajectories_csv: false
+  load_params_json: false
+  load_config_used_yaml: true
+
+metadata_extraction:
+  plume_regex: "(gaussian|smoke)_([a-z]+)"
+  mode_regex: "(bilateral|unilateral)"
+
+metrics_calculation:
+  velocity_threshold: 1.0
+  smoothing_window: 5
+
+metrics_to_compute:
+  - success_rate
+  - latency
+  - path_length
+  - average_speed
+  - net_upwind_displacement
+  - straightness
+  - turning_rate
+
+metric_parameters:
+  average_speed:
+    dt_source: from_config_used_yaml
+    dt_fixed_value: 0.02
+    framerate_field_in_config_used: frame_rate
+  net_upwind_displacement:
+    upwind_axis: y
+    upwind_positive_direction: true
+
+trajectory_processing:
+  required_columns:
+    - t
+    - x
+    - y
+    - theta
+    - turn
+
+aggregation_groups:
+  - plume_type
+  - sensing_mode
+
+aggregation_options:
+  group_by_keys:
+    - plume_type
+    - sensing_mode
+  statistics_to_compute:
+    - mean
+    - std
+    - sem
+    - count
+    - median
+    - min
+    - max
+
+plotting_parameters:
+  colors:
+    gaussian: blue
+    smoke: orange
+  output_format: png
+  metrics:
+    - velocity
+    - turning_rate
+
+statistical_tests:
+  significance_level: 0.05
+  tests:
+    - ttest
+    - anova
+
+output_paths:
+  figures: figures
+  tables: tables
+  processed: analysis_results

--- a/docs/analysis_plan.md
+++ b/docs/analysis_plan.md
@@ -14,6 +14,8 @@ This document describes a parameterized approach for processing simulation resul
   - `output_paths` – directories for figures, tables and analysis outputs.
 
 The analysis scripts load this YAML at startup using `load_analysis_config`.
+The loader relies on `yaml.safe_load`, so the configuration file must be
+valid YAML.
 
 ## 2. Data Discovery and Organization
 - Directories containing processed results are specified under `data_paths.processed_base_dirs`.

--- a/tests/test_calculate_metrics.py
+++ b/tests/test_calculate_metrics.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import json
+import yaml
 import math
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -31,7 +31,7 @@ def test_calculate_metrics(tmp_path):
         },
     }
     cfg_path = tmp_path / "analysis.yaml"
-    cfg_path.write_text(json.dumps(cfg_dict))
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
     cfg = load_analysis_config(cfg_path)
 
     trajectories = [

--- a/tests/test_comparative_analysis.py
+++ b/tests/test_comparative_analysis.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import json
+import yaml
 import tempfile
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -52,7 +52,7 @@ def sample_config(tmp_path):
         "output_paths": {"figures": str(tmp_path), "tables": str(tmp_path), "processed": str(tmp_path)},
     }
     cfg_path = tmp_path / "analysis_config.yaml"
-    cfg_path.write_text(json.dumps(cfg_dict))
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
     return cfg_path
 
 

--- a/tests/test_discover_processed_data.py
+++ b/tests/test_discover_processed_data.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import json
+import yaml
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -23,7 +23,7 @@ def test_discover_processed_data(tmp_path):
         "load_run_config": True,
     }
     cfg_path = tmp_path / "analysis_config.yaml"
-    cfg_path.write_text(json.dumps(cfg_dict))
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
     cfg = load_analysis_config(cfg_path)
 
     records = list(discover_processed_data(cfg))
@@ -56,7 +56,7 @@ def test_conditional_loading_options(tmp_path):
         },
     }
     cfg_path = tmp_path / "analysis_config.yaml"
-    cfg_path.write_text(json.dumps(cfg_dict))
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
     cfg = load_analysis_config(cfg_path)
 
     records = list(discover_processed_data(cfg))

--- a/tests/test_load_trajectories.py
+++ b/tests/test_load_trajectories.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import json
+import yaml
 import pandas as pd
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -23,7 +23,7 @@ def test_load_trajectories_required_columns(tmp_path):
         }
     }
     cfg_path = tmp_path / "analysis_config.yaml"
-    cfg_path.write_text(json.dumps(cfg_dict))
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
 
     cfg = load_analysis_config(cfg_path)
     df = load_trajectories(csv_path, cfg)

--- a/tests/test_parameter_usage.py
+++ b/tests/test_parameter_usage.py
@@ -1,4 +1,5 @@
 import json
+import yaml
 import os
 import sys
 from pathlib import Path
@@ -26,7 +27,7 @@ def test_use_config_used_for_dt(tmp_path):
         }
     }
     cfg_path = tmp_path / "analysis.yaml"
-    cfg_path.write_text(json.dumps(cfg_dict))
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
     cfg = load_analysis_config(cfg_path)
 
     records = list(discover_processed_data(cfg))
@@ -54,7 +55,7 @@ def test_check_model_parameter_consistency(tmp_path):
         }
     }
     cfg_path = tmp_path / "analysis.yaml"
-    cfg_path.write_text(json.dumps(cfg_dict))
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
     cfg = load_analysis_config(cfg_path)
 
     records = list(discover_processed_data(cfg))


### PR DESCRIPTION
## Summary
- parse analysis configs with `yaml.safe_load`
- update data discovery to respect `data_loading_options`
- rewrite config example in YAML
- adjust tests to use YAML
- document YAML requirement

## Testing
- `pytest -q tests/test_load_analysis_config.py tests/test_comparative_analysis.py::test_generate_tables_and_stats tests/test_calculate_metrics.py::test_calculate_metrics tests/test_discover_processed_data.py tests/test_parameter_usage.py::test_use_config_used_for_dt`
- `pytest -q tests/test_load_trajectories.py::test_load_trajectories_required_columns` *(fails: ModuleNotFoundError: No module named 'pandas')*