### PR TITLE
Add pip fallback for conda-lock install

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -95,16 +95,22 @@ setup_environment() {
   # Ensure conda-lock is installed and generate lock file
   if ! command -v conda-lock >/dev/null 2>&1; then
     log INFO "Installing conda-lock"
-    run_command_verbose conda install -y -n base -c conda-forge conda-lock
-    
+    if ! run_command_verbose conda install -y -n base -c conda-forge conda-lock; then
+      log WARNING "conda install failed, attempting pip fallback"
+      if ! run_command_verbose pip install --user conda-lock; then
+        error "Failed to install conda-lock with conda or pip"
+      fi
+      export PATH="$HOME/.local/bin:${PATH}"
+    fi
+
     # Refresh the shell to update PATH
     if [ -f "${CONDA_BASE_DIR}/etc/profile.d/conda.sh" ]; then
       source "${CONDA_BASE_DIR}/etc/profile.d/conda.sh"
     fi
-    
+
     # Add conda to PATH if not already there
     export PATH="${CONDA_BASE_DIR}/bin:${PATH}"
-    
+
     # Verify installation
     if ! command -v conda-lock >/dev/null 2>&1; then
       error "Failed to install conda-lock or make it available in PATH"

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -27,3 +27,8 @@ def test_setup_env_script_runs_idempotently():
     assert result1.returncode == 0
     result2 = subprocess.run(['bash', '-c', cmd], capture_output=True, text=True)
     assert result2.returncode == 0
+
+def test_setup_env_has_conda_lock_pip_fallback():
+    with open('setup_env.sh') as f:
+        content = f.read()
+    assert 'pip install --user conda-lock' in content


### PR DESCRIPTION
## Summary
- expect pip fallback in setup tests
- install `conda-lock` via pip `--user` if `conda` install fails

## Testing
- `pytest tests/test_setup_env_script.py -q`
- ❌ `pre-commit run --files setup_env.sh tests/test_setup_env_script.py` (pre-commit not installed)