### PR TITLE
Fix video script path handling

### DIFF
--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -38,12 +38,13 @@ def load_intensities(
     if plume_type == "crimaldi":
         return get_intensities_from_crimaldi(path)
     if plume_type == "video":
-        script_contents = Path(path).read_text()
+        script_path = Path(path).resolve()
+        script_contents = script_path.read_text()
         return get_intensities_from_video_via_matlab(
             script_contents,
             matlab_exec_path,
-            work_dir=str(Path(path).parent),
-            orig_script_path=str(path),
+            work_dir=str(script_path.parent),
+            orig_script_path=str(script_path),
         )
 
     raise ValueError(f"Unknown plume_type: {plume_type}")

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -97,9 +97,10 @@ defines ``orig_script_path`` and ``orig_script_dir`` variables, the
 current directory is the original script folder. Prefer ``orig_script_dir``
 or an absolute path when locating configuration files.
 
-Save the script and pass **its full path** to the Python utility. The
-`TEMP_MAT_FILE_SUCCESS` line is used by `compare_intensity_stats.py` to locate the
-generated MAT-file.
+Save the script and pass its path to the Python utility. Relative paths are
+resolved to absolute ones, so both `video_script.m` and `/abs/path/video_script.m`
+work. The `TEMP_MAT_FILE_SUCCESS` line is used by
+`compare_intensity_stats.py` to locate the generated MAT-file.
 
 Run the comparison using the development environment created with `./setup_env.sh --dev`:
 


### PR DESCRIPTION
## Summary
- resolve MATLAB video script paths to an absolute path in `compare_intensity_stats.load_intensities`
- clarify in docs that relative script paths are acceptable

## Testing
- `pytest -q` *(fails: AGENTS_PER_CONDITION should be environment overridable)*