### PR TITLE
Add intensity stats utility

### DIFF
--- a/Code/intensity_stats.py
+++ b/Code/intensity_stats.py
@@ -1,0 +1,76 @@
+"""Utilities for computing statistics on intensity arrays."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+try:
+    import numpy as np  # type: ignore
+except Exception as exc:  # pragma: no cover - optional dependency
+    raise ImportError("calculate_intensity_stats_dict requires numpy") from exc
+
+
+_PERCENTILES: List[float] = [
+    1,
+    5,
+    10,
+    25,
+    50,
+    75,
+    90,
+    95,
+    99,
+    99.5,
+    99.9,
+]
+
+
+def calculate_intensity_stats_dict(
+    intensities_array: np.ndarray, min_threshold: float = 0.01
+) -> Dict[str, float | int | Dict[float, float]]:
+    """Return a dictionary of summary statistics for ``intensities_array``.
+
+    Parameters
+    ----------
+    intensities_array : numpy.ndarray
+        1D array of intensity values.
+    min_threshold : float, optional
+        Minimum value to include in statistics, by default 0.01.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``mean``, ``median``, ``std``, ``min``, ``max``,
+        ``percentiles`` and pixel counts.
+    """
+
+    num_total = int(len(intensities_array))
+    filtered = intensities_array[intensities_array >= min_threshold]
+    num_filtered = int(len(filtered))
+
+    stats: Dict[str, float | int | Dict[float, float]] = {
+        "num_pixels_total": num_total,
+        "num_pixels_analyzed_post_threshold": num_filtered,
+        "percentiles": {},
+        "mean": float("nan"),
+        "median": float("nan"),
+        "std": float("nan"),
+        "min": float("nan"),
+        "max": float("nan"),
+    }
+
+    if num_filtered == 0:
+        return stats
+
+    stats["mean"] = float(np.mean(filtered))
+    stats["median"] = float(np.median(filtered))
+    stats["std"] = float(np.std(filtered))
+    stats["min"] = float(np.min(filtered))
+    stats["max"] = float(np.max(filtered))
+
+    percentiles = np.percentile(filtered, _PERCENTILES)
+    stats["percentiles"] = {
+        p: float(val) for p, val in zip(_PERCENTILES, percentiles)
+    }
+
+    return stats

--- a/tests/test_intensity_stats.py
+++ b/tests/test_intensity_stats.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Code.intensity_stats import calculate_intensity_stats_dict
+
+
+def test_intensity_stats_basic():
+    intensities = np.array([0, 0.02, 0.5, 1.0, 2.0, 0.005])
+    stats = calculate_intensity_stats_dict(intensities, min_threshold=0.01)
+    filtered = intensities[intensities >= 0.01]
+
+    assert stats["num_pixels_total"] == len(intensities)
+    assert stats["num_pixels_analyzed_post_threshold"] == len(filtered)
+    assert stats["mean"] == pytest.approx(filtered.mean())
+    assert stats["median"] == pytest.approx(np.median(filtered))
+    assert stats["std"] == pytest.approx(filtered.std())
+    assert stats["min"] == pytest.approx(filtered.min())
+    assert stats["max"] == pytest.approx(filtered.max())
+    for p in [1, 5, 10, 25, 50, 75, 90, 95, 99, 99.5, 99.9]:
+        assert stats["percentiles"][p] == pytest.approx(np.percentile(filtered, p))
+
+
+def test_intensity_stats_empty():
+    intensities = np.array([0.001, 0.005])
+    stats = calculate_intensity_stats_dict(intensities, min_threshold=0.01)
+
+    assert stats["num_pixels_total"] == len(intensities)
+    assert stats["num_pixels_analyzed_post_threshold"] == 0
+    assert np.isnan(stats["mean"])
+    assert np.isnan(stats["median"])
+    assert np.isnan(stats["std"])
+    assert np.isnan(stats["min"])
+    assert np.isnan(stats["max"])
+    assert stats["percentiles"] == {}


### PR DESCRIPTION
## Summary
- start test for intensity stats calculation
- add `calculate_intensity_stats_dict` utility

## Testing
- `./setup_env.sh --dev` *(fails: conda is not installed)*
- `pytest tests/test_intensity_stats.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*