### PR TITLE
Expose original MATLAB script path

### DIFF
--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -40,7 +40,10 @@ def load_intensities(
     if plume_type == "video":
         script_contents = Path(path).read_text()
         return get_intensities_from_video_via_matlab(
-            script_contents, matlab_exec_path, work_dir=str(Path(path).parent)
+            script_contents,
+            matlab_exec_path,
+            work_dir=str(Path(path).parent),
+            orig_script_path=str(Path(path)),
         )
 
     raise ValueError(f"Unknown plume_type: {plume_type}")
@@ -129,9 +132,7 @@ def write_json(
     """Write statistics to a JSON file."""
     path = Path(json_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    entries = [
-        {"identifier": ident, "statistics": stats} for ident, stats in results
-    ]
+    entries = [{"identifier": ident, "statistics": stats} for ident, stats in results]
     if diff is not None:
         entries.append({"identifier": "DIFF", "statistics": diff})
     path.write_text(json.dumps(entries, indent=4))

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -98,3 +98,52 @@ def test_path_with_spaces_and_quotes(monkeypatch, tmp_path):
     assert "disp(" in captured["script_contents"]
     assert not Path(captured["script_path"]).exists()
     assert not mat_file.exists()
+
+
+def test_orig_script_path_injected_and_logged(monkeypatch, tmp_path, caplog):
+    matlab_exec = "/usr/local/MATLAB/R2023b/bin/matlab"
+    script_content = 'disp("hello")'
+
+    orig_script = tmp_path / "orig'script.m"
+    orig_script.write_text("disp('orig')")
+
+    mat_file = tmp_path / "out.mat"
+    from scipy.io import savemat
+
+    savemat(mat_file, {"all_intensities": np.array([1], dtype=np.float32)})
+
+    stdout = f"TEMP_MAT_FILE_SUCCESS:{mat_file}\n"
+
+    captured = {}
+
+    orig_ntf = tempfile.NamedTemporaryFile
+
+    def fake_ntf(*args, **kwargs):
+        kwargs.setdefault("delete", False)
+        tmp = orig_ntf(*args, **kwargs)
+        captured["script_path"] = tmp.name
+        return tmp
+
+    def fake_run(cmd, capture_output, text):
+        with open(captured["script_path"]) as fh:
+            captured["script_contents"] = fh.read()
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", fake_ntf)
+
+    caplog.set_level("INFO")
+    arr = get_intensities_from_video_via_matlab(
+        script_content,
+        matlab_exec,
+        orig_script_path=str(orig_script),
+        work_dir=str(tmp_path),
+    )
+    assert np.array_equal(arr, np.array([1], dtype=np.float32))
+
+    assert f"orig_script_path = '{str(orig_script).replace("'", "''")}';" in captured["script_contents"]
+    assert "orig_script_dir = fileparts(orig_script_path);" in captured["script_contents"]
+
+    log_msg = "".join(r.getMessage() for r in caplog.records)
+    assert str(tmp_path) in log_msg
+    assert str(captured["script_path"]) in log_msg

--- a/tests/test_load_intensities.py
+++ b/tests/test_load_intensities.py
@@ -67,3 +67,26 @@ def test_work_dir_passed_to_video_loader(monkeypatch, tmp_path):
 
     cis.load_intensities(str(mfile), plume_type='video')
     assert captured['work_dir'] == str(mfile.parent)
+
+
+def test_orig_script_path_passed(monkeypatch, tmp_path):
+    mfile = tmp_path / 'script.m'
+    mfile.write_text('disp("hi")')
+    captured = {}
+
+    def fake_video(
+        contents,
+        matlab_exec_path='matlab',
+        px_per_mm=None,
+        frame_rate=None,
+        work_dir=None,
+        orig_script_path=None,
+    ):
+        captured['orig_script_path'] = orig_script_path
+        return np.array([5.0])
+
+    monkeypatch.setattr(cis, 'get_intensities_from_crimaldi', lambda *a, **k: [_ for _ in ()])
+    monkeypatch.setattr(cis, 'get_intensities_from_video_via_matlab', fake_video)
+
+    cis.load_intensities(str(mfile), plume_type='video')
+    assert captured['orig_script_path'] == str(mfile)


### PR DESCRIPTION
## Summary
- log MATLAB script path and working directory when getting intensities
- allow passing `orig_script_path` to the helper and propagate from `load_intensities`
- test new behaviour

## Testing
- `ruff check Code/video_intensity.py Code/compare_intensity_stats.py`
- `pytest -k orig_script_path -v tests/test_get_intensities_from_video_via_matlab.py` *(fails: collected 0 items / 1 skipped)*