### PR TITLE
Clarify config path in intensity comparison docs

### DIFF
--- a/Code/characterize_plume_intensities.py
+++ b/Code/characterize_plume_intensities.py
@@ -92,6 +92,7 @@ def main(args: List[str] | None = None) -> None:  # pragma: no cover - CLI entry
             ns.matlab_exec,
             px_per_mm=ns.px_per_mm,
             frame_rate=ns.frame_rate,
+            work_dir=str(Path(ns.file_path).parent),
         )
     else:
         intensities = get_intensities_from_crimaldi(ns.file_path)

--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -39,7 +39,9 @@ def load_intensities(
         return get_intensities_from_crimaldi(path)
     if plume_type == "video":
         script_contents = Path(path).read_text()
-        return get_intensities_from_video_via_matlab(script_contents, matlab_exec_path)
+        return get_intensities_from_video_via_matlab(
+            script_contents, matlab_exec_path, work_dir=str(Path(path).parent)
+        )
 
     raise ValueError(f"Unknown plume_type: {plume_type}")
 

--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -32,6 +32,7 @@ def get_intensities_from_video_via_matlab(
     matlab_exec_path: str,
     px_per_mm: float | None = None,
     frame_rate: float | None = None,
+    work_dir: str | None = None,
 ) -> np.ndarray:
     """Run a MATLAB script and return the extracted intensity vector.
 
@@ -48,6 +49,8 @@ def get_intensities_from_video_via_matlab(
     frame_rate : float, optional
         Frame rate of the video in Hz. As with ``px_per_mm``, the value is
         embedded in the temporary MATLAB script for use by helper routines.
+    work_dir : str, optional
+        Directory MATLAB should change into before running the temporary script.
 
     Notes
     -----
@@ -72,6 +75,8 @@ def get_intensities_from_video_via_matlab(
     try:
         script_file = tempfile.NamedTemporaryFile(delete=False, suffix=".m")
         header_lines = []
+        if work_dir is not None:
+            header_lines.append(f"cd('{work_dir}')")
         if px_per_mm is not None:
             header_lines.append(f"px_per_mm = {px_per_mm};")
         if frame_rate is not None:

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -74,12 +74,20 @@ are pulled from that file. The YAML file defines `px_per_mm` and
 `frame_rate` used by `load_plume_video`:
 
 ```matlab
-cfg = load_config('configs/my_complex_plume_config.yaml');
+% Construct an absolute path so MATLAB can locate the YAML file even when
+% the script is executed from a temporary directory.
+thisDir = fileparts(mfilename('fullpath'));
+cfgPath = fullfile(thisDir, '..', 'configs', 'my_complex_plume_config.yaml');
+cfg = load_config(cfgPath);
 plume = load_plume_video('data/smoke_1a_bgsub_raw.avi', cfg.px_per_mm, cfg.frame_rate);
 all_intensities = plume.data(:);
 save('temp_intensities.mat', 'all_intensities');
 fprintf('TEMP_MAT_FILE_SUCCESS:%s\n', which('temp_intensities.mat'));
 ```
+
+The first two lines compute the configuration path relative to the
+script's location, ensuring `load_config` can find the YAML file even
+though MATLAB temporarily changes directories when executing the script.
 
 Save the script and pass **its full path** to the Python utility. The
 `TEMP_MAT_FILE_SUCCESS` line is used by `compare_intensity_stats.py` to locate the

--- a/tests/test_load_intensities_work_dir.py
+++ b/tests/test_load_intensities_work_dir.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import importlib
+import types
+
+fake_np = types.SimpleNamespace(array=lambda x: x)
+fake_h5py = types.SimpleNamespace(File=lambda *a, **k: None)
+fake_scipy = types.SimpleNamespace(io=types.SimpleNamespace(loadmat=lambda p: {"all_intensities": [1]}))
+sys.modules['numpy'] = fake_np
+sys.modules['h5py'] = fake_h5py
+sys.modules['scipy'] = fake_scipy
+sys.modules['scipy.io'] = fake_scipy.io
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Code import compare_intensity_stats as cis
+
+def test_work_dir_passed_to_video_loader(monkeypatch, tmp_path):
+    mfile = tmp_path / 'nested' / 'script.m'
+    mfile.parent.mkdir()
+    mfile.write_text('disp("hi")')
+    captured = {}
+
+    def fake_video(contents, matlab_exec_path='matlab', px_per_mm=None, frame_rate=None, work_dir=None):
+        captured['work_dir'] = work_dir
+        return [1]
+
+    monkeypatch.setattr(cis, 'get_intensities_from_crimaldi', lambda *a, **k: [_ for _ in ()])
+    monkeypatch.setattr(cis, 'get_intensities_from_video_via_matlab', fake_video)
+
+    cis.load_intensities(str(mfile), plume_type='video')
+    assert captured['work_dir'] == str(mfile.parent)

--- a/tests/test_video_work_dir_no_numpy.py
+++ b/tests/test_video_work_dir_no_numpy.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+import os
+import subprocess
+import tempfile
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Insert fake numpy and scipy modules so Code.video_intensity imports
+class DummyArray(list):
+    def flatten(self):
+        return self
+
+fake_np = types.SimpleNamespace(asarray=lambda x: DummyArray(x))
+def fake_loadmat(path):
+    return {"all_intensities": [1]}
+
+fake_scipy_io = types.SimpleNamespace(loadmat=fake_loadmat)
+sys.modules['numpy'] = fake_np
+sys.modules['scipy'] = types.SimpleNamespace(io=fake_scipy_io)
+sys.modules['scipy.io'] = fake_scipy_io
+
+vi = importlib.reload(importlib.import_module('Code.video_intensity'))
+
+
+def test_work_dir_inserts_cd(monkeypatch, tmp_path):
+    captured = {}
+
+    orig_ntf = tempfile.NamedTemporaryFile
+
+    def fake_ntf(*args, **kwargs):
+        kwargs.setdefault('delete', False)
+        fh = orig_ntf(*args, **kwargs)
+        captured['path'] = fh.name
+        return fh
+
+    def fake_run(cmd, capture_output, text):
+        with open(captured['path']) as fh:
+            captured['contents'] = fh.read()
+        mat_file = tmp_path / 'dummy.mat'
+        mat_file.write_bytes(b'')
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=f'TEMP_MAT_FILE_SUCCESS:{mat_file}\n',
+            stderr=''
+        )
+
+    monkeypatch.setattr(tempfile, 'NamedTemporaryFile', fake_ntf)
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    arr = vi.get_intensities_from_video_via_matlab('disp("hi")', 'matlab', work_dir=str(tmp_path))
+    assert arr == [1]
+    assert captured['contents'].splitlines()[0] == f"cd('{tmp_path}')"


### PR DESCRIPTION
## Summary
- explain that the MATLAB example must build an absolute path to the configuration file

## Testing
- `conda run --prefix ./dev-env pytest -q` *(fails: `conda` not found)*