### PR TITLE
Update analysis config key

### DIFF
--- a/configs/analysis_config.yaml
+++ b/configs/analysis_config.yaml
@@ -71,11 +71,14 @@ plotting_parameters:
     - velocity
     - turning_rate
 
-statistical_tests:
-  significance_level: 0.05
-  tests:
-    - ttest
-    - anova
+statistical_analysis:
+  - test_type: t_test_ind
+    metric_name: success_rate
+    grouping_variable: plume_type
+    groups_to_compare:
+      - gaussian
+      - smoke
+    alpha_level: 0.05
 
 output_paths:
   figures: figures

--- a/docs/analysis_plan.md
+++ b/docs/analysis_plan.md
@@ -10,7 +10,12 @@ This document describes a parameterized approach for processing simulation resul
   - `metrics_calculation` – parameters for computing metrics.
   - `aggregation_groups` – how to group results before summarising.
   - `plotting_parameters` – figure options and metrics to display.
-  - `statistical_tests` – tests to run and significance levels.
+  - `statistical_analysis` – statistical tests to run. Each entry specifies:
+    - `test_type` – e.g. `t_test_ind` for an independent t-test.
+    - `metric_name` – metric to compare.
+    - `grouping_variable` – key used to split records.
+    - `groups_to_compare` – two group labels to test.
+    - `alpha_level` – significance threshold.
   - `output_paths` – directories for figures, tables and analysis outputs.
 
 The analysis scripts load this YAML at startup using `load_analysis_config`.
@@ -32,7 +37,7 @@ valid YAML.
 
 ## 5. Plotting and Statistical Tests
 - Plot appearance and output formats are controlled via `plotting_parameters`.
-- Statistical tests defined in `statistical_tests` are executed on the aggregated data.
+- Statistical tests defined in `statistical_analysis` are executed on the aggregated data.
 
 ## 6. Output
 - Tables, figures and processed analysis data are written to the paths given in `output_paths`.

--- a/tests/test_load_analysis_config.py
+++ b/tests/test_load_analysis_config.py
@@ -11,3 +11,5 @@ def test_load_analysis_config():
     assert cfg['data_paths']['raw_data_dir'] == 'data/raw'
     assert 'metrics_calculation' in cfg
     assert 'output_paths' in cfg
+    assert 'statistical_analysis' in cfg
+    assert 'statistical_tests' not in cfg


### PR DESCRIPTION
## Summary
- adopt `statistical_analysis` key in `analysis_config.yaml`
- describe `statistical_analysis` section in documentation
- expect `statistical_analysis` in config loading test

## Testing
- `pytest -q tests/test_load_analysis_config.py` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `./setup_env.sh --dev` *(fails: wget unable to fetch Miniconda)*