### PR TITLE
Implement video intensity retrieval

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -1,0 +1,48 @@
+"""Utilities for retrieving video intensities using MATLAB."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from scipy.io import loadmat
+
+
+def get_intensities_from_video_via_matlab(script_contents: str, matlab_exec_path: str) -> np.ndarray:
+    """Run a MATLAB script and return the extracted intensity vector."""
+    script_file = None
+    mat_path = None
+    try:
+        script_file = tempfile.NamedTemporaryFile(delete=False, suffix=".m")
+        script_file.write(script_contents.encode())
+        script_file.flush()
+        matlab_cmd = [matlab_exec_path, "-batch", Path(script_file.name).stem]
+        proc = subprocess.run(matlab_cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise RuntimeError(f"MATLAB failed: {proc.stdout}\n{proc.stderr}")
+
+        for line in proc.stdout.splitlines():
+            if line.startswith("TEMP_MAT_FILE_SUCCESS:"):
+                mat_path = line.split(":", 1)[1].strip()
+                break
+        if not mat_path or not os.path.exists(mat_path):
+            raise RuntimeError("MATLAB did not report output MAT-file")
+
+        data = loadmat(mat_path)
+        if "all_intensities" not in data:
+            raise KeyError("all_intensities not found in MAT-file")
+        return np.asarray(data["all_intensities"]).flatten()
+    finally:
+        if script_file is not None:
+            try:
+                os.unlink(script_file.name)
+            except FileNotFoundError:
+                pass
+        if mat_path is not None:
+            try:
+                os.unlink(mat_path)
+            except FileNotFoundError:
+                pass

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -1,0 +1,44 @@
+import os
+import subprocess
+from pathlib import Path
+import numpy as np
+import tempfile
+
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Code.video_intensity import get_intensities_from_video_via_matlab
+
+
+def test_get_intensities_from_video_via_matlab(monkeypatch, tmp_path):
+    matlab_exec = '/usr/local/MATLAB/R2023b/bin/matlab'
+    script_content = 'disp("hello")'
+
+    mat_file = tmp_path / 'out.mat'
+    from scipy.io import savemat
+    savemat(mat_file, {'all_intensities': np.array([1, 2, 3], dtype=np.float32)})
+
+    stdout = f"some log\nTEMP_MAT_FILE_SUCCESS:{mat_file}\n"
+
+    def fake_run(cmd, capture_output, text):
+        assert cmd[0] == matlab_exec
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr='')
+
+    created_files = []
+    orig_ntf = tempfile.NamedTemporaryFile
+
+    def fake_ntf(*args, **kwargs):
+        kwargs.setdefault('delete', False)
+        tmp = orig_ntf(*args, **kwargs)
+        created_files.append(tmp.name)
+        return tmp
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    monkeypatch.setattr(tempfile, 'NamedTemporaryFile', fake_ntf)
+
+    arr = get_intensities_from_video_via_matlab(script_content, matlab_exec)
+    assert np.array_equal(arr, np.array([1, 2, 3], dtype=np.float32))
+
+    for f in created_files:
+        assert not Path(f).exists(), f"temporary file {f} should be removed"
+    assert not mat_file.exists(), "MAT-file should be cleaned up"


### PR DESCRIPTION
## Notes
- Conda isn't available so tests fail during import.

## Summary
- Added failing test for MATLAB intensity retrieval via Python
- Implemented `get_intensities_from_video_via_matlab` to run MATLAB, parse output MAT file, and return intensities