### PR TITLE
Refactor plume stats calculation

### DIFF
--- a/Code/characterize_plume_intensities.py
+++ b/Code/characterize_plume_intensities.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
-import statistics
 from pathlib import Path
 from typing import Any, Dict, List
+
+from Code.intensity_stats import calculate_intensity_stats_dict
 
 
 def process_plume(
@@ -30,19 +31,21 @@ def process_plume(
     output_path = Path(output_json)
 
     if intensities:
-        mean_val = statistics.mean(intensities)
-        std_val = statistics.stdev(intensities) if len(intensities) > 1 else 0.0
+        stats = calculate_intensity_stats_dict(intensities)
     else:
-        mean_val = float("nan")
-        std_val = float("nan")
+        stats = {
+            "mean": float("nan"),
+            "median": float("nan"),
+            "p95": float("nan"),
+            "p99": float("nan"),
+            "min": float("nan"),
+            "max": float("nan"),
+            "count": 0,
+        }
 
     new_entry = {
         "plume_id": plume_id,
-        "statistics": {
-            "mean": mean_val,
-            "std": std_val,
-            "count": len(intensities),
-        },
+        "statistics": stats,
     }
 
     if output_path.exists():

--- a/tests/test_characterize_plume_intensities.py
+++ b/tests/test_characterize_plume_intensities.py
@@ -1,8 +1,41 @@
 import os
 import json
 import sys
+import types
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+def simple_stats(values):
+    values = sorted(values)
+    n = len(values)
+
+    def pct(p):
+        k = (n - 1) * p / 100
+        f = int(k)
+        c = min(f + 1, n - 1)
+        if f == c:
+            return float(values[f])
+        return float(values[f] * (c - k) + values[c] * (k - f))
+
+    mean = sum(values) / n if n else float("nan")
+    if n % 2 == 1:
+        median = float(values[n // 2])
+    else:
+        median = (values[n // 2 - 1] + values[n // 2]) / 2
+    stats = {
+        "mean": float(mean),
+        "median": float(median),
+        "p95": pct(95),
+        "p99": pct(99),
+        "min": float(values[0]),
+        "max": float(values[-1]),
+        "count": n,
+    }
+    return stats
+
+sys.modules["Code.intensity_stats"] = types.SimpleNamespace(
+    calculate_intensity_stats_dict=simple_stats
+)
 
 from Code.characterize_plume_intensities import process_plume
 
@@ -11,10 +44,13 @@ def test_json_creation_and_update(tmp_path):
     output = tmp_path / "stats.json"
 
     # first plume
-    process_plume("p1", [1, 2, 3], output)
+    intensities1 = [1, 2, 3]
+    process_plume("p1", intensities1, output)
     data = json.loads(output.read_text())
     assert len(data) == 1
     assert data[0]["plume_id"] == "p1"
+    expected1 = simple_stats(intensities1)
+    assert data[0]["statistics"] == expected1
 
     # second plume
     process_plume("p2", [4, 5], output)
@@ -24,11 +60,13 @@ def test_json_creation_and_update(tmp_path):
     assert ids == {"p1", "p2"}
 
     # update first plume
-    process_plume("p1", [7], output)
+    intensities_update = [7]
+    process_plume("p1", intensities_update, output)
     data = json.loads(output.read_text())
     assert len(data) == 2
     entry = next(d for d in data if d["plume_id"] == "p1")
-    assert entry["statistics"]["mean"] == 7
+    expected_update = simple_stats(intensities_update)
+    assert entry["statistics"] == expected_update
 
 
 def test_corrupted_or_empty_file(tmp_path):

--- a/tests/test_characterize_plume_intensities_cli.py
+++ b/tests/test_characterize_plume_intensities_cli.py
@@ -1,12 +1,44 @@
 import json
 import os
 import sys
+import types
 
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import types
+
+def simple_stats(values):
+    values = sorted(values)
+    n = len(values)
+
+    def pct(p):
+        k = (n - 1) * p / 100
+        f = int(k)
+        c = min(f + 1, n - 1)
+        if f == c:
+            return float(values[f])
+        return float(values[f] * (c - k) + values[c] * (k - f))
+
+    mean = sum(values) / n if n else float("nan")
+    if n % 2 == 1:
+        median = float(values[n // 2])
+    else:
+        median = (values[n // 2 - 1] + values[n // 2]) / 2
+    return {
+        "mean": float(mean),
+        "median": float(median),
+        "p95": pct(95),
+        "p99": pct(99),
+        "min": float(values[0]),
+        "max": float(values[-1]),
+        "count": n,
+    }
+
+
+sys.modules["Code.intensity_stats"] = types.SimpleNamespace(
+    calculate_intensity_stats_dict=simple_stats
+)
 
 from Code import characterize_plume_intensities as cpi
 


### PR DESCRIPTION
## Summary
- compute statistics in `process_plume` using `calculate_intensity_stats_dict`
- add fallback when no intensities provided
- adjust unit tests to expect new metrics and to avoid numpy dependency

## Testing
- `pytest tests/test_characterize_plume_intensities.py tests/test_characterize_plume_intensities_cli.py -q`