### PR TITLE
feat: ensure pip path added via helper

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -96,12 +96,15 @@ ensure_conda_lock() {
         export PATH="${CONDA_BASE_DIR}/bin:${PATH}"
 
         # Always include user's pip bin directory
-        export PATH="${USER_BIN}:${PATH}"
+        append_path_if_missing "${USER_BIN}"
+        if [ -x "${USER_BIN}/conda-lock" ]; then
+            "${USER_BIN}/conda-lock" --version >/dev/null 2>&1 || true
+        fi
         hash -r
 
         # Verify installation
         if ! command -v conda-lock >/dev/null 2>&1 || ! conda-lock --version >/dev/null 2>&1; then
-            error "conda-lock installed but not on PATH. Add ${USER_BIN} to PATH."
+            error "conda-lock installed but not on PATH. Add ${USER_BIN}/conda-lock to PATH."
         fi
     fi
 }

--- a/setup_utils.sh
+++ b/setup_utils.sh
@@ -50,3 +50,14 @@ run_command_verbose() {
   fi
   return 0
 }
+
+# Prepend directory to PATH if it is not already included
+append_path_if_missing() {
+  local dir="$1"
+  case ":$PATH:" in
+    *":${dir}:"*) ;;
+    *)
+      export PATH="${dir}:${PATH}"
+      ;;
+  esac
+}

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -40,7 +40,18 @@ def test_setup_env_exports_user_bin_for_conda_lock():
     with open('setup_env.sh') as f:
         content = f.read()
     assert 'site --user-base' in content
+    assert 'append_path_if_missing "${USER_BIN}"' in content
     assert 'hash -r' in content
+
+
+def test_setup_env_invokes_append_path_helper_after_pip():
+    """append_path_if_missing should run after pip fallback and before hash."""
+    with open('setup_env.sh') as f:
+        content = f.read()
+    pip_idx = content.index('python -m pip install --user conda-lock')
+    append_idx = content.index('append_path_if_missing "${USER_BIN}"')
+    hash_idx = content.index('hash -r')
+    assert pip_idx < append_idx < hash_idx
 
 
 def test_setup_env_checks_existing_conda_lock():

--- a/tests/test_setup_utils_script.py
+++ b/tests/test_setup_utils_script.py
@@ -12,6 +12,7 @@ def test_setup_utils_functions_defined():
     assert 'error()' in content
     assert 'run_command_verbose()' in content
     assert 'log()' in content
+    assert 'append_path_if_missing()' in content
 
 
 def test_setup_env_sources_utils():


### PR DESCRIPTION
## Summary
- add `append_path_if_missing` helper in `setup_utils.sh`
- use helper when installing `conda-lock` via pip
- verify `$USER_BIN/conda-lock` exists and adjust error message with full path
- test that helper is defined and invoked

## Testing
- `pytest tests/test_setup_env_script.py tests/test_setup_utils_script.py -q`