### PR TITLE
Add exported data validation utility

### DIFF
--- a/Code/validate_exported_data.py
+++ b/Code/validate_exported_data.py
@@ -1,0 +1,73 @@
+"""Validate exported simulation results against expected schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+
+
+def validate_exported_data(path: str | Path, cfg: Dict[str, Any] | None = None) -> None:
+    """Validate exported trajectories, params, and summary files.
+
+    Parameters
+    ----------
+    path : str or Path
+        Directory containing ``trajectories.csv``, ``params.json`` and
+        ``summary.json``.
+    cfg : dict, optional
+        Analysis configuration that may define required trajectory columns under
+        ``trajectory_processing.required_columns``.
+
+    Raises
+    ------
+    ValueError
+        If required fields are missing or have the wrong type.
+    """
+    run_dir = Path(path)
+
+    csv_file = run_dir / "trajectories.csv"
+    summary_file = run_dir / "summary.json"
+    params_file = run_dir / "params.json"
+
+    if not csv_file.is_file():
+        raise FileNotFoundError(csv_file)
+    if not summary_file.is_file():
+        raise FileNotFoundError(summary_file)
+    if not params_file.is_file():
+        raise FileNotFoundError(params_file)
+
+    df = pd.read_csv(csv_file)
+
+    required_cols = None
+    if cfg is not None:
+        required_cols = cfg.get("trajectory_processing", {}).get("required_columns")
+
+    if required_cols:
+        missing = [c for c in required_cols if c not in df.columns]
+        if missing:
+            raise ValueError(f"Missing required columns: {missing}")
+        for col in required_cols:
+            if not pd.api.types.is_numeric_dtype(df[col]):
+                raise TypeError(f"Column {col} must be numeric")
+
+    with open(summary_file, "r") as f:
+        summary = json.load(f)
+
+    if not isinstance(summary.get("successrate"), (int, float)):
+        raise TypeError("successrate must be numeric")
+    if not 0 <= float(summary["successrate"]) <= 1:
+        raise ValueError("successrate out of range")
+    if not isinstance(summary.get("latency"), list) or not all(
+        isinstance(v, (int, float)) for v in summary["latency"]
+    ):
+        raise TypeError("latency must be a list of numbers")
+    if not isinstance(summary.get("n_trials"), int):
+        raise TypeError("n_trials must be integer")
+    if not isinstance(summary.get("timesteps"), int):
+        raise TypeError("timesteps must be integer")
+
+    with open(params_file, "r") as f:
+        json.load(f)

--- a/tests/test_validate_exported_data.py
+++ b/tests/test_validate_exported_data.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import json
+import yaml
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Code.load_analysis_config import load_analysis_config
+from Code.validate_exported_data import validate_exported_data
+
+
+def make_run_dir(tmp_path, traj_content, summary_content, params_content="{}"):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "trajectories.csv").write_text(traj_content)
+    (run_dir / "summary.json").write_text(summary_content)
+    (run_dir / "params.json").write_text(params_content)
+    return run_dir
+
+
+def test_validate_missing_column(tmp_path):
+    cfg_dict = {"trajectory_processing": {"required_columns": ["t", "x", "y", "theta", "turn"]}}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
+    cfg = load_analysis_config(cfg_path)
+
+    traj_content = "t,x,y,turn\n0,0,0,0"
+    summary_content = json.dumps({"successrate": 1.0, "latency": [1], "n_trials": 1, "timesteps": 1})
+    run_dir = make_run_dir(tmp_path, traj_content, summary_content)
+
+    try:
+        validate_exported_data(run_dir, cfg)
+    except Exception as e:
+        assert "theta" in str(e)
+    else:
+        raise AssertionError("Validator did not detect missing column")
+
+
+def test_validate_invalid_summary(tmp_path):
+    cfg_dict = {"trajectory_processing": {"required_columns": ["t", "x", "y", "theta", "turn"]}}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
+    cfg = load_analysis_config(cfg_path)
+
+    traj_content = "t,x,y,theta,turn\n0,0,0,0,0"
+    summary_content = json.dumps({"successrate": "bad", "latency": [1], "n_trials": 1, "timesteps": 1})
+    run_dir = make_run_dir(tmp_path, traj_content, summary_content)
+
+    try:
+        validate_exported_data(run_dir, cfg)
+    except Exception as e:
+        assert "successrate" in str(e)
+    else:
+        raise AssertionError("Validator did not detect invalid summary")
+
+
+def test_validate_valid_run(tmp_path):
+    cfg_dict = {"trajectory_processing": {"required_columns": ["t", "x", "y", "theta", "turn"]}}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_dict))
+    cfg = load_analysis_config(cfg_path)
+
+    traj_content = "t,x,y,theta,turn\n0,0,0,0,0"
+    summary_content = json.dumps({"successrate": 1.0, "latency": [1.0], "n_trials": 1, "timesteps": 1})
+    run_dir = make_run_dir(tmp_path, traj_content, summary_content)
+
+    validate_exported_data(run_dir, cfg)


### PR DESCRIPTION
## Summary
- add unit tests for exported data validation
- implement `validate_exported_data` script to check CSV and JSON outputs

## Testing
- `pytest tests/test_validate_exported_data.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*