### PR TITLE
Clarify plume intensity documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,21 @@ python -m Code.characterize_plume_intensities \
     --output_json plume_stats.json
 
 # Video plume example
+
+First create a small MATLAB script to load your movie and write out the
+intensity vector. For ``data/smoke_1a_bgsub_raw.avi`` the script might look like
+``video_script.m``:
+
+```matlab
+plume = load_plume_video('data/smoke_1a_bgsub_raw.avi', 20, 40);
+all_intensities = plume.data(:);
+save('temp_intensities.mat', 'all_intensities');
+fprintf('TEMP_MAT_FILE_SUCCESS:%s\n', which('temp_intensities.mat'));
+```
+
+Run the utility with the path to this script:
+
+```bash
 python -m Code.characterize_plume_intensities \
     --plume_type video \
     --file_path path/to/video_script.m \
@@ -593,6 +608,9 @@ To compare a custom video plume against Crimaldi, first create the development e
 ```bash
 conda run --prefix ./dev-env python -m Code.compare_intensity_stats VID video path/to/video_script.m CRIM crimaldi data/10302017_10cms_bounded.hdf5 --matlab_exec /path/to/matlab
 ```
+
+``path/to/video_script.m`` should point to the MATLAB file shown above that
+loads your ``.avi`` movie and writes ``temp_intensities.mat``.
 
 ## Repository Layout
 

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -66,14 +66,21 @@ Figure saved to figures/intensity_comparison.png
 
 ### Comparing a Video Plume to Crimaldi
 
-If you have a custom plume movie, extract the intensity values in MATLAB and compare them to the Crimaldi data. Below is a minimal script `video_script.m`:
+If you have a custom plume movie, extract the intensity values in MATLAB and compare
+them to the Crimaldi data. Below is a minimal script `video_script.m`. Replace
+`'my_plume.avi'` with the path to your movie, for example
+`'data/smoke_1a_bgsub_raw.avi'`:
 
 ```matlab
-plume = load_plume_video('my_plume.avi', 20, 40);
+plume = load_plume_video('data/smoke_1a_bgsub_raw.avi', 20, 40);
 all_intensities = plume.data(:);
 save('temp_intensities.mat', 'all_intensities');
 fprintf('TEMP_MAT_FILE_SUCCESS:%s\n', which('temp_intensities.mat'));
 ```
+
+Save the script and pass **its full path** to the Python utility. The
+`TEMP_MAT_FILE_SUCCESS` line is used by `compare_intensity_stats.py` to locate the
+generated MAT-file.
 
 Run the comparison using the development environment created with `./setup_env.sh --dev`:
 


### PR DESCRIPTION
## Summary
- explain how to create a MATLAB video script for intensity extraction
- document running the video plume utilities with this script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*