### PR TITLE
Refactor CLI to use explicit item flag

### DIFF
--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -79,27 +79,23 @@ def write_csv(results: Iterable[Tuple[str, Stats]], csv_path: str) -> None:
 def main(argv: List[str] | None = None) -> None:  # pragma: no cover - CLI wrapper
     parser = argparse.ArgumentParser(description="Compare intensity statistics")
     parser.add_argument(
-        "items",
-        nargs="+",
-        help="identifier [plume_type] path entries; plume_type optional",
+        "--item",
+        action="append",
+        nargs=2,
+        metavar=("ID[:TYPE]", "PATH"),
+        required=True,
+        help="Add a dataset: ID optionally followed by ':TYPE' and its PATH",
     )
     parser.add_argument("--csv", dest="csv_path", help="Output CSV file")
     ns = parser.parse_args(argv)
 
-    if len(ns.items) % 3 == 0:
-        entries = [
-            (ns.items[i], ns.items[i + 2], ns.items[i + 1])
-            for i in range(0, len(ns.items), 3)
-        ]
-    elif len(ns.items) % 2 == 0:
-        entries = [
-            (ns.items[i], ns.items[i + 1], None)
-            for i in range(0, len(ns.items), 2)
-        ]
-    else:
-        parser.error(
-            "Expected pairs (identifier path) or triples (identifier plume_type path)"
-        )
+    entries = []
+    for id_type, path in ns.item:
+        if ":" in id_type:
+            identifier, plume_type = id_type.split(":", 1)
+        else:
+            identifier, plume_type = id_type, None
+        entries.append((identifier, path, plume_type))
 
     results = compare_intensity_stats(entries)
 

--- a/README.md
+++ b/README.md
@@ -555,10 +555,14 @@ files and prints a table of summary statistics or writes them to CSV.
 
 ```bash
 # Display results in the terminal
-python Code/compare_intensity_stats.py A data/crimaldi.hdf5 B data/custom.hdf5
+python Code/compare_intensity_stats.py \
+    --item A data/crimaldi.hdf5 \
+    --item B data/custom.hdf5
 
 # Write to CSV
-python Code/compare_intensity_stats.py A data/crimaldi.hdf5 B data/custom.hdf5 \
+python Code/compare_intensity_stats.py \
+    --item A data/crimaldi.hdf5 \
+    --item B data/custom.hdf5 \
     --csv intensity_comparison.csv
 ```
 

--- a/tests/test_compare_intensity_stats.py
+++ b/tests/test_compare_intensity_stats.py
@@ -22,7 +22,10 @@ def test_compare_intensity_stats_table(tmp_path, capsys):
     create_hdf5(f1, arr1)
     create_hdf5(f2, arr2)
 
-    cis.main(['A', str(f1), 'B', str(f2)])
+    cis.main([
+        '--item', 'A', str(f1),
+        '--item', 'B', str(f2),
+    ])
     out = capsys.readouterr().out.strip().splitlines()
     assert out[0].startswith('identifier')
     assert out[1].split('\t')[0] == 'A'
@@ -51,12 +54,8 @@ def test_compare_intensity_stats_video_vs_crimaldi(monkeypatch, tmp_path, capsys
     )
 
     cis.main([
-        'VID',
-        'video',
-        str(script),
-        'CRIM',
-        'crimaldi',
-        str(hfile),
+        '--item', 'VID:video', str(script),
+        '--item', 'CRIM:crimaldi', str(hfile),
     ])
     out = capsys.readouterr().out.strip().splitlines()
     assert out[0].startswith('identifier')


### PR DESCRIPTION
## Summary
- update compare_intensity_stats CLI to use repeated `--item` flag
- adjust tests for new argument syntax
- update README examples

## Testing
- `pytest tests/test_compare_intensity_stats.py -q` *(fails: ModuleNotFoundError: No module named 'h5py')*