### PR TITLE
Update setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,7 @@ dependencies = [
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["Code"]
+exclude = ["tests", "docs", "data", "external", "configs"]


### PR DESCRIPTION
## Summary
- add setuptools package discovery settings

## Testing
- `pip install -e .` *(fails: Could not install build dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*