### PR TITLE
Add video support to compare_intensity_stats

### DIFF
--- a/tests/test_compare_intensity_stats.py
+++ b/tests/test_compare_intensity_stats.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from Code.compare_intensity_stats import main
+from Code import compare_intensity_stats as cis
 
 
 def create_hdf5(path, data):
@@ -22,7 +22,7 @@ def test_compare_intensity_stats_table(tmp_path, capsys):
     create_hdf5(f1, arr1)
     create_hdf5(f2, arr2)
 
-    main(['A', str(f1), 'B', str(f2)])
+    cis.main(['A', str(f1), 'B', str(f2)])
     out = capsys.readouterr().out.strip().splitlines()
     assert out[0].startswith('identifier')
     assert out[1].split('\t')[0] == 'A'
@@ -33,3 +33,34 @@ def test_compare_intensity_stats_table(tmp_path, capsys):
     mean_b = arr2.mean()
     assert f"{mean_a:.3f}" in out[1]
     assert f"{mean_b:.3f}" in out[2]
+
+
+def test_compare_intensity_stats_video_vs_crimaldi(monkeypatch, tmp_path, capsys):
+    hfile = tmp_path / 'c.h5'
+    arr_crim = np.array([10.0, 20.0], dtype=float)
+    create_hdf5(hfile, arr_crim)
+
+    script = tmp_path / 'video_script.m'
+    script.write_text("disp('hi')")
+    arr_vid = np.array([1.0, 2.0, 3.0], dtype=float)
+
+    monkeypatch.setattr(
+        cis,
+        'get_intensities_from_video_via_matlab',
+        lambda s, m='matlab': arr_vid,
+    )
+
+    cis.main([
+        'VID',
+        'video',
+        str(script),
+        'CRIM',
+        'crimaldi',
+        str(hfile),
+    ])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out[0].startswith('identifier')
+    assert out[1].split('\t')[0] == 'VID'
+    assert out[2].split('\t')[0] == 'CRIM'
+    assert f"{arr_vid.mean():.3f}" in out[1]
+    assert f"{arr_crim.mean():.3f}" in out[2]


### PR DESCRIPTION
## Summary
- allow loading intensities from video or Crimaldi data
- extend CLI to accept optional plume type per entry
- test mixed video and Crimaldi comparisons

## Testing
- `./setup_env.sh --dev` *(fails: conda not found)*
- `pytest -q` *(fails: missing dependencies such as h5py)*
- `pre-commit run --files Code/compare_intensity_stats.py tests/test_compare_intensity_stats.py` *(fails: command not found)*