### PR TITLE
Fix fake video capture test

### DIFF
--- a/tests/test_characterize_plume_intensities_cli.py
+++ b/tests/test_characterize_plume_intensities_cli.py
@@ -79,6 +79,7 @@ def test_video_valid_arguments(monkeypatch, tmp_path):
         captured["px_per_mm"] = px_per_mm
         captured["frame_rate"] = frame_rate
         captured["matlab_exec"] = m
+        captured["script"] = s
         return [1.0, 2.0, 3.0]
 
     fake_vid = types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- capture the script path in `fake_vid_func` for `test_video_valid_arguments`

## Testing
- `python3 -m pytest tests/test_characterize_plume_intensities_cli.py::test_video_valid_arguments -vv`
- `conda run -p ./dev-env pytest tests/test_characterize_plume_intensities_cli.py::test_video_valid_arguments` *(fails: conda not found)*