### PR TITLE
Update CLI to forward video parameters

### DIFF
--- a/Code/characterize_plume_intensities.py
+++ b/Code/characterize_plume_intensities.py
@@ -62,7 +62,15 @@ def process_plume(
 
 
 def main(args: List[str] | None = None) -> None:  # pragma: no cover - CLI entry
-    """Command-line interface for characterizing plume intensities."""
+    """Command-line interface for characterizing plume intensities.
+
+    Parameters
+    ----------
+    args : list of str or None, optional
+        Command-line arguments. ``--px_per_mm`` and ``--frame_rate`` are passed
+        through to :func:`get_intensities_from_video_via_matlab` when processing
+        video plumes.
+    """
     import argparse
 
     from Code.analyze_crimaldi_data import get_intensities_from_crimaldi
@@ -82,7 +90,12 @@ def main(args: List[str] | None = None) -> None:  # pragma: no cover - CLI entry
         if ns.px_per_mm is None or ns.frame_rate is None:
             parser.error("--px_per_mm and --frame_rate are required for video plumes")
         script_contents = Path(ns.file_path).read_text()
-        intensities = get_intensities_from_video_via_matlab(script_contents, "matlab")
+        intensities = get_intensities_from_video_via_matlab(
+            script_contents,
+            "matlab",
+            px_per_mm=ns.px_per_mm,
+            frame_rate=ns.frame_rate,
+        )
     else:
         intensities = get_intensities_from_crimaldi(ns.file_path)
 

--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -11,8 +11,30 @@ import numpy as np
 from scipy.io import loadmat
 
 
-def get_intensities_from_video_via_matlab(script_contents: str, matlab_exec_path: str) -> np.ndarray:
-    """Run a MATLAB script and return the extracted intensity vector."""
+def get_intensities_from_video_via_matlab(
+    script_contents: str,
+    matlab_exec_path: str,
+    px_per_mm: float | None = None,
+    frame_rate: float | None = None,
+) -> np.ndarray:
+    """Run a MATLAB script and return the extracted intensity vector.
+
+    Parameters
+    ----------
+    script_contents : str
+        Contents of the MATLAB script to execute.
+    matlab_exec_path : str
+        Path to the MATLAB executable to run.
+    px_per_mm : float, optional
+        Pixel-to-millimetre conversion factor used by the MATLAB script.
+    frame_rate : float, optional
+        Frame rate of the video in Hz.
+
+    Returns
+    -------
+    numpy.ndarray
+        Flattened array of the intensity values extracted from the MAT-file.
+    """
     script_file = None
     mat_path = None
     try:

--- a/tests/test_characterize_plume_intensities_cli.py
+++ b/tests/test_characterize_plume_intensities_cli.py
@@ -17,7 +17,7 @@ def test_video_requires_px_per_mm_and_frame_rate(tmp_path):
     out_json = tmp_path / "out.json"
     fake_crim = types.SimpleNamespace(get_intensities_from_crimaldi=lambda p: [1])
     fake_vid = types.SimpleNamespace(
-        get_intensities_from_video_via_matlab=lambda s, m: [1]
+        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate: [1]
     )
     sys.modules["Code.analyze_crimaldi_data"] = fake_crim
     sys.modules["Code.video_intensity"] = fake_vid
@@ -41,8 +41,15 @@ def test_video_valid_arguments(monkeypatch, tmp_path):
     script.write_text("disp('hi')")
     out_json = tmp_path / "out.json"
     fake_crim = types.SimpleNamespace(get_intensities_from_crimaldi=lambda p: [1])
+    captured = {}
+
+    def fake_vid_func(s, m, px_per_mm, frame_rate):
+        captured["px_per_mm"] = px_per_mm
+        captured["frame_rate"] = frame_rate
+        return [1.0, 2.0, 3.0]
+
     fake_vid = types.SimpleNamespace(
-        get_intensities_from_video_via_matlab=lambda s, m: [1.0, 2.0, 3.0]
+        get_intensities_from_video_via_matlab=fake_vid_func
     )
     sys.modules["Code.analyze_crimaldi_data"] = fake_crim
     sys.modules["Code.video_intensity"] = fake_vid
@@ -67,6 +74,8 @@ def test_video_valid_arguments(monkeypatch, tmp_path):
     data = json.loads(out_json.read_text())
     assert data[0]["plume_id"] == "pid"
     assert data[0]["statistics"]["count"] == 3
+    assert captured["px_per_mm"] == 10
+    assert captured["frame_rate"] == 25
 
 
 def test_crimaldi_valid_arguments(monkeypatch, tmp_path):
@@ -76,7 +85,7 @@ def test_crimaldi_valid_arguments(monkeypatch, tmp_path):
         get_intensities_from_crimaldi=lambda path: [4.0, 5.0]
     )
     fake_vid = types.SimpleNamespace(
-        get_intensities_from_video_via_matlab=lambda s, m: [1]
+        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate: [1]
     )
     sys.modules["Code.analyze_crimaldi_data"] = fake_crim
     sys.modules["Code.video_intensity"] = fake_vid

--- a/tests/test_generate_dashboard_additional.py
+++ b/tests/test_generate_dashboard_additional.py
@@ -1,31 +1,39 @@
+# ruff: noqa: E402
 import os
 import sys
 import types
-import yaml
-import builtins
+
 
 # Pre-insert dummy matplotlib before importing the module under test
 class DummyAx:
     def bar(self, *a, **k):
         pass
+
     def boxplot(self, *a, **k):
         pass
+
     def hist(self, *a, **k):
         pass
+
     def set_title(self, *a, **k):
         pass
+
     def set_ylabel(self, *a, **k):
         pass
+
     def set_xlabel(self, *a, **k):
         pass
+
 
 class DummyFig:
     def __init__(self, axes):
         self.axes = axes
+
     def tight_layout(self):
         pass
+
     def savefig(self, path):
-        with open(path, 'w') as _:
+        with open(path, "w") as _:
             pass
 
 
@@ -38,26 +46,26 @@ def dummy_subplots(nrows, ncols, figsize=None):
         return fig, axes[0]
     return fig, axes
 
+
 def dummy_close(fig):
     pass
 
-mpl = types.ModuleType('matplotlib')
+
+mpl = types.ModuleType("matplotlib")
 mpl.use = lambda *a, **k: None
-plt = types.ModuleType('matplotlib.pyplot')
+plt = types.ModuleType("matplotlib.pyplot")
 plt.subplots = dummy_subplots
 plt.close = dummy_close
 plt.bar = DummyAx().bar
 plt.boxplot = DummyAx().boxplot
 plt.hist = DummyAx().hist
 
-sys.modules.setdefault('matplotlib', mpl)
-sys.modules.setdefault('matplotlib.pyplot', plt)
+sys.modules.setdefault("matplotlib", mpl)
+sys.modules.setdefault("matplotlib.pyplot", plt)
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from Code.generate_dashboard import generate_dashboard
-from Code.load_analysis_config import load_analysis_config
-
 
 SAMPLE_DATA = [
     {"metric": 1, "value": 10},
@@ -68,9 +76,7 @@ SAMPLE_DATA = [
 def test_bar_without_group(tmp_path):
     cfg = {
         "dashboard_layout": {
-            "subplots": [
-                {"metric": "value", "plot_type": "bar"}
-            ],
+            "subplots": [{"metric": "value", "plot_type": "bar"}],
             "output_filename": "dash.png",
         },
         "output_paths": {"figures": str(tmp_path)},

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -1,43 +1,46 @@
 import os
 import subprocess
-from pathlib import Path
-import numpy as np
-import tempfile
-
 import sys
+import tempfile
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from Code.video_intensity import get_intensities_from_video_via_matlab
 
 
 def test_get_intensities_from_video_via_matlab(monkeypatch, tmp_path):
-    matlab_exec = '/usr/local/MATLAB/R2023b/bin/matlab'
+    matlab_exec = "/usr/local/MATLAB/R2023b/bin/matlab"
     script_content = 'disp("hello")'
 
-    mat_file = tmp_path / 'out.mat'
+    mat_file = tmp_path / "out.mat"
     from scipy.io import savemat
-    savemat(mat_file, {'all_intensities': np.array([1, 2, 3], dtype=np.float32)})
+
+    savemat(mat_file, {"all_intensities": np.array([1, 2, 3], dtype=np.float32)})
 
     stdout = f"some log\nTEMP_MAT_FILE_SUCCESS:{mat_file}\n"
 
     def fake_run(cmd, capture_output, text):
         assert cmd[0] == matlab_exec
-        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr='')
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
     created_files = []
     orig_ntf = tempfile.NamedTemporaryFile
 
     def fake_ntf(*args, **kwargs):
-        kwargs.setdefault('delete', False)
+        kwargs.setdefault("delete", False)
         tmp = orig_ntf(*args, **kwargs)
         created_files.append(tmp.name)
         return tmp
 
-    monkeypatch.setattr(subprocess, 'run', fake_run)
-    monkeypatch.setattr(tempfile, 'NamedTemporaryFile', fake_ntf)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", fake_ntf)
 
-    arr = get_intensities_from_video_via_matlab(script_content, matlab_exec)
+    arr = get_intensities_from_video_via_matlab(
+        script_content, matlab_exec, px_per_mm=0.5, frame_rate=60.0
+    )
     assert np.array_equal(arr, np.array([1, 2, 3], dtype=np.float32))
 
     for f in created_files:


### PR DESCRIPTION
## Summary
- forward `--px_per_mm` and `--frame_rate` to `get_intensities_from_video_via_matlab`
- document these options in `main` and helper function
- adjust CLI and helper tests

## Testing
- `ruff check Code/video_intensity.py Code/characterize_plume_intensities.py tests/test_characterize_plume_intensities_cli.py tests/test_get_intensities_from_video_via_matlab.py tests/test_generate_dashboard_additional.py --fix`
- `black Code/video_intensity.py Code/characterize_plume_intensities.py tests/test_characterize_plume_intensities_cli.py tests/test_get_intensities_from_video_via_matlab.py tests/test_generate_dashboard_additional.py`
- `isort Code/video_intensity.py Code/characterize_plume_intensities.py tests/test_characterize_plume_intensities_cli.py tests/test_get_intensities_from_video_via_matlab.py tests/test_generate_dashboard_additional.py`
- `mypy Code/video_intensity.py Code/characterize_plume_intensities.py` *(fails: missing numpy stubs)*
- `pytest -q tests/test_characterize_plume_intensities_cli.py::test_video_valid_arguments`
- `pytest -q tests/test_get_intensities_from_video_via_matlab.py -k test_get_intensities_from_video_via_matlab` *(fails: ModuleNotFoundError: numpy)*
- `pytest -q tests/test_characterize_plume_intensities_cli.py::test_video_requires_px_per_mm_and_frame_rate`