### PR TITLE
Add characterize_plume_intensities CLI

### DIFF
--- a/Code/characterize_plume_intensities.py
+++ b/Code/characterize_plume_intensities.py
@@ -1,0 +1,63 @@
+"""CLI for characterizing plume intensities."""
+
+from __future__ import annotations
+
+import argparse
+import json  # noqa: F401  # placeholder for future use
+import os  # noqa: F401  # placeholder for future use
+try:
+    import numpy as np  # noqa: F401  # placeholder for future use
+except ImportError:  # pragma: no cover - optional dependency
+    np = None
+
+
+def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Characterize plume intensities"
+    )
+    parser.add_argument(
+        "--plume_type",
+        choices=["video", "crimaldi"],
+        required=True,
+        help="Type of plume data to analyze",
+    )
+    parser.add_argument("--file_path", required=True, help="Path to input file")
+    parser.add_argument(
+        "--output_json", required=True, help="Path to output JSON file"
+    )
+    parser.add_argument("--plume_id", required=True, help="Identifier for the run")
+    parser.add_argument(
+        "--px_per_mm",
+        type=float,
+        help="Pixels per millimeter (required for video)",
+    )
+    parser.add_argument(
+        "--frame_rate", type=float, help="Frame rate in Hz (required for video)"
+    )
+    parser.add_argument(
+        "--min_threshold",
+        type=float,
+        default=0.01,
+        help="Minimum intensity threshold",
+    )
+    parser.add_argument(
+        "--matlab_path", default="matlab", help="Path to MATLAB executable"
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.plume_type == "video":
+        if args.px_per_mm is None or args.frame_rate is None:
+            parser.error("--px_per_mm and --frame_rate are required for video")
+
+    return args
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_arguments(argv)
+    print(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_characterize_plume_intensities_cli.py
+++ b/tests/test_characterize_plume_intensities_cli.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+
+
+def run_script(args):
+    return subprocess.run(['python', 'Code/characterize_plume_intensities.py'] + args, capture_output=True, text=True)
+
+
+def test_script_exists():
+    assert os.path.isfile('Code/characterize_plume_intensities.py'), 'Script does not exist'
+
+
+def test_video_requires_px_per_mm_and_frame_rate():
+    result = run_script(['--plume_type', 'video', '--file_path', 'path', '--output_json', 'out.json', '--plume_id', 'pid'])
+    assert result.returncode != 0
+
+
+def test_video_valid_arguments():
+    result = run_script([
+        '--plume_type', 'video',
+        '--file_path', 'path',
+        '--output_json', 'out.json',
+        '--plume_id', 'pid',
+        '--px_per_mm', '10.0',
+        '--frame_rate', '25.0'
+    ])
+    assert result.returncode == 0
+    assert "plume_type='video'" in result.stdout
+
+
+def test_crimaldi_valid_arguments():
+    result = run_script([
+        '--plume_type', 'crimaldi',
+        '--file_path', 'path',
+        '--output_json', 'out.json',
+        '--plume_id', 'pid'
+    ])
+    assert result.returncode == 0
+    assert "plume_type='crimaldi'" in result.stdout


### PR DESCRIPTION
## Summary
- scaffold `characterize_plume_intensities.py` script with argument parsing
- add CLI tests for `characterize_plume_intensities`

## Testing
- `pytest tests/test_characterize_plume_intensities_cli.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*