### PR TITLE
fix: handle USER_BIN in setup script

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -77,6 +77,7 @@ try_load_conda_module() {
 
 # Ensure conda-lock command exists and functions
 ensure_conda_lock() {
+    local USER_BIN="$(python -m site --user-base)/bin"
     if ! command -v conda-lock >/dev/null 2>&1 || ! conda-lock --version >/dev/null 2>&1; then
         log INFO "Installing conda-lock"
         if ! run_command_verbose conda install -y -n base -c conda-forge conda-lock; then
@@ -96,7 +97,6 @@ ensure_conda_lock() {
 
         # If pip installed into user base, ensure that directory is on PATH
         if ! command -v conda-lock >/dev/null 2>&1; then
-            USER_BIN="$(python -m site --user-base)/bin"
             if [ -x "${USER_BIN}/conda-lock" ]; then
                 export PATH="${USER_BIN}:${PATH}"
                 hash -r


### PR DESCRIPTION
## Summary
- avoid unbound variable error when installing conda-lock

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*