### PR TITLE
Update docs for video plume comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,8 +558,7 @@ variables.
 
 ### Compare intensity statistics
 
-`Code/compare_intensity_stats.py` reads intensity vectors from one or more HDF5
-files and prints a table of summary statistics or writes them to CSV.
+`Code/compare_intensity_stats.py` reads intensity vectors from one or more HDF5 files and prints a table of summary statistics or writes them to CSV. It also accepts MATLAB scripts that output a MAT-file of intensities, enabling comparisons between video plumes and the Crimaldi dataset.
 
 ```bash
 # Display results in the terminal
@@ -572,6 +571,12 @@ python Code/compare_intensity_stats.py A data/crimaldi.hdf5 B data/custom.hdf5 \
     --matlab_exec /path/to/matlab
 ```
 
+
+To compare a custom video plume against Crimaldi, first create the development environment with `./setup_env.sh --dev` and then run:
+
+```bash
+conda run --prefix ./dev-env python Code/compare_intensity_stats.py VID video path/to/video_script.m CRIM crimaldi data/10302017_10cms_bounded.hdf5 --matlab_exec /path/to/matlab
+```
 
 ## Repository Layout
 

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -56,6 +56,23 @@ Difference (mean): 0.4
 Figure saved to figures/intensity_comparison.png
 ```
 
+### Comparing a Video Plume to Crimaldi
+
+If you have a custom plume movie, extract the intensity values in MATLAB and compare them to the Crimaldi data. Below is a minimal script `video_script.m`:
+
+```matlab
+plume = load_plume_video('my_plume.avi', 20, 40);
+all_intensities = plume.data(:);
+save('temp_intensities.mat', 'all_intensities');
+fprintf('TEMP_MAT_FILE_SUCCESS:%s\n', which('temp_intensities.mat'));
+```
+
+Run the comparison using the development environment created with `./setup_env.sh --dev`:
+
+```bash
+conda run --prefix ./dev-env python Code/compare_intensity_stats.py VID video path/to/video_script.m CRIM crimaldi data/10302017_10cms_bounded.hdf5 --matlab_exec /path/to/matlab
+```
+
 ## Notes
 
 - All commands assume the development environment created via `./setup_env.sh --dev`.


### PR DESCRIPTION
## Summary
- document dev environment creation before commands
- show example MATLAB script for video plumes
- describe comparing Crimaldi data with a video plume

## Testing
- `./setup_env.sh --dev --no-tests` *(fails: wget: unable to resolve host)*