### PR TITLE
Remove test execution from setup script

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -313,25 +313,6 @@ main() {
 # Run the main function
 main "$@"
 
-if [ "$RUN_TESTS" -eq 1 ]; then
-  section "Running tests"
-  # Get the absolute path to the project root
-  PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  
-  # Activate the environment
-  log INFO "Activating the environment..."
-  eval "$(conda shell.bash hook)"
-  conda activate "$PROJECT_ROOT/$LOCAL_ENV_DIR"
-  
-  # Run tests with the project root in PYTHONPATH
-  log INFO "Running tests..."
-  PYTHONPATH="$PROJECT_ROOT" pytest -v tests/ || \
-    log WARNING "Some tests failed"
-  
-  # Deactivate the environment
-  conda deactivate
-fi
-
 # Simple variable substitution function
 substitute_vars() {
     local content


### PR DESCRIPTION
## Summary
- remove post-setup test execution block from `setup_env.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*