### PR TITLE
Use intensity stats helper for empty plume

### DIFF
--- a/Code/characterize_plume_intensities.py
+++ b/Code/characterize_plume_intensities.py
@@ -33,15 +33,7 @@ def process_plume(
     if intensities:
         stats = calculate_intensity_stats_dict(intensities)
     else:
-        stats = {
-            "mean": float("nan"),
-            "median": float("nan"),
-            "p95": float("nan"),
-            "p99": float("nan"),
-            "min": float("nan"),
-            "max": float("nan"),
-            "count": 0,
-        }
+        stats = calculate_intensity_stats_dict([])
 
     new_entry = {
         "plume_id": plume_id,

--- a/tests/test_characterize_plume_intensities.py
+++ b/tests/test_characterize_plume_intensities.py
@@ -92,3 +92,22 @@ def test_creates_parent_directory(tmp_path):
     expected = simple_stats([1, 2])
     assert data[0]["plume_id"] == "p1"
     assert data[0]["statistics"] == expected
+
+def test_empty_intensities_calls_stats_function(monkeypatch, tmp_path):
+    import Code.characterize_plume_intensities as cpi
+
+    called = {}
+
+    def fake_calc(values):
+        called["vals"] = list(values)
+        return {"placeholder": True}
+
+    monkeypatch.setattr(cpi, "calculate_intensity_stats_dict", fake_calc)
+    out = tmp_path / "stats.json"
+
+    result = cpi.process_plume("pid", [], out)
+
+    assert called["vals"] == []
+    assert result["statistics"] == {"placeholder": True}
+    data = json.loads(out.read_text())
+    assert data[0]["statistics"] == {"placeholder": True}


### PR DESCRIPTION
## Summary
- delegate empty plume stats to `calculate_intensity_stats_dict`
- validate that helper gets called for empty intensities

## Testing
- `pytest tests/test_characterize_plume_intensities.py -q`
- `conda run -p ./dev-env pytest tests/test_characterize_plume_intensities.py -q` *(fails: `conda` not found)*