### PR TITLE
Update statistical analysis key

### DIFF
--- a/configs/analysis_config.yaml
+++ b/configs/analysis_config.yaml
@@ -71,11 +71,14 @@ plotting_parameters:
     - velocity
     - turning_rate
 
-statistical_tests:
-  significance_level: 0.05
-  tests:
-    - ttest
-    - anova
+statistical_analysis:
+  - test_type: t_test_ind
+    metric_name: success_rate
+    grouping_variable: plume_type
+    groups_to_compare:
+      - gaussian
+      - smoke
+    alpha_level: 0.05
 
 output_paths:
   figures: figures

--- a/docs/analysis_plan.md
+++ b/docs/analysis_plan.md
@@ -10,7 +10,7 @@ This document describes a parameterized approach for processing simulation resul
   - `metrics_calculation` – parameters for computing metrics.
   - `aggregation_groups` – how to group results before summarising.
   - `plotting_parameters` – figure options and metrics to display.
-  - `statistical_tests` – tests to run and significance levels.
+  - `statistical_analysis` – tests to run and significance levels.
   - `output_paths` – directories for figures, tables and analysis outputs.
 
 The analysis scripts load this YAML at startup using `load_analysis_config`.
@@ -32,7 +32,7 @@ valid YAML.
 
 ## 5. Plotting and Statistical Tests
 - Plot appearance and output formats are controlled via `plotting_parameters`.
-- Statistical tests defined in `statistical_tests` are executed on the aggregated data.
+- Statistical tests defined in `statistical_analysis` are executed on the aggregated data.
 
 ## 6. Output
 - Tables, figures and processed analysis data are written to the paths given in `output_paths`.


### PR DESCRIPTION
## Summary
- use `statistical_analysis` in example config
- document new key in the analysis plan

## Testing
- `pytest -q` *(fails: No module named 'yaml')*