### PR TITLE
Add Loguru and other deps

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pandas
   - numpy
   - h5py
+  - loguru
   - pyyaml
   - matplotlib
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - pandas
   - numpy
   - h5py
+  - loguru
   - pyyaml
   - pytest
   - matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,12 @@ name = "elementary-transformations"
 version = "0.1.0"
 dependencies = [
   "numpy",
-  "scipy"
+  "scipy",
+  "pandas",
+  "h5py",
+  "pyyaml",
+  "matplotlib",
+  "loguru",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- include `loguru` in both conda environments
- list pandas, h5py, pyyaml, matplotlib and loguru in project deps

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*