### PR TITLE
Add MATLAB script generator for video intensities

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -1,0 +1,55 @@
+"""Helper to extract video plume intensities using MATLAB."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+def get_intensities_from_video_via_matlab(
+    video_file_path: str | Path,
+    px_per_mm: float,
+    frame_rate: float,
+    temp_out_file: str | Path,
+) -> str:
+    """Return MATLAB script to extract intensities from a video file.
+
+    Parameters
+    ----------
+    video_file_path : str or Path
+        Path to the plume video file.
+    px_per_mm : float
+        Pixels per millimeter scaling for the video.
+    frame_rate : float
+        Frame rate of the video in Hz.
+    temp_out_file : str or Path
+        Path to a temporary ``.mat`` file to store intensities.
+
+    Returns
+    -------
+    str
+        MATLAB script that can be executed to save ``all_intensities`` to
+        ``temp_out_file``.
+    """
+    video_file = Path(video_file_path)
+    out_file = Path(temp_out_file)
+
+    template = r"""
+try
+    addpath('{code_dir}')
+    plume = load_plume_video('{video}', {px_per_mm}, {frame_rate});
+    all_intensities = plume.data(:);
+    save('{out_file}', 'all_intensities');
+    fprintf('INTENSITY_EXTRACTION_SUCCESS:%s\n', '{out_file}');
+catch ME
+    disp(getReport(ME));
+    exit(1);
+end
+"""
+
+    script = template.format(
+        code_dir=str(Path('Code').resolve()).replace('\\', '/'),
+        video=str(video_file).replace('\\', '/'),
+        px_per_mm=px_per_mm,
+        frame_rate=frame_rate,
+        out_file=str(out_file).replace('\\', '/'),
+    )
+    return script

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Code.video_intensity import get_intensities_from_video_via_matlab
+
+
+def test_script_generation():
+    script = get_intensities_from_video_via_matlab(
+        video_file_path=r"C:\path\to\video.avi",
+        px_per_mm=20,
+        frame_rate=50,
+        temp_out_file=r"C:\tmp\out.mat",
+    )
+    assert "load_plume_video" in script
+    assert "all_intensities" in script
+    assert "C:/tmp/out.mat" in script.replace('\\', '/')


### PR DESCRIPTION
## Summary
- add test for generating MATLAB helper script
- implement `get_intensities_from_video_via_matlab` to produce MATLAB script text

## Testing
- `pytest tests/test_get_intensities_from_video_via_matlab.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*