### PR TITLE
Update tests to conditionally import heavy libs

### DIFF
--- a/tests/test_analyze_crimaldi_data.py
+++ b/tests/test_analyze_crimaldi_data.py
@@ -1,7 +1,10 @@
 import os
-import numpy as np
-import h5py
 import unittest
+
+import pytest
+
+np = pytest.importorskip("numpy")
+h5py = pytest.importorskip("h5py")
 
 from Code.analyze_crimaldi_data import analyze_crimaldi_data
 

--- a/tests/test_calculate_metrics.py
+++ b/tests/test_calculate_metrics.py
@@ -1,7 +1,10 @@
 import os
 import sys
-import yaml
 import math
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_comparative_analysis.py
+++ b/tests/test_comparative_analysis.py
@@ -1,8 +1,10 @@
 import os
 import sys
-import yaml
 import tempfile
+
 import pytest
+
+yaml = pytest.importorskip("yaml")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_discover_processed_data.py
+++ b/tests/test_discover_processed_data.py
@@ -1,7 +1,10 @@
 import os
 import sys
-import yaml
 from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_generate_dashboard.py
+++ b/tests/test_generate_dashboard.py
@@ -1,6 +1,9 @@
 import os
 import sys
-import yaml
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_get_intensities_from_crimaldi.py
+++ b/tests/test_get_intensities_from_crimaldi.py
@@ -1,7 +1,10 @@
 import os
-import numpy as np
-import h5py
 import unittest
+
+import pytest
+
+np = pytest.importorskip("numpy")
+h5py = pytest.importorskip("h5py")
 
 from Code.analyze_crimaldi_data import get_intensities_from_crimaldi
 

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -4,7 +4,9 @@ import sys
 import tempfile
 from pathlib import Path
 
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_intensity_stats.py
+++ b/tests/test_intensity_stats.py
@@ -1,8 +1,9 @@
 import os
 import sys
 import types
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_load_intensities.py
+++ b/tests/test_load_intensities.py
@@ -1,6 +1,9 @@
 import os
 import sys
-import numpy as np
+
+import pytest
+
+np = pytest.importorskip("numpy")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_load_trajectories.py
+++ b/tests/test_load_trajectories.py
@@ -1,7 +1,10 @@
 import os
 import sys
-import yaml
-import pandas as pd
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+pd = pytest.importorskip("pandas")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_main_analysis.py
+++ b/tests/test_main_analysis.py
@@ -1,8 +1,11 @@
 import os
 import sys
-import yaml
 import json
 import csv
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_parameter_usage.py
+++ b/tests/test_parameter_usage.py
@@ -1,9 +1,11 @@
 import json
-import yaml
 import os
 import sys
 from pathlib import Path
+
 import pytest
+
+yaml = pytest.importorskip("yaml")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_trajectory_animation.py
+++ b/tests/test_trajectory_animation.py
@@ -3,7 +3,9 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 
 from Code.trajectory_animation import animate_trajectories
 

--- a/tests/test_trajectory_heatmap.py
+++ b/tests/test_trajectory_heatmap.py
@@ -1,8 +1,11 @@
 import os
 import sys
-import yaml
 import csv
 import tempfile
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_validate_exported_data.py
+++ b/tests/test_validate_exported_data.py
@@ -1,8 +1,11 @@
 import os
 import sys
 import json
-import yaml
-import pandas as pd
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+pd = pytest.importorskip("pandas")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 


### PR DESCRIPTION
## Summary
- avoid heavy imports in unit tests if modules aren't present
- skip tests without numpy, h5py, yaml, or pandas

## Testing
- `pytest -q tests/test_analyze_crimaldi_data.py`
