### PR TITLE
Implement robust logging

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -2,6 +2,28 @@
 # Set up local conda prefix environment for the project
 set -euo pipefail
 
+# --- Logging utility ---
+log() {
+  local level="$1"; shift
+  local timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+
+  local color_reset="\e[0m"
+  local color_info="\e[34m"
+  local color_success="\e[32m"
+  local color_warning="\e[33m"
+  local color_error="\e[31m"
+
+  local color="$color_info"
+  case "$level" in
+    INFO) color="$color_info" ;;
+    SUCCESS) color="$color_success" ;;
+    WARNING) color="$color_warning" ;;
+    ERROR) color="$color_error" ;;
+  esac
+
+  echo -e "${color}[$timestamp] [$level] $*${color_reset}"
+}
+
 # --- Configuration ---
 # LOCAL_ENV_DIR: Directory name for the local Conda prefix environment.
 # This will be created in the current project directory (e.g., "./dev-env/").
@@ -14,68 +36,69 @@ DEV_REQUIREMENTS_FILE="requirements-dev.txt"
 INSTALL_DEV_EXTRAS=0
 if [[ "${1:-}" == "--dev" ]]; then
   INSTALL_DEV_EXTRAS=1
-  echo "Development mode enabled: Extras like dev-specific packages and pre-commit hooks will be set up."
+  log INFO "Development mode enabled: Extras like dev-specific packages and pre-commit hooks will be set up."
 fi
 
 # Check if conda is installed
 if ! command -v conda >/dev/null 2>&1; then
-  echo "Error: conda is required but not found in PATH." >&2
+  log ERROR "conda is required but not found in PATH." >&2
   exit 1
 fi
 
 # Check if base environment file exists
 if [ ! -f "$BASE_ENV_FILE" ]; then
-  echo "Error: Base environment file '$BASE_ENV_FILE' not found in the current directory." >&2
+  log ERROR "Base environment file '$BASE_ENV_FILE' not found in the current directory." >&2
   exit 1
 fi
 
 # Create/update the local prefix environment
 # The environment will be located at "./$LOCAL_ENV_DIR"
-echo "Creating/updating local Conda environment in './$LOCAL_ENV_DIR' using '$BASE_ENV_FILE'..."
+log INFO "Creating/updating local Conda environment in './$LOCAL_ENV_DIR' using '$BASE_ENV_FILE'..."
 conda env update --prefix "./$LOCAL_ENV_DIR" -f "$BASE_ENV_FILE" --prune --yes
 if [ $? -ne 0 ]; then
-  echo "Error: Failed to create/update Conda environment './$LOCAL_ENV_DIR'." >&2
+  log ERROR "Failed to create/update Conda environment './$LOCAL_ENV_DIR'." >&2
   exit 1
 fi
-echo "Base environment './$LOCAL_ENV_DIR' created/updated successfully."
+log SUCCESS "Base environment './$LOCAL_ENV_DIR' created/updated successfully."
 
 # Install development dependencies and set up pre-commit if --dev flag is present
 if [ "$INSTALL_DEV_EXTRAS" -eq 1 ]; then
-  echo "Processing development extras..."
+  log INFO "Processing development extras..."
 
   # Install development-specific pip packages
   if [ -f "$DEV_REQUIREMENTS_FILE" ]; then
-    echo "Installing development dependencies from '$DEV_REQUIREMENTS_FILE' into './$LOCAL_ENV_DIR'..."
+    log INFO "Installing development dependencies from '$DEV_REQUIREMENTS_FILE' into './$LOCAL_ENV_DIR'..."
     conda run --prefix "./$LOCAL_ENV_DIR" pip install -r "$DEV_REQUIREMENTS_FILE"
     if [ $? -ne 0 ]; then
-      echo "Error: Failed to install development dependencies from '$DEV_REQUIREMENTS_FILE'." >&2
+      log ERROR "Failed to install development dependencies from '$DEV_REQUIREMENTS_FILE'." >&2
       # Consider if this should be a fatal error (exit 1)
     else
-      echo "Development dependencies from '$DEV_REQUIREMENTS_FILE' installed successfully."
+      log SUCCESS "Development dependencies from '$DEV_REQUIREMENTS_FILE' installed successfully."
     fi
   else
-    echo "Note: Development mode enabled, but '$DEV_REQUIREMENTS_FILE' not found. Skipping additional dev-specific pip packages."
+    log WARNING "Development mode enabled, but '$DEV_REQUIREMENTS_FILE' not found. Skipping additional dev-specific pip packages."
   fi
 
   # Install pre-commit and set up hooks
   # pre-commit should be listed as a dependency in your environment.yml or requirements-dev.txt
   # Alternatively, install it directly here:
-  echo "Installing pre-commit into './$LOCAL_ENV_DIR'..."
+  log INFO "Installing pre-commit into './$LOCAL_ENV_DIR'..."
   conda run --prefix "./$LOCAL_ENV_DIR" pip install pre-commit
   if [ $? -ne 0 ]; then
-      echo "Error: Failed to install pre-commit. Add it to '$BASE_ENV_FILE' or '$DEV_REQUIREMENTS_FILE'." >&2
+      log ERROR "Failed to install pre-commit. Add it to '$BASE_ENV_FILE' or '$DEV_REQUIREMENTS_FILE'." >&2
       # Consider if this should be a fatal error (exit 1)
   else
-    echo "Setting up pre-commit hooks..."
+    log INFO "Setting up pre-commit hooks..."
     conda run --prefix "./$LOCAL_ENV_DIR" pre-commit install --install-hooks
     if [ $? -ne 0 ]; then
-        echo "Warning: Failed to set up pre-commit hooks, but pre-commit command was found." >&2
+        log WARNING "Failed to set up pre-commit hooks, but pre-commit command was found." >&2
     else
-        echo "Pre-commit hooks set up successfully."
+        log SUCCESS "Pre-commit hooks set up successfully."
     fi
   fi
 fi
 
 echo ""
-echo "Setup complete."
-echo "To activate the Conda environment, run: conda activate \"./$LOCAL_ENV_DIR\""
+log SUCCESS "Setup complete."
+log INFO "To activate the Conda environment, run: conda activate \"./$LOCAL_ENV_DIR\""
+

--- a/tests/test_setup_env_logging.py
+++ b/tests/test_setup_env_logging.py
@@ -1,0 +1,11 @@
+import os
+
+
+def test_setup_env_script_has_log_function():
+    with open('setup_env.sh') as f:
+        content = f.read()
+    assert 'log()' in content, 'setup_env.sh should define a log function'
+    assert 'INFO' in content
+    assert 'SUCCESS' in content
+    assert 'WARNING' in content
+    assert 'ERROR' in content


### PR DESCRIPTION
## Summary
- add failing test for `log` function in setup script
- implement a colorized `log` utility in `setup_env.sh`
- use the new logger throughout the script

## Testing
- `pytest tests/test_setup_env_logging.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*