### PR TITLE
feat: add simulation health check tool

### DIFF
--- a/Code/check_simulation_health.py
+++ b/Code/check_simulation_health.py
@@ -1,0 +1,72 @@
+"""Scan simulation runs for common anomalies."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import List, Dict, Any
+
+from Code.data_discovery import discover_processed_data
+
+
+def check_simulation_health(cfg: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Check runs specified in the config and return detected issues."""
+    opts = cfg.setdefault("data_loading_options", {})
+    opts.setdefault("load_summary_json", True)
+    opts.setdefault("load_config_used_yaml", True)
+    opts.setdefault("load_params_json", False)
+    opts.setdefault("load_trajectories_csv", False)
+
+    bounds = cfg.get("health_checks", {}).get("reasonable_bounds", {})
+    require_traj = cfg.get("health_checks", {}).get("require_trajectories", False)
+
+    issues: List[Dict[str, str]] = []
+    for rec in discover_processed_data(cfg):
+        path = rec["path"]
+        summary = rec.get("summary", {})
+        config = rec.get("config", {})
+        trajectories = rec.get("trajectories")
+
+        sr = summary.get("successrate")
+        if sr is None or (isinstance(sr, float) and math.isnan(sr)):
+            issues.append({"path": path, "issue": "successrate is NaN"})
+        else:
+            b = bounds.get("successrate")
+            if b and not (b[0] <= sr <= b[1]):
+                issues.append({"path": path, "issue": f"successrate {sr} outside [{b[0]}, {b[1]}]"})
+
+        if "n_trials" in summary and "ntrials" in config:
+            if summary["n_trials"] != config["ntrials"]:
+                issues.append({
+                    "path": path,
+                    "issue": f"n_trials {summary['n_trials']} != config ntrials {config['ntrials']}",
+                })
+
+        if require_traj:
+            if trajectories is None:
+                issues.append({"path": path, "issue": "trajectories missing"})
+            elif len(trajectories) == 0:
+                issues.append({"path": path, "issue": "trajectories empty"})
+
+    return issues
+
+
+def main(argv: List[str] | None = None) -> None:
+    import argparse
+    from Code.load_analysis_config import load_analysis_config
+
+    parser = argparse.ArgumentParser(description="Check simulation directories for anomalies")
+    parser.add_argument("config", help="Analysis config YAML file")
+    args = parser.parse_args(argv)
+
+    cfg = load_analysis_config(args.config)
+    issues = check_simulation_health(cfg)
+    if issues:
+        for item in issues:
+            print(f"{item['path']}: {item['issue']}")
+    else:
+        print("No issues found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_simulation_health.py
+++ b/tests/test_check_simulation_health.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Code.check_simulation_health import check_simulation_health
+
+
+def test_check_simulation_health_flags_issues(tmp_path):
+    base = tmp_path / "data" / "raw"
+    run_ok = base / "gaussian_bilateral" / "agent_0" / "seed_0"
+    run_nan = base / "gaussian_bilateral" / "agent_1" / "seed_0"
+    run_mismatch = base / "gaussian_bilateral" / "agent_2" / "seed_0"
+
+    for p in [run_ok, run_nan, run_mismatch]:
+        p.mkdir(parents=True)
+        (p / "config_used.yaml").write_text("ntrials: 100\n")
+
+    json.dump({"successrate": 0.8, "n_trials": 100}, (run_ok / "summary.json").open("w"))
+    json.dump({"successrate": float('nan'), "n_trials": 100}, (run_nan / "summary.json").open("w"))
+    json.dump({"successrate": 0.7, "n_trials": 1}, (run_mismatch / "summary.json").open("w"))
+
+    cfg = {
+        "data_paths": {"processed_base_dirs": [str(base)]},
+        "metadata_extraction": {"directory_template": "{plume}_{mode}/agent_{agent_id}/seed_{seed}"},
+        "data_loading_options": {"load_summary_json": True, "load_config_used_yaml": True},
+        "health_checks": {"reasonable_bounds": {"successrate": [0.0, 1.0]}}
+    }
+
+    issues = check_simulation_health(cfg)
+    assert any("successrate is NaN" in issue["issue"] for issue in issues)
+    assert any("n_trials" in issue["issue"] and "config" in issue["issue"] for issue in issues)


### PR DESCRIPTION
## Summary
- add failing test for simulation health checker
- implement `check_simulation_health` utility

## Testing
- `pytest tests/test_check_simulation_health.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*