### PR TITLE
Fix env setup in batch job

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -64,7 +64,7 @@ MATLAB_OPTIONS=${MATLAB_OPTIONS:--nodisplay -nosplash}
 
 # Setup conda environment if available
 if [ -f setup_env.sh ]; then
-    source setup_env.sh --dev
+    bash ./setup_env.sh --dev
     conda activate .env
 fi
 

--- a/tests/test_run_batch_job_env_setup.py
+++ b/tests/test_run_batch_job_env_setup.py
@@ -1,0 +1,8 @@
+import os
+
+
+def test_env_setup_uses_bash():
+    with open('run_batch_job.sh') as f:
+        content = f.read()
+    assert 'bash ./setup_env.sh --dev' in content, 'batch job should invoke setup_env.sh with bash'
+    assert 'source setup_env.sh' not in content

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -22,7 +22,7 @@ def test_setup_env_script_contains_expected_commands():
 def test_setup_env_script_runs_idempotently():
     if shutil.which('conda') is None:
         pytest.skip('conda not available')
-    cmd = 'source setup_env.sh --dev'
+    cmd = 'bash ./setup_env.sh --dev'
     result1 = subprocess.run(['bash', '-c', cmd], capture_output=True, text=True)
     assert result1.returncode == 0
     result2 = subprocess.run(['bash', '-c', cmd], capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- ensure batch jobs run `setup_env.sh` with bash
- update tests for new invocation
- add regression test for batch job environment setup

## Testing
- `pytest -q tests/test_run_batch_job_env_setup.py tests/test_setup_env_script.py`