### PR TITLE
Add compare_intensity_stats utility

### DIFF
--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -1,0 +1,71 @@
+"""Compare intensity statistics across multiple datasets."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from typing import Iterable, List, Tuple
+
+import numpy as np
+
+from Code.analyze_crimaldi_data import get_intensities_from_crimaldi
+from Code.intensity_stats import calculate_intensity_stats_dict
+
+
+Stats = dict[str, float]
+
+
+def load_intensities(path: str) -> np.ndarray:
+    """Load intensity vector from an HDF5 file using :func:`get_intensities_from_crimaldi`."""
+    return get_intensities_from_crimaldi(path)
+
+
+def compare_intensity_stats(sources: Iterable[Tuple[str, str]]) -> List[Tuple[str, Stats]]:
+    """Return statistics for each identifier/path pair."""
+    results: List[Tuple[str, Stats]] = []
+    for identifier, path in sources:
+        intensities = load_intensities(path)
+        stats = calculate_intensity_stats_dict(intensities)
+        results.append((identifier, stats))
+    return results
+
+
+def format_table(results: Iterable[Tuple[str, Stats]]) -> str:
+    keys = ["mean", "median", "p95", "p99", "min", "max", "count"]
+    header = ["identifier"] + keys
+    lines = ["\t".join(header)]
+    for ident, stats in results:
+        row = [ident] + [f"{stats[k]:.3f}" if k != "count" else str(stats[k]) for k in keys]
+        lines.append("\t".join(row))
+    return "\n".join(lines)
+
+
+def write_csv(results: Iterable[Tuple[str, Stats]], csv_path: str) -> None:
+    keys = ["mean", "median", "p95", "p99", "min", "max", "count"]
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["identifier"] + keys)
+        for ident, stats in results:
+            writer.writerow([ident] + [stats[k] for k in keys])
+
+
+def main(argv: List[str] | None = None) -> None:  # pragma: no cover - CLI wrapper
+    parser = argparse.ArgumentParser(description="Compare intensity statistics")
+    parser.add_argument("pairs", nargs="+", help="identifier and file path pairs")
+    parser.add_argument("--csv", dest="csv_path", help="Output CSV file")
+    ns = parser.parse_args(argv)
+
+    if len(ns.pairs) % 2 != 0:
+        parser.error("Expected pairs of identifier and path")
+
+    pairs = [(ns.pairs[i], ns.pairs[i + 1]) for i in range(0, len(ns.pairs), 2)]
+    results = compare_intensity_stats(pairs)
+
+    if ns.csv_path:
+        write_csv(results, ns.csv_path)
+    else:
+        print(format_table(results))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_compare_intensity_stats.py
+++ b/tests/test_compare_intensity_stats.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import h5py
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Code.compare_intensity_stats import main
+
+
+def create_hdf5(path, data):
+    with h5py.File(path, 'w') as f:
+        f.create_dataset('dataset_1', data=data)
+
+
+def test_compare_intensity_stats_table(tmp_path, capsys):
+    f1 = tmp_path / 'a.h5'
+    f2 = tmp_path / 'b.h5'
+    arr1 = np.array([1, 2, 3], dtype=float)
+    arr2 = np.array([4, 5], dtype=float)
+    create_hdf5(f1, arr1)
+    create_hdf5(f2, arr2)
+
+    main(['A', str(f1), 'B', str(f2)])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out[0].startswith('identifier')
+    assert out[1].split('\t')[0] == 'A'
+    assert out[2].split('\t')[0] == 'B'
+
+    # compute expected values for a simple sanity check
+    mean_a = arr1.mean()
+    mean_b = arr2.mean()
+    assert f"{mean_a:.3f}" in out[1]
+    assert f"{mean_b:.3f}" in out[2]


### PR DESCRIPTION
## Summary
- support comparing multiple intensity datasets
- print table or write CSV of intensity stats
- test new comparison helper

## Testing
- `pytest -q tests/test_compare_intensity_stats.py` *(fails: ModuleNotFoundError: No module named 'h5py')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*