### PR TITLE
Add environment setup script

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# setup_env.sh - Configure development environment
+# Usage: source setup_env.sh [--dev]
+
+# Prevent re-running if already sourced
+if [[ -n "${SETUP_ENV_INITIALIZED}" ]]; then
+    return 0
+fi
+export SETUP_ENV_INITIALIZED=1
+
+usage() {
+    echo "Usage: source setup_env.sh [--dev]"
+}
+
+DEV=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dev)
+            DEV=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            return 0
+            ;;
+        *)
+            usage
+            return 1
+            ;;
+    esac
+done
+
+if [[ "$DEV" -eq 1 ]]; then
+    if command -v conda >/dev/null 2>&1; then
+        if conda env list | grep -q '^\.env'; then
+            echo "Conda environment .env already exists"
+        else
+            echo "Creating conda environment .env"
+            conda create -y -n .env python=3.10 numpy pandas pytest h5py pyyaml pre-commit >/dev/null
+        fi
+        echo "Installing pre-commit hooks"
+        conda run -n .env pre-commit install >/dev/null
+    else
+        echo "conda not found; skipping environment creation"
+    fi
+fi
+
+return 0

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+
+
+def test_setup_env_script_exists():
+    assert os.path.isfile('setup_env.sh'), 'setup_env.sh does not exist'
+
+
+def test_setup_env_script_contains_expected_commands():
+    with open('setup_env.sh') as f:
+        content = f.read()
+    assert '--dev' in content
+    assert 'conda create' in content
+    assert 'pre-commit install' in content
+
+
+def test_setup_env_script_runs_idempotently():
+    cmd = 'source setup_env.sh --dev'
+    result1 = subprocess.run(['bash', '-c', cmd], capture_output=True, text=True)
+    assert result1.returncode == 0
+    result2 = subprocess.run(['bash', '-c', cmd], capture_output=True, text=True)
+    assert result2.returncode == 0


### PR DESCRIPTION
## Summary
- add tests for `setup_env.sh`
- implement `setup_env.sh` to provision Conda dev env

## Testing
- `pytest -q tests/test_setup_env_script.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*