### PR TITLE
Ensure plume directory exists

### DIFF
--- a/Code/characterize_plume_intensities.py
+++ b/Code/characterize_plume_intensities.py
@@ -60,6 +60,7 @@ def process_plume(
 
     existing = [e for e in existing if e.get("plume_id") != plume_id]
     existing.append(new_entry)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(existing, indent=4))
     return new_entry
 

--- a/tests/test_characterize_plume_intensities.py
+++ b/tests/test_characterize_plume_intensities.py
@@ -1,9 +1,11 @@
-import os
+# ruff: noqa: E402
 import json
+import os
 import sys
 import types
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 
 def simple_stats(values):
     values = sorted(values)
@@ -32,6 +34,7 @@ def simple_stats(values):
         "count": n,
     }
     return stats
+
 
 sys.modules["Code.intensity_stats"] = types.SimpleNamespace(
     calculate_intensity_stats_dict=simple_stats
@@ -77,3 +80,15 @@ def test_corrupted_or_empty_file(tmp_path):
     data = json.loads(output.read_text())
     assert len(data) == 1
     assert data[0]["plume_id"] == "p1"
+
+
+def test_creates_parent_directory(tmp_path):
+    output = tmp_path / "missing" / "stats.json"
+
+    process_plume("p1", [1, 2], output)
+    assert output.exists()
+    data = json.loads(output.read_text())
+    assert len(data) == 1
+    expected = simple_stats([1, 2])
+    assert data[0]["plume_id"] == "p1"
+    assert data[0]["statistics"] == expected


### PR DESCRIPTION
## Summary
- handle missing directories when saving plume data
- regression test for missing output directory

## Testing
- `pytest tests/test_characterize_plume_intensities.py::test_creates_parent_directory -q`
