### PR TITLE
Add custom MATLAB executable option

### DIFF
--- a/Code/characterize_plume_intensities.py
+++ b/Code/characterize_plume_intensities.py
@@ -86,6 +86,7 @@ def main(args: List[str] | None = None) -> None:  # pragma: no cover - CLI entry
     parser.add_argument("--output_json", required=True)
     parser.add_argument("--px_per_mm", type=float)
     parser.add_argument("--frame_rate", type=float)
+    parser.add_argument("--matlab_exec", default="matlab", help="Path to MATLAB executable")
 
     ns = parser.parse_args(args)
 
@@ -95,7 +96,7 @@ def main(args: List[str] | None = None) -> None:  # pragma: no cover - CLI entry
         script_contents = Path(ns.file_path).read_text()
         intensities = get_intensities_from_video_via_matlab(
             script_contents,
-            "matlab",
+            ns.matlab_exec,
             px_per_mm=ns.px_per_mm,
             frame_rate=ns.frame_rate,
         )

--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -45,13 +45,14 @@ def load_intensities(
 
 
 def compare_intensity_stats(
-    sources: Iterable[Tuple[str, str, str | None]]
+    sources: Iterable[Tuple[str, str, str | None]],
+    matlab_exec_path: str = "matlab",
 ) -> List[Tuple[str, Stats]]:
     """Return statistics for each identifier/path/type triple."""
 
     results: List[Tuple[str, Stats]] = []
     for identifier, path, plume_type in sources:
-        intensities = load_intensities(path, plume_type)
+        intensities = load_intensities(path, plume_type, matlab_exec_path)
         stats = calculate_intensity_stats_dict(intensities)
         results.append((identifier, stats))
     return results
@@ -84,6 +85,7 @@ def main(argv: List[str] | None = None) -> None:  # pragma: no cover - CLI wrapp
         help="identifier [plume_type] path entries; plume_type optional",
     )
     parser.add_argument("--csv", dest="csv_path", help="Output CSV file")
+    parser.add_argument("--matlab_exec", default="matlab", help="Path to MATLAB executable")
     ns = parser.parse_args(argv)
 
     if len(ns.items) % 3 == 0:
@@ -101,7 +103,7 @@ def main(argv: List[str] | None = None) -> None:  # pragma: no cover - CLI wrapp
             "Expected pairs (identifier path) or triples (identifier plume_type path)"
         )
 
-    results = compare_intensity_stats(entries)
+    results = compare_intensity_stats(entries, ns.matlab_exec)
 
     if ns.csv_path:
         write_csv(results, ns.csv_path)

--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ python Code/characterize_plume_intensities.py \
     --plume_id my_video \
     --px_per_mm 20 \
     --frame_rate 40 \
+    --matlab_exec /path/to/matlab \
     --output_json plume_stats.json
 ```
 
@@ -556,10 +557,12 @@ files and prints a table of summary statistics or writes them to CSV.
 ```bash
 # Display results in the terminal
 python Code/compare_intensity_stats.py A data/crimaldi.hdf5 B data/custom.hdf5
+    --matlab_exec /path/to/matlab
 
 # Write to CSV
 python Code/compare_intensity_stats.py A data/crimaldi.hdf5 B data/custom.hdf5 \
     --csv intensity_comparison.csv
+    --matlab_exec /path/to/matlab
 ```
 
 

--- a/tests/test_characterize_plume_intensities_cli.py
+++ b/tests/test_characterize_plume_intensities_cli.py
@@ -78,6 +78,7 @@ def test_video_valid_arguments(monkeypatch, tmp_path):
     def fake_vid_func(s, m, px_per_mm, frame_rate):
         captured["px_per_mm"] = px_per_mm
         captured["frame_rate"] = frame_rate
+        captured["matlab_exec"] = m
         return [1.0, 2.0, 3.0]
 
     fake_vid = types.SimpleNamespace(
@@ -107,6 +108,7 @@ def test_video_valid_arguments(monkeypatch, tmp_path):
     assert data[0]["plume_id"] == "pid"
     assert data[0]["statistics"]["count"] == 3
     assert captured["px_per_mm"] == 10
+    assert captured["matlab_exec"] == "matlab"
     assert captured["frame_rate"] == 25
 
 
@@ -139,3 +141,26 @@ def test_crimaldi_valid_arguments(monkeypatch, tmp_path):
     data = json.loads(out_json.read_text())
     assert data[0]["plume_id"] == "pid"
     assert data[0]["statistics"]["count"] == 2
+
+def test_matlab_exec_option(monkeypatch, tmp_path):
+    script = tmp_path / "script.m"
+    script.write_text("disp('hi')")
+    out_json = tmp_path / "out.json"
+    fake_crim = types.SimpleNamespace(get_intensities_from_crimaldi=lambda p: [1])
+    captured = {}
+    def fake_vid_func(s, m, px_per_mm, frame_rate):
+        captured["matlab_exec"] = m
+        return [1]
+    fake_vid = types.SimpleNamespace(get_intensities_from_video_via_matlab=fake_vid_func)
+    sys.modules["Code.analyze_crimaldi_data"] = fake_crim
+    sys.modules["Code.video_intensity"] = fake_vid
+    cpi.main([
+        "--plume_type", "video",
+        "--file_path", str(script),
+        "--output_json", str(out_json),
+        "--plume_id", "pid",
+        "--px_per_mm", "10",
+        "--frame_rate", "25",
+        "--matlab_exec", "/custom/matlab",
+    ])
+    assert captured["matlab_exec"] == "/custom/matlab"


### PR DESCRIPTION
## Summary
- allow custom MATLAB path with `--matlab_exec` in both intensity CLI tools
- pass `matlab_exec` parameter through to helper functions
- document new option in the README
- cover new behaviour with tests

## Testing
- `pytest tests/test_characterize_plume_intensities_cli.py::test_matlab_exec_option -q`
- `pytest tests/test_compare_intensity_stats.py::test_matlab_exec_option -q` *(fails: ModuleNotFoundError: No module named 'h5py')*