### PR TITLE
Add CSV diff row test

### DIFF
--- a/tests/test_compare_intensity_stats_diff.py
+++ b/tests/test_compare_intensity_stats_diff.py
@@ -3,6 +3,7 @@ import os
 import sys
 import types
 import pytest
+import csv
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -100,3 +101,23 @@ def test_diff_option_prints_table(cis, monkeypatch, capsys):
     cis.main(['A', 'path1', 'B', 'path2', '--diff'])
     out_lines = capsys.readouterr().out.strip().splitlines()
     assert out_lines[-1].startswith('DIFF')
+
+def test_diff_option_writes_csv(cis, monkeypatch, tmp_path):
+    arr_a = [1.0, 2.0]
+    arr_b = [3.0, 5.0]
+
+    def fake_load(path, *_, **__):
+        return arr_a if path == 'path1' else arr_b
+
+    monkeypatch.setattr(cis, 'load_intensities', fake_load)
+    monkeypatch.setattr(cis, 'calculate_intensity_stats_dict', simple_stats)
+
+    csv_path = tmp_path / 'stats.csv'
+    cis.main(['A', 'path1', 'B', 'path2', '--diff', '--csv', str(csv_path)])
+
+    with csv_path.open(newline='') as f:
+        rows = list(csv.reader(f))
+
+    assert rows[-1][0] == 'DIFF'
+    assert float(rows[-1][1]) == pytest.approx(-2.5)
+    assert float(rows[-1][2]) == pytest.approx(-2.5)


### PR DESCRIPTION
## Summary
- extend intensity comparison tests with CSV diff row check

## Testing
- `pytest -k test_diff_option_writes_csv -q tests/test_compare_intensity_stats_diff.py`
- `conda run -p ./dev-env pytest tests/test_compare_intensity_stats_diff.py` *(fails: `conda` not found)*