### PR TITLE
Update docs for intensity scripts

### DIFF
--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -4,25 +4,31 @@ This page describes how to characterise the intensity of individual odour plumes
 
 ## Characterising a Single Plume
 
-To obtain intensity statistics for a single plume, use the `analyse_crimaldi_data.py` script. The command prints summary statistics such as the peak intensity and integrated intensity over time.
+To obtain intensity statistics for a single plume, use the `analyze_crimaldi_data.py` script. The command prints summary statistics such as the minimum, maximum and percentile values.
 
 ```bash
-conda run --prefix ./dev-env python Code/analyse_crimaldi_data.py data/raw/plume1.hdf5
+conda run --prefix ./dev-env python Code/analyze_crimaldi_data.py data/raw/plume1.hdf5
 ```
 
 Expected output:
 
 ```
-Peak intensity: 3.2
-Mean intensity: 1.4
+Min: 0.05
+Max: 3.2
+Mean: 1.4
+Std: 0.8
+1th percentile: 0.10
+5th percentile: 0.20
+95th percentile: 2.9
+99th percentile: 3.1
 ```
 
 ## Comparing Multiple Datasets
 
-Use the `compare_intensity_datasets.py` script with multiple input files. The script computes cross‑dataset statistics and produces a plot showing the distribution of intensities.
+Use the `compare_intensity_stats.py` script with multiple input files. The script computes cross‑dataset statistics and produces a plot showing the distribution of intensities.
 
 ```bash
-conda run --prefix ./dev-env python Code/compare_intensity_datasets.py data/raw/plume1.hdf5 data/raw/plume2.hdf5
+conda run --prefix ./dev-env python Code/compare_intensity_stats.py data/raw/plume1.hdf5 data/raw/plume2.hdf5
 ```
 
 Typical output:


### PR DESCRIPTION
## Summary
- fix command names in `docs/intensity_comparison.md`
- show example output from `analyze_crimaldi_data.py`

## Testing
- `./setup_env.sh --dev` *(fails: wget unable to fetch Miniconda)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*