### PR TITLE
Add orig_script_path handling for MATLAB video intensities

### DIFF
--- a/Code/characterize_plume_intensities.py
+++ b/Code/characterize_plume_intensities.py
@@ -93,6 +93,7 @@ def main(args: List[str] | None = None) -> None:  # pragma: no cover - CLI entry
             px_per_mm=ns.px_per_mm,
             frame_rate=ns.frame_rate,
             work_dir=str(Path(ns.file_path).parent),
+            orig_script_path=str(ns.file_path),
         )
     else:
         intensities = get_intensities_from_crimaldi(ns.file_path)

--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -40,7 +40,10 @@ def load_intensities(
     if plume_type == "video":
         script_contents = Path(path).read_text()
         return get_intensities_from_video_via_matlab(
-            script_contents, matlab_exec_path, work_dir=str(Path(path).parent)
+            script_contents,
+            matlab_exec_path,
+            work_dir=str(Path(path).parent),
+            orig_script_path=str(path),
         )
 
     raise ValueError(f"Unknown plume_type: {plume_type}")

--- a/tests/test_characterize_plume_intensities_cli.py
+++ b/tests/test_characterize_plume_intensities_cli.py
@@ -49,7 +49,7 @@ def test_video_requires_px_per_mm_and_frame_rate(tmp_path):
     out_json = tmp_path / "out.json"
     fake_crim = types.SimpleNamespace(get_intensities_from_crimaldi=lambda p: [1])
     fake_vid = types.SimpleNamespace(
-        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate: [1]
+        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate, orig_script_path=None: [1]
     )
     sys.modules["Code.analyze_crimaldi_data"] = fake_crim
     sys.modules["Code.video_intensity"] = fake_vid
@@ -75,7 +75,7 @@ def test_video_valid_arguments(monkeypatch, tmp_path):
     fake_crim = types.SimpleNamespace(get_intensities_from_crimaldi=lambda p: [1])
     captured = {}
 
-    def fake_vid_func(s, m, px_per_mm, frame_rate):
+    def fake_vid_func(s, m, px_per_mm, frame_rate, orig_script_path=None):
         captured["px_per_mm"] = px_per_mm
         captured["frame_rate"] = frame_rate
         captured["matlab_exec"] = m
@@ -121,7 +121,7 @@ def test_crimaldi_valid_arguments(monkeypatch, tmp_path):
         get_intensities_from_crimaldi=lambda path: [4.0, 5.0]
     )
     fake_vid = types.SimpleNamespace(
-        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate: [1]
+        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate, orig_script_path=None: [1]
     )
     sys.modules["Code.analyze_crimaldi_data"] = fake_crim
     sys.modules["Code.video_intensity"] = fake_vid
@@ -150,7 +150,7 @@ def test_matlab_exec_option(monkeypatch, tmp_path):
     out_json = tmp_path / "out.json"
     fake_crim = types.SimpleNamespace(get_intensities_from_crimaldi=lambda p: [1])
     captured = {}
-    def fake_vid_func(s, m, px_per_mm, frame_rate):
+    def fake_vid_func(s, m, px_per_mm, frame_rate, orig_script_path=None):
         captured["matlab_exec"] = m
         return [1]
     fake_vid = types.SimpleNamespace(get_intensities_from_video_via_matlab=fake_vid_func)

--- a/tests/test_compare_intensity_stats.py
+++ b/tests/test_compare_intensity_stats.py
@@ -49,7 +49,7 @@ def test_compare_intensity_stats_video_vs_crimaldi(monkeypatch, tmp_path, capsys
 
     captured = {}
 
-    def fake_func(s, m='matlab'):
+    def fake_func(s, m='matlab', orig_script_path=None):
         captured['matlab_exec'] = m
         return arr_vid
 
@@ -77,7 +77,7 @@ def test_matlab_exec_option(monkeypatch, tmp_path):
     arr_vid = np.array([1.0], dtype=float)
     captured = {}
 
-    def fake_func(s, m='matlab'):
+    def fake_func(s, m='matlab', orig_script_path=None):
         captured['matlab_exec'] = m
         return arr_vid
 
@@ -104,7 +104,7 @@ def test_csv_output_and_directory_creation(monkeypatch, tmp_path):
     monkeypatch.setattr(
         cis,
         'get_intensities_from_video_via_matlab',
-        lambda s, m='matlab': arr_vid,
+        lambda s, m='matlab', orig_script_path=None: arr_vid,
     )
 
     csv_path = tmp_path / 'nested' / 'results' / 'stats.csv'
@@ -151,7 +151,7 @@ def test_json_output_and_directory_creation(monkeypatch, tmp_path):
     monkeypatch.setattr(
         cis,
         'get_intensities_from_video_via_matlab',
-        lambda s, m='matlab': arr_vid,
+        lambda s, m='matlab', orig_script_path=None: arr_vid,
     )
 
     json_path = tmp_path / 'nested' / 'results' / 'stats.json'

--- a/tests/test_load_intensities.py
+++ b/tests/test_load_intensities.py
@@ -35,7 +35,7 @@ def test_m_file_uses_video_loader(monkeypatch, tmp_path):
     mfile.write_text('disp("hi")')
     captured = {}
 
-    def fake_video(contents, matlab_exec_path='matlab'):
+    def fake_video(contents, matlab_exec_path='matlab', orig_script_path=None):
         captured['contents'] = contents
         captured['matlab'] = matlab_exec_path
         return np.array([2.0, 3.0])
@@ -58,7 +58,7 @@ def test_work_dir_passed_to_video_loader(monkeypatch, tmp_path):
     mfile.write_text('disp("hi")')
     captured = {}
 
-    def fake_video(contents, matlab_exec_path='matlab', px_per_mm=None, frame_rate=None, work_dir=None):
+    def fake_video(contents, matlab_exec_path='matlab', px_per_mm=None, frame_rate=None, work_dir=None, orig_script_path=None):
         captured['work_dir'] = work_dir
         return [1]
 

--- a/tests/test_load_intensities_work_dir.py
+++ b/tests/test_load_intensities_work_dir.py
@@ -21,7 +21,7 @@ def test_work_dir_passed_to_video_loader(monkeypatch, tmp_path):
     mfile.write_text('disp("hi")')
     captured = {}
 
-    def fake_video(contents, matlab_exec_path='matlab', px_per_mm=None, frame_rate=None, work_dir=None):
+    def fake_video(contents, matlab_exec_path='matlab', px_per_mm=None, frame_rate=None, work_dir=None, orig_script_path=None):
         captured['work_dir'] = work_dir
         return [1]
 

--- a/tests/test_video_intensity_error.py
+++ b/tests/test_video_intensity_error.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+import tempfile
+import sys
+import importlib
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+
+def test_error_message_contains_hint(monkeypatch, tmp_path):
+    # Provide fake numpy/scipy so the module can be imported
+    monkeypatch.setitem(sys.modules, 'numpy', types.SimpleNamespace(asarray=lambda x: x))
+    fake_scipy_io = types.SimpleNamespace(loadmat=lambda p: {'all_intensities': []})
+    monkeypatch.setitem(sys.modules, 'scipy', types.SimpleNamespace(io=fake_scipy_io))
+    monkeypatch.setitem(sys.modules, 'scipy.io', fake_scipy_io)
+
+    vi = importlib.reload(importlib.import_module('Code.video_intensity'))
+    func = vi.get_intensities_from_video_via_matlab
+
+    captured = {}
+    orig_ntf = tempfile.NamedTemporaryFile
+
+    def fake_ntf(*args, **kwargs):
+        kwargs.setdefault('delete', False)
+        fh = orig_ntf(*args, **kwargs)
+        captured['path'] = fh.name
+        return fh
+
+    def fake_run(cmd, capture_output, text):
+        with open(captured['path']) as fh:
+            captured['contents'] = fh.read()
+        return subprocess.CompletedProcess(cmd, 1, stdout='', stderr='Configuration file not found')
+
+    monkeypatch.setattr(tempfile, 'NamedTemporaryFile', fake_ntf)
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    with pytest.raises(RuntimeError) as exc:
+        func(
+            'disp("hi")',
+            'matlab',
+            work_dir='.',
+            orig_script_path='/path/to/script.m',
+        )
+
+    msg = str(exc.value)
+    assert '/path/to/script.m' in msg
+    assert 'orig_script_dir' in msg
+
+    assert "orig_script_path = '/path/to/script.m';" in captured['contents']
+    assert 'orig_script_dir = fileparts(orig_script_path);' in captured['contents']


### PR DESCRIPTION
## Summary
- expose `orig_script_path` and `orig_script_dir` in temporary MATLAB scripts
- surface failing MATLAB command with helpful hint
- pass new parameter from consumers
- cover failure case and update existing mocks

## Testing
- `pytest tests/test_video_intensity_error.py tests/test_load_intensities.py -q`