### PR TITLE
Escape script path when calling MATLAB

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import os
 import subprocess
 import tempfile
-from pathlib import Path
 
 import numpy as np
 from scipy.io import loadmat
@@ -39,6 +38,12 @@ def get_intensities_from_video_via_matlab(
         Frame rate of the video in Hz. As with ``px_per_mm``, the value is
         embedded in the temporary MATLAB script for use by helper routines.
 
+    Notes
+    -----
+    The temporary script path is embedded in a ``run('...')`` command.
+    Any single quotes in the path are escaped for MATLAB by doubling them so
+    paths with spaces or quotes are handled correctly.
+
     Returns
     -------
     numpy.ndarray
@@ -56,7 +61,8 @@ def get_intensities_from_video_via_matlab(
         full_contents = "\n".join(header_lines + [script_contents])
         script_file.write(full_contents.encode())
         script_file.flush()
-        matlab_cmd = [matlab_exec_path, "-batch", f"run('{script_file.name}')"]
+        safe_path = script_file.name.replace("'", "''")
+        matlab_cmd = [matlab_exec_path, "-batch", f"run('{safe_path}')"]
         proc = subprocess.run(matlab_cmd, capture_output=True, text=True)
         if proc.returncode != 0:
             raise RuntimeError(f"MATLAB failed: {proc.stdout}\n{proc.stderr}")

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -56,3 +56,43 @@ def test_get_intensities_from_video_via_matlab(monkeypatch, tmp_path):
     for f in created_files:
         assert not Path(f).exists(), f"temporary file {f} should be removed"
     assert not mat_file.exists(), "MAT-file should be cleaned up"
+
+
+def test_path_with_spaces_and_quotes(monkeypatch, tmp_path):
+    matlab_exec = "/usr/local/MATLAB/R2023b/bin/matlab"
+    script_content = 'disp("hello")'
+
+    mat_file = tmp_path / "out.mat"
+    from scipy.io import savemat
+
+    savemat(mat_file, {"all_intensities": np.array([1], dtype=np.float32)})
+
+    stdout = f"ok\nTEMP_MAT_FILE_SUCCESS:{mat_file}\n"
+
+    captured = {}
+
+    def fake_ntf(*args, **kwargs):
+        kwargs.setdefault("delete", False)
+        file_path = tmp_path / "with space's" / "temp.m"
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = open(file_path, "w+b")
+        captured["script_path"] = str(file_path)
+        return fh
+
+    def fake_run(cmd, capture_output, text):
+        assert cmd[0] == matlab_exec
+        expected = captured["script_path"].replace("'", "''")
+        assert cmd[2] == f"run('{expected}')"
+        with open(captured["script_path"]) as fh:
+            captured["script_contents"] = fh.read()
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", fake_ntf)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    arr = get_intensities_from_video_via_matlab(script_content, matlab_exec)
+    assert np.array_equal(arr, np.array([1], dtype=np.float32))
+
+    assert "disp(" in captured["script_contents"]
+    assert not Path(captured["script_path"]).exists()
+    assert not mat_file.exists()


### PR DESCRIPTION
## Summary
- add regression test covering paths with spaces and quotes
- escape single quotes before building MATLAB `run` command

## Testing
- `conda run -p ./dev-env pytest tests/test_get_intensities_from_video_via_matlab.py -q` *(fails: `conda: command not found`)*
- `pytest tests/test_get_intensities_from_video_via_matlab.py -q` *(fails: `ModuleNotFoundError: No module named 'numpy'`)*
