### PR TITLE
Update README and docs to use module invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Python dependencies are managed using Conda and are split into two files:
    # This will create a local environment in ./dev-env
    ./setup_env.sh --dev
    ```
+   This prepares the development environment. Run scripts located in the
+   `Code` package with the module syntax so the repository root is added to
+   `sys.path`:
+   ```bash
+   python -m Code.some_script
+   ```
 
 4. **Activate the development environment**:
    ```bash
@@ -534,14 +540,14 @@ video plumes processed via MATLAB.
 
 ```bash
 # Crimaldi plume example
-python Code/characterize_plume_intensities.py \
+python -m Code.characterize_plume_intensities \
     --plume_type crimaldi \
     --file_path data/10302017_10cms_bounded.hdf5 \
     --plume_id crimaldi \
     --output_json plume_stats.json
 
 # Video plume example
-python Code/characterize_plume_intensities.py \
+python -m Code.characterize_plume_intensities \
     --plume_type video \
     --file_path path/to/video_script.m \
     --plume_id my_video \
@@ -562,11 +568,11 @@ variables.
 
 ```bash
 # Display results in the terminal
-python Code/compare_intensity_stats.py A data/crimaldi.hdf5 B data/custom.hdf5
+python -m Code.compare_intensity_stats A data/crimaldi.hdf5 B data/custom.hdf5
     --matlab_exec /path/to/matlab
 
 # Write to CSV
-python Code/compare_intensity_stats.py A data/crimaldi.hdf5 B data/custom.hdf5 \
+python -m Code.compare_intensity_stats A data/crimaldi.hdf5 B data/custom.hdf5 \
     --csv intensity_comparison.csv
     --matlab_exec /path/to/matlab
 ```
@@ -575,7 +581,7 @@ python Code/compare_intensity_stats.py A data/crimaldi.hdf5 B data/custom.hdf5 \
 To compare a custom video plume against Crimaldi, first create the development environment with `./setup_env.sh --dev` and then run:
 
 ```bash
-conda run --prefix ./dev-env python Code/compare_intensity_stats.py VID video path/to/video_script.m CRIM crimaldi data/10302017_10cms_bounded.hdf5 --matlab_exec /path/to/matlab
+conda run --prefix ./dev-env python -m Code.compare_intensity_stats VID video path/to/video_script.m CRIM crimaldi data/10302017_10cms_bounded.hdf5 --matlab_exec /path/to/matlab
 ```
 
 ## Repository Layout

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -2,13 +2,14 @@
 
 This page describes how to characterise the intensity of individual odour plumes and how to compare multiple intensity datasets.
 Before running any commands, create the development environment using `./setup_env.sh --dev`.
+Use the module form `python -m Code.<script>` when executing scripts so the repository root is on `sys.path`.
 
 ## Characterising a Single Plume
 
 To obtain intensity statistics for a single plume, use the `analyze_crimaldi_data.py` script. The command prints summary statistics such as the minimum, maximum and percentile values.
 
 ```bash
-conda run --prefix ./dev-env python Code/analyze_crimaldi_data.py data/raw/plume1.hdf5
+conda run --prefix ./dev-env python -m Code.analyze_crimaldi_data data/raw/plume1.hdf5
 ```
 
 Expected output:
@@ -29,13 +30,13 @@ Std: 0.8
 Use the `compare_intensity_stats.py` script with multiple input files. The script computes cross‑dataset statistics and produces a plot showing the distribution of intensities.
 
 ```bash
-conda run --prefix ./dev-env python Code/compare_intensity_stats.py data/raw/plume1.hdf5 data/raw/plume2.hdf5
+conda run --prefix ./dev-env python -m Code.compare_intensity_stats data/raw/plume1.hdf5 data/raw/plume2.hdf5
 ```
 
 To see the mean and median differences when exactly two datasets are provided, add the `--diff` option:
 
 ```bash
-conda run --prefix ./dev-env python Code/compare_intensity_stats.py A data/raw/plume1.hdf5 B data/raw/plume2.hdf5 --diff
+conda run --prefix ./dev-env python -m Code.compare_intensity_stats A data/raw/plume1.hdf5 B data/raw/plume2.hdf5 --diff
 ```
 
 Sample output:
@@ -70,7 +71,7 @@ fprintf('TEMP_MAT_FILE_SUCCESS:%s\n', which('temp_intensities.mat'));
 Run the comparison using the development environment created with `./setup_env.sh --dev`:
 
 ```bash
-conda run --prefix ./dev-env python Code/compare_intensity_stats.py VID video path/to/video_script.m CRIM crimaldi data/10302017_10cms_bounded.hdf5 --matlab_exec /path/to/matlab
+conda run --prefix ./dev-env python -m Code.compare_intensity_stats VID video path/to/video_script.m CRIM crimaldi data/10302017_10cms_bounded.hdf5 --matlab_exec /path/to/matlab
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary
- note that `setup_env.sh --dev` prepares a development environment
- recommend using `python -m Code.<script>` so the repo root is on `sys.path`
- update intensity helper examples to invoke scripts as modules

## Testing
- `./setup_env.sh --dev` *(fails: wget: unable to resolve host)*
- `pre-commit run --files README.md docs/intensity_comparison.md` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*