### PR TITLE
feat: insert video parameters into MATLAB script

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,11 @@ python Code/characterize_plume_intensities.py \
     --output_json plume_stats.json
 ```
 
+``px_per_mm`` and ``frame_rate`` are inserted into the temporary MATLAB script
+before execution so that your MATLAB code can access these values as workspace
+variables.
+```
+
 ### Compare intensity statistics
 
 `Code/compare_intensity_stats.py` reads intensity vectors from one or more HDF5

--- a/tests/test_characterize_plume_intensities_cli.py
+++ b/tests/test_characterize_plume_intensities_cli.py
@@ -78,6 +78,7 @@ def test_video_valid_arguments(monkeypatch, tmp_path):
     def fake_vid_func(s, m, px_per_mm, frame_rate):
         captured["px_per_mm"] = px_per_mm
         captured["frame_rate"] = frame_rate
+        captured["script"] = s
         return [1.0, 2.0, 3.0]
 
     fake_vid = types.SimpleNamespace(
@@ -108,6 +109,7 @@ def test_video_valid_arguments(monkeypatch, tmp_path):
     assert data[0]["statistics"]["count"] == 3
     assert captured["px_per_mm"] == 10
     assert captured["frame_rate"] == 25
+    assert captured["script"] == script.read_text()
 
 
 def test_crimaldi_valid_arguments(monkeypatch, tmp_path):

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -22,9 +22,7 @@ def test_get_intensities_from_video_via_matlab(monkeypatch, tmp_path):
 
     stdout = f"some log\nTEMP_MAT_FILE_SUCCESS:{mat_file}\n"
 
-    def fake_run(cmd, capture_output, text):
-        assert cmd[0] == matlab_exec
-        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+    captured = {}
 
     created_files = []
     orig_ntf = tempfile.NamedTemporaryFile
@@ -33,7 +31,14 @@ def test_get_intensities_from_video_via_matlab(monkeypatch, tmp_path):
         kwargs.setdefault("delete", False)
         tmp = orig_ntf(*args, **kwargs)
         created_files.append(tmp.name)
+        captured["script_path"] = tmp.name
         return tmp
+
+    def fake_run(cmd, capture_output, text):
+        assert cmd[0] == matlab_exec
+        with open(captured["script_path"]) as fh:
+            captured["script_contents"] = fh.read()
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", fake_ntf)
@@ -42,6 +47,9 @@ def test_get_intensities_from_video_via_matlab(monkeypatch, tmp_path):
         script_content, matlab_exec, px_per_mm=0.5, frame_rate=60.0
     )
     assert np.array_equal(arr, np.array([1, 2, 3], dtype=np.float32))
+
+    assert "px_per_mm = 0.5" in captured["script_contents"]
+    assert "frame_rate = 60.0" in captured["script_contents"]
 
     for f in created_files:
         assert not Path(f).exists(), f"temporary file {f} should be removed"


### PR DESCRIPTION
## Summary
- embed `px_per_mm` and `frame_rate` at the start of the temp MATLAB script
- test that MATLAB script receives `px_per_mm` and `frame_rate`
- verify CLI passes script contents to MATLAB helper
- document parameter injection behaviour in README and code

## Testing
- `./setup_env.sh --dev --no-tests` *(fails: wget unable to download Miniconda)*
- `pytest -k test_get_intensities_from_video_via_matlab -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files Code/video_intensity.py README.md tests/test_characterize_plume_intensities_cli.py tests/test_get_intensities_from_video_via_matlab.py` *(fails: command not found)*