### PR TITLE
Add plume intensity statistics utility

### DIFF
--- a/Code/intensity_stats.py
+++ b/Code/intensity_stats.py
@@ -1,0 +1,60 @@
+"""Utility functions for plume intensity statistics."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence, Dict
+
+try:
+    import numpy as np
+except Exception as exc:  # pragma: no cover
+    raise ImportError("numpy is required for intensity statistics") from exc
+
+
+def calculate_intensity_stats_dict(intensities: Sequence[float]) -> Dict[str, float]:
+    """Return basic statistics for the provided intensities."""
+    arr = np.asarray(intensities, dtype=float)
+    stats = {
+        "mean": float(arr.mean()),
+        "median": float(np.median(arr)),
+        "p95": float(np.percentile(arr, 95)),
+        "p99": float(np.percentile(arr, 99)),
+        "min": float(arr.min()),
+        "max": float(arr.max()),
+        "count": int(arr.size),
+    }
+    return stats
+
+
+def _print_stats(identifier: str, file_path: str, stats: Dict[str, float]) -> None:
+    print(f"Plume: {identifier}")
+    print(f"File: {file_path}")
+    for key in ["mean", "median", "p95", "p99", "min", "max", "count"]:
+        print(f"{key}: {stats[key]}")
+
+
+def main(args: Sequence[str] | None = None) -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Calculate intensity statistics")
+    parser.add_argument("identifier", help="Plume identifier")
+    parser.add_argument("file", help="Path to text file containing intensities")
+    parser.add_argument("--plot_histogram", action="store_true", help="Plot intensity histogram")
+    ns = parser.parse_args(args)
+
+    data = np.loadtxt(ns.file)
+    stats = calculate_intensity_stats_dict(data)
+    _print_stats(ns.identifier, ns.file, stats)
+
+    if ns.plot_histogram:
+        try:
+            import matplotlib.pyplot as plt
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError("matplotlib is required for plotting") from exc
+        plt.hist(data, bins=30)
+        plt.title(f"Intensity Histogram: {ns.identifier}")
+        plt.xlabel("Intensity")
+        plt.ylabel("Frequency")
+        plt.show()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_intensity_stats.py
+++ b/tests/test_intensity_stats.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import types
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Code.intensity_stats import calculate_intensity_stats_dict, main
+
+
+def test_calculate_intensity_stats_dict():
+    intensities = np.array([0, 1, 2, 3, 4, 5], dtype=float)
+    stats = calculate_intensity_stats_dict(intensities)
+    assert stats["mean"] == pytest.approx(np.mean(intensities))
+    assert stats["median"] == pytest.approx(np.median(intensities))
+    assert stats["p95"] == pytest.approx(np.percentile(intensities, 95))
+    assert stats["p99"] == pytest.approx(np.percentile(intensities, 99))
+    assert stats["min"] == pytest.approx(intensities.min())
+    assert stats["max"] == pytest.approx(intensities.max())
+    assert stats["count"] == intensities.size
+
+
+def test_main_prints_stats(tmp_path, capsys):
+    data = np.arange(10)
+    f = tmp_path / "data.txt"
+    np.savetxt(f, data)
+    main(["plumeA", str(f)])
+    out = capsys.readouterr().out
+    assert "Plume: plumeA" in out
+    assert f"File: {f}" in out
+    assert "mean:" in out
+
+
+def test_main_plot_histogram(monkeypatch, tmp_path):
+    data = np.linspace(0, 1, 5)
+    f = tmp_path / "data.txt"
+    np.savetxt(f, data)
+    dummy = types.SimpleNamespace(hist=lambda *a, **k: None,
+                                  title=lambda *a, **k: None,
+                                  xlabel=lambda *a, **k: None,
+                                  ylabel=lambda *a, **k: None,
+                                  show=lambda *a, **k: None)
+    monkeypatch.setitem(sys.modules, 'matplotlib.pyplot', dummy)
+    main(["plumeB", str(f), "--plot_histogram"])


### PR DESCRIPTION
## Summary
- add tests for new intensity stats module
- implement intensity statistics utilities for plume data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*