### PR TITLE
Implement Crimaldi intensity loader

### DIFF
--- a/Code/analyze_crimaldi_data.py
+++ b/Code/analyze_crimaldi_data.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 from typing import Dict
+import os
 
 try:
     import numpy as np
@@ -50,6 +51,44 @@ def analyze_crimaldi_data(path: str) -> Dict[str, float | dict]:
         },
     }
     return stats
+
+
+def get_intensities_from_crimaldi(
+    hdf5_path: str, dataset_name: str = "dataset_1"
+) -> np.ndarray:
+    """Return a flat array of intensity values from the Crimaldi plume file.
+
+    Parameters
+    ----------
+    hdf5_path : str
+        Path to the HDF5 file to read.
+    dataset_name : str, optional
+        Name of the dataset within the file. Defaults to ``dataset_1``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Flattened 1-D array of the intensity values.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    KeyError
+        If ``dataset_name`` is not found in the file.
+    """
+
+    if not os.path.isfile(hdf5_path):
+        raise FileNotFoundError(f"HDF5 file not found: {hdf5_path}")
+
+    with h5py.File(hdf5_path, "r") as f:
+        if dataset_name not in f:
+            raise KeyError(
+                f"Dataset '{dataset_name}' not found in {hdf5_path}"
+            )
+        data = f[dataset_name][:]
+
+    return data.flatten()
 
 
 def main() -> None:  # pragma: no cover - CLI wrapper

--- a/tests/test_get_intensities_from_crimaldi.py
+++ b/tests/test_get_intensities_from_crimaldi.py
@@ -1,0 +1,32 @@
+import os
+import numpy as np
+import h5py
+import unittest
+
+from Code.analyze_crimaldi_data import get_intensities_from_crimaldi
+
+class TestGetIntensitiesFromCrimaldi(unittest.TestCase):
+    def setUp(self):
+        self.tmpfile = 'tests/sample_crimaldi.hdf5'
+        data = np.arange(27, dtype=np.float32).reshape(3,3,3)
+        with h5py.File(self.tmpfile, 'w') as f:
+            f.create_dataset('dataset_1', data=data)
+        self.data = data
+
+    def tearDown(self):
+        if os.path.isfile(self.tmpfile):
+            os.remove(self.tmpfile)
+
+    def test_returns_flat_array(self):
+        arr = get_intensities_from_crimaldi(self.tmpfile)
+        self.assertIsInstance(arr, np.ndarray)
+        self.assertEqual(arr.ndim, 1)
+        self.assertEqual(arr.size, self.data.size)
+        np.testing.assert_array_equal(arr, self.data.flatten())
+
+    def test_missing_dataset_raises(self):
+        with self.assertRaises(KeyError):
+            get_intensities_from_crimaldi(self.tmpfile, 'missing')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add failing test for loading Crimaldi intensities
- implement `get_intensities_from_crimaldi` helper

## Testing
- `pytest tests/test_get_intensities_from_crimaldi.py` *(fails: ModuleNotFoundError: No module named 'numpy')*