### PR TITLE
Add module-based conda loading

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -59,6 +59,21 @@ conda_supports_force() {
   conda env create --help 2>&1 | grep -q -- '--force'
 }
 
+# Attempt to load Conda via the environment modules system
+try_load_conda_module() {
+  if type module >/dev/null 2>&1; then
+    for m in miniconda anaconda conda; do
+      if module avail "$m" 2>&1 | grep -qi "$m"; then
+        log INFO "Loading $m module for Conda"
+        if module load "$m"; then
+          return 0
+        fi
+      fi
+    done
+  fi
+  return 1
+}
+
 # Ensure conda-lock command exists and functions
 ensure_conda_lock() {
   if ! command -v conda-lock >/dev/null 2>&1 || ! conda-lock --version >/dev/null 2>&1; then
@@ -90,9 +105,11 @@ ensure_conda_lock() {
 setup_environment() {
   section "Starting environment setup"
   
-  # Check if conda is installed
+  # Check if conda is installed, attempt to load via modules if missing
   if ! command -v conda >/dev/null 2>&1; then
-    if [ -f /.dockerenv ] || grep -q docker /proc/1/cgroup 2>/dev/null; then
+    if try_load_conda_module && command -v conda >/dev/null 2>&1; then
+      log INFO "Loaded Conda via module system"
+    elif [ -f /.dockerenv ] || grep -q docker /proc/1/cgroup 2>/dev/null; then
       log WARNING "conda not found, installing Miniconda"
       if ! command -v wget >/dev/null 2>&1; then
         run_command_verbose apt-get update
@@ -102,7 +119,7 @@ setup_environment() {
       run_command_verbose bash /tmp/miniconda.sh -b -p "$HOME/miniconda"
       export PATH="$HOME/miniconda/bin:$PATH"
     else
-      error "conda is required but not found in PATH. Please install Miniconda or Anaconda."
+      error "conda is required but not found in PATH. Please load the appropriate module or install Miniconda."
     fi
   fi
 

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -47,3 +47,10 @@ def test_setup_env_handles_old_conda_versions():
         content = f.read()
     assert 'conda_supports_force' in content
     assert 'conda env remove --prefix "./${LOCAL_ENV_DIR}" -y' in content
+
+
+def test_setup_env_attempts_module_load():
+    """Script should try loading Conda via environment modules."""
+    with open('setup_env.sh') as f:
+        content = f.read()
+    assert 'try_load_conda_module' in content or 'module load' in content


### PR DESCRIPTION
## Summary
- load Conda via environment modules if `conda` command is missing
- ensure setup script mentions the module-loading logic
- add test covering module load attempt

## Testing
- `pytest -q tests/test_setup_env_script.py::test_setup_env_attempts_module_load`
- `pytest -q tests/test_setup_env_script.py`