### PR TITLE
Add docstring examples

### DIFF
--- a/Code/data_aggregation.py
+++ b/Code/data_aggregation.py
@@ -1,4 +1,12 @@
-"""Aggregate agent metrics based on analysis configuration."""
+"""Aggregate agent metrics based on analysis configuration.
+
+Examples
+--------
+>>> records = [{'plume': 'A', 'metric': 1.0}, {'plume': 'A', 'metric': 3.0}]
+>>> cfg = {'aggregation_options': {'group_by_keys': ['plume']}}
+>>> aggregate_metrics(records, cfg)[('A',)]['metric']['count']
+2
+"""
 
 from __future__ import annotations
 
@@ -24,6 +32,13 @@ def aggregate_metrics(records: List[Dict[str, Any]], cfg: Dict[str, Any]) -> Dic
     dict
         Nested dictionary keyed by the grouping tuple. Each metric has another
         dictionary with computed statistics.
+    
+    Examples
+    --------
+    >>> records = [{'plume': 'A', 'metric': 1.0}, {'plume': 'A', 'metric': 3.0}]
+    >>> cfg = {'aggregation_options': {'group_by_keys': ['plume']}}
+    >>> aggregate_metrics(records, cfg)[('A',)]['metric']['mean']
+    2.0
     """
     opts = cfg.get("aggregation_options", {})
     group_keys = opts.get("group_by_keys", [])

--- a/Code/data_discovery.py
+++ b/Code/data_discovery.py
@@ -1,4 +1,16 @@
-"""Utilities for discovering processed data files based on a config."""
+"""Utilities for discovering processed data files based on a config.
+
+Examples
+--------
+Run discovery using the project environment::
+
+    ./setup_env.sh --dev
+    conda run --prefix ./dev-env python - <<'PY'
+    from Code.data_discovery import discover_processed_data
+    cfg = {'data_paths': {'processed_base_dirs': ['data/processed']}}
+    list(discover_processed_data(cfg))
+    PY
+"""
 
 from __future__ import annotations
 
@@ -76,6 +88,13 @@ def discover_processed_data(cfg: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
         Dictionary with keys ``path`` and ``metadata`` plus optional entries
         for ``config``, ``summary``, ``params``, and ``trajectories`` depending
         on ``data_loading_options``.
+
+    Examples
+    --------
+    >>> cfg = {'data_paths': {'processed_base_dirs': ['data/processed']}}
+    >>> gen = discover_processed_data(cfg)
+    >>> isinstance(next(gen, {}), dict)
+    True
     """
     base_dirs = cfg.get("data_paths", {}).get("processed_base_dirs", [])
     template = cfg.get("metadata_extraction", {}).get(
@@ -175,6 +194,12 @@ def check_parameter_consistency(records: List[Dict[str, Any]], cfg: Dict[str, An
         Records returned by :func:`discover_processed_data`.
     cfg : dict
         Analysis configuration containing ``parameter_usage`` options.
+
+    Examples
+    --------
+    >>> recs = [{'metadata': {'plume': 'A', 'mode': 'm'}, 'params': {'tau': 1}}]
+    >>> cfg = {'parameter_usage': {'check_model_parameter_consistency': {'enabled': True, 'parameters_to_check': ['tau']}}}
+    >>> check_parameter_consistency(recs, cfg)
     """
     param_cfg = cfg.get("parameter_usage", {}).get(
         "check_model_parameter_consistency", {}

--- a/Code/intensity_stats.py
+++ b/Code/intensity_stats.py
@@ -1,4 +1,12 @@
-"""Utility functions for plume intensity statistics."""
+"""Utility functions for plume intensity statistics.
+
+Examples
+--------
+Run the CLI inside the project environment::
+
+    ./setup_env.sh --dev
+    conda run --prefix ./dev-env python -m Code.intensity_stats plumeA intensities.txt
+"""
 
 from __future__ import annotations
 
@@ -12,7 +20,13 @@ except Exception as exc:  # pragma: no cover
 
 
 def calculate_intensity_stats_dict(intensities: Sequence[float]) -> Dict[str, float]:
-    """Return basic statistics for the provided intensities."""
+    """Return basic statistics for the provided intensities.
+
+    Examples
+    --------
+    >>> calculate_intensity_stats_dict([1, 2, 3])['count']
+    3
+    """
     arr = np.asarray(intensities, dtype=float)
     if arr.size == 0:
         return {

--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -4,6 +4,17 @@ The helper function in this module writes a temporary MATLAB script to disk and
 executes it using ``matlab -batch``.  If ``px_per_mm`` and ``frame_rate`` values
 are supplied, they are inserted as variable assignments at the beginning of the
 script so that MATLAB code can access them directly.
+
+Examples
+--------
+Create the development environment and run a short Python snippet inside it::
+
+    ./setup_env.sh --dev
+    conda run --prefix ./dev-env python - <<'PY'
+    from Code.video_intensity import get_intensities_from_video_via_matlab
+    arr = get_intensities_from_video_via_matlab('myscript.m', 'matlab')
+    print(arr.shape)
+    PY
 """
 
 from __future__ import annotations
@@ -48,6 +59,13 @@ def get_intensities_from_video_via_matlab(
     -------
     numpy.ndarray
         Flattened array of the intensity values extracted from the MAT-file.
+
+    Examples
+    --------
+    >>> from Code.video_intensity import get_intensities_from_video_via_matlab
+    >>> arr = get_intensities_from_video_via_matlab('myscript.m', 'matlab')
+    >>> arr.size >= 0
+    True
     """
     script_file = None
     mat_path = None


### PR DESCRIPTION
## Summary
- update module docstrings for typical CLI usage
- add minimal examples to helper functions

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q tests/test_intensity_stats.py tests/test_data_aggregation.py tests/test_discover_processed_data.py` *(fails: missing modules)*