### PR TITLE
Add docstring details for run_statistical_tests

### DIFF
--- a/Code/comparative_analysis.py
+++ b/Code/comparative_analysis.py
@@ -84,9 +84,37 @@ def _normal_p_value(t_stat: float) -> float:
 
 
 def run_statistical_tests(records: List[Record], cfg: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Run statistical tests specified in the config.
+    """Run statistical tests specified in ``cfg``.
 
-    Currently supports independent t-tests.
+    Parameters
+    ----------
+    records : list of dict
+        Collection of input measurements. Each record should contain at least
+        the metric to analyse as well as the variable used for grouping.
+    cfg : dict
+        Analysis configuration. ``cfg['statistical_analysis']`` must be a list
+        of dictionaries with the following keys:
+
+        ``test_type``
+            Name of the statistical test to perform. Only ``"t_test_ind"`` is
+            currently supported.
+        ``metric_name``
+            Key in ``records`` holding the numeric metric to compare.
+        ``grouping_variable``
+            Key in ``records`` that defines the group membership of each
+            observation.
+        ``groups_to_compare``
+            Two-element list specifying the values of the grouping variable that
+            should be contrasted.
+        ``alpha_level``
+            Optional significance level. It is not used by this function but is
+            included to mirror the expected configuration schema.
+
+    Returns
+    -------
+    list of dict
+        List of result dictionaries. Each entry summarises one test and contains
+        ``metric``, ``groups``, ``t_stat``, and ``p_value``.
     """
     tests_cfg = cfg.get("statistical_analysis", [])
     results = []

--- a/tests/test_run_statistical_tests_docstring.py
+++ b/tests/test_run_statistical_tests_docstring.py
@@ -1,0 +1,13 @@
+import inspect
+
+from Code.comparative_analysis import run_statistical_tests
+
+
+def test_run_statistical_tests_docstring_details():
+    doc = inspect.getdoc(run_statistical_tests)
+    assert doc is not None
+    doc = doc.lower()
+    assert "cfg['statistical_analysis']" in doc
+    assert 'metric_name' in doc
+    assert 'groups_to_compare' in doc
+    assert 'list of result dictionaries' in doc


### PR DESCRIPTION
## Summary
- add failing test checking run_statistical_tests docstring details
- expand the docstring for run_statistical_tests to include configuration schema and return value description

## Testing
- `python3 -m pytest tests/test_run_statistical_tests_docstring.py -q`
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*