### PR TITLE
Add CSV output tests and ensure output directory creation

### DIFF
--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -70,7 +70,9 @@ def format_table(results: Iterable[Tuple[str, Stats]]) -> str:
 
 def write_csv(results: Iterable[Tuple[str, Stats]], csv_path: str) -> None:
     keys = ["mean", "median", "p95", "p99", "min", "max", "count"]
-    with open(csv_path, "w", newline="") as f:
+    path = Path(csv_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["identifier"] + keys)
         for ident, stats in results:


### PR DESCRIPTION
## Summary
- extend `compare_intensity_stats` tests to cover `--csv` option
- allow `write_csv` to create parent directories automatically

## Testing
- `conda run --prefix ./dev-env pytest -q` *(fails: `conda` not found)*