### PR TITLE
Add nested csv output support

### DIFF
--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -70,6 +70,7 @@ def format_table(results: Iterable[Tuple[str, Stats]]) -> str:
 
 def write_csv(results: Iterable[Tuple[str, Stats]], csv_path: str) -> None:
     keys = ["mean", "median", "p95", "p99", "min", "max", "count"]
+    Path(csv_path).parent.mkdir(parents=True, exist_ok=True)
     with open(csv_path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["identifier"] + keys)

--- a/tests/test_compare_intensity_stats.py
+++ b/tests/test_compare_intensity_stats.py
@@ -87,3 +87,19 @@ def test_matlab_exec_option(monkeypatch, tmp_path):
         '--matlab_exec', '/opt/matlab',
     ])
     assert captured['matlab_exec'] == '/opt/matlab'
+
+
+def test_csv_option_creates_nested_path(tmp_path):
+    hfile = tmp_path / 'vals.h5'
+    arr = np.array([1.0, 2.0])
+    create_hdf5(hfile, arr)
+    csv_path = tmp_path / 'nested' / 'dir' / 'stats.csv'
+
+    cis.main([
+        'ID',
+        str(hfile),
+        '--csv',
+        str(csv_path),
+    ])
+
+    assert csv_path.is_file()


### PR DESCRIPTION
## Summary
- ensure csv directory is created
- test csv option with nested output path

## Testing
- `./setup_env.sh --dev` *(fails: wget blocked)*
- `pytest -q tests/test_compare_intensity_stats.py::test_csv_option_creates_nested_path` *(fails: no collectors)*