### PR TITLE
Update MATLAB batch command path handling

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -56,7 +56,7 @@ def get_intensities_from_video_via_matlab(
         full_contents = "\n".join(header_lines + [script_contents])
         script_file.write(full_contents.encode())
         script_file.flush()
-        matlab_cmd = [matlab_exec_path, "-batch", Path(script_file.name).stem]
+        matlab_cmd = [matlab_exec_path, "-batch", f"run('{script_file.name}')"]
         proc = subprocess.run(matlab_cmd, capture_output=True, text=True)
         if proc.returncode != 0:
             raise RuntimeError(f"MATLAB failed: {proc.stdout}\n{proc.stderr}")

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -36,6 +36,8 @@ def test_get_intensities_from_video_via_matlab(monkeypatch, tmp_path):
 
     def fake_run(cmd, capture_output, text):
         assert cmd[0] == matlab_exec
+        assert cmd[1] == "-batch"
+        assert cmd[2] == f"run('{captured['script_path']}')"
         with open(captured["script_path"]) as fh:
             captured["script_contents"] = fh.read()
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")


### PR DESCRIPTION
## Summary
- expect the MATLAB batch command to use `run()`
- call MATLAB with an absolute script path

## Testing
- `pytest tests/test_get_intensities_from_video_via_matlab.py::test_get_intensities_from_video_via_matlab -q` *(fails: ModuleNotFoundError: No module named 'numpy')*