### PR TITLE
Handle empty intensity arrays

### DIFF
--- a/Code/intensity_stats.py
+++ b/Code/intensity_stats.py
@@ -14,6 +14,16 @@ except Exception as exc:  # pragma: no cover
 def calculate_intensity_stats_dict(intensities: Sequence[float]) -> Dict[str, float]:
     """Return basic statistics for the provided intensities."""
     arr = np.asarray(intensities, dtype=float)
+    if arr.size == 0:
+        return {
+            "mean": float("nan"),
+            "median": float("nan"),
+            "p95": float("nan"),
+            "p99": float("nan"),
+            "min": float("nan"),
+            "max": float("nan"),
+            "count": 0,
+        }
     stats = {
         "mean": float(arr.mean()),
         "median": float(np.median(arr)),

--- a/tests/test_intensity_stats.py
+++ b/tests/test_intensity_stats.py
@@ -43,3 +43,14 @@ def test_main_plot_histogram(monkeypatch, tmp_path):
                                   show=lambda *a, **k: None)
     monkeypatch.setitem(sys.modules, 'matplotlib.pyplot', dummy)
     main(["plumeB", str(f), "--plot_histogram"])
+
+
+def test_empty_intensity_stats_returns_nans():
+    stats = calculate_intensity_stats_dict(np.array([]))
+    assert np.isnan(stats["mean"])
+    assert np.isnan(stats["median"])
+    assert np.isnan(stats["p95"])
+    assert np.isnan(stats["p99"])
+    assert np.isnan(stats["min"])
+    assert np.isnan(stats["max"])
+    assert stats["count"] == 0


### PR DESCRIPTION
## Summary
- handle empty intensity arrays in `calculate_intensity_stats_dict`
- test that empty arrays return NaNs

## Testing
- `./setup_env.sh --dev` *(fails: wget to repo.anaconda.com blocked)*
- `conda run --prefix ./dev-env pytest -q` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*