### PR TITLE
Update pip fallback to use python -m pip and verify conda-lock

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -102,7 +102,7 @@ setup_environment() {
     log INFO "Installing conda-lock"
     if ! run_command_verbose conda install -y -n base -c conda-forge conda-lock; then
       log WARNING "conda install failed, attempting pip fallback"
-      if ! run_command_verbose pip install --user conda-lock; then
+      if ! run_command_verbose python -m pip install --user conda-lock; then
         error "Failed to install conda-lock with conda or pip"
       fi
       export PATH="$HOME/.local/bin:${PATH}"
@@ -119,6 +119,11 @@ setup_environment() {
     # Verify installation
     if ! command -v conda-lock >/dev/null 2>&1; then
       error "Failed to install conda-lock or make it available in PATH"
+    fi
+
+    # Ensure conda-lock command works
+    if ! conda-lock --version >/dev/null 2>&1; then
+      error "conda-lock installation succeeded but 'conda-lock --version' failed"
     fi
   fi
 

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -31,7 +31,8 @@ def test_setup_env_script_runs_idempotently():
 def test_setup_env_has_conda_lock_pip_fallback():
     with open('setup_env.sh') as f:
         content = f.read()
-    assert 'pip install --user conda-lock' in content
+    assert 'python -m pip install --user conda-lock' in content
+    assert 'conda-lock --version' in content
 
 
 def test_setup_env_handles_old_conda_versions():


### PR DESCRIPTION
## Summary
- update `setup_env.sh` to use `python -m pip` as a fallback for installing conda-lock
- verify conda-lock works by running `conda-lock --version`
- adjust test for new behaviour

## Testing
- `pytest tests/test_setup_env_script.py -q`