### PR TITLE
Fix orig_script_dir path handling

### DIFF
--- a/configs/paths.yaml.template
+++ b/configs/paths.yaml.template
@@ -7,7 +7,7 @@ project_root: "${PROJECT_DIR}"
 
 # Script directories
 scripts:
-  # Directory containing MATLAB analysis scripts (original_script_dir will point here)
+  # Directory containing MATLAB analysis scripts (orig_script_dir will point here)
   matlab: "${PROJECT_DIR}/scripts"
   # Directory containing Python modules and utilities
   python: "${PROJECT_DIR}/Code"

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -104,7 +104,7 @@ When processing video data, the system uses a MATLAB script (`process_smoke_vide
 1. **Path Configuration**: The system loads paths from `configs/paths.yaml`
 2. **Script Preparation**: The MATLAB script is copied to a temporary directory for execution
 3. **Path Variables**: The following variables are automatically set:
-   - `original_script_dir`: Points to the MATLAB scripts directory from `paths.yaml`
+   - `orig_script_dir`: Points to the MATLAB scripts directory from `paths.yaml`
    - `scriptDir`: Set to the temporary execution directory
 
 This ensures that while the script executes in a temporary directory, it can still locate all necessary dependencies through the configured paths.
@@ -113,7 +113,7 @@ This ensures that while the script executes in a temporary directory, it can sti
 
 ```yaml
 scripts:
-  matlab: "${PROJECT_DIR}/scripts"  # Original script directory (original_script_dir)
+  matlab: "${PROJECT_DIR}/scripts"  # Original script directory (orig_script_dir)
   python: "${PROJECT_DIR}/Code"     # Python modules
   temp: "${TMPDIR}/matlab_scripts"   # Temporary execution directory
 ```

--- a/process_smoke_video.m
+++ b/process_smoke_video.m
@@ -4,8 +4,9 @@
 % and save the results to a MAT file for further analysis.
 % 
 % The script uses the project's paths configuration (configs/paths.yaml) to manage
-% file locations. The 'original_script_dir' variable is automatically set to the
-% MATLAB scripts directory defined in the paths configuration.
+% file locations. The 'orig_script_dir' variable is automatically set by the
+% Python wrapper to the MATLAB scripts directory defined in the paths
+% configuration.
 % 
 % The script expects the following variables to be defined in the workspace:
 %   - video_path: Path to the input video file
@@ -14,12 +15,16 @@
 %   - frame_rate: Video frame rate in Hz (optional)
 %   - start_frame: First frame to process (optional, default=1)
 %   - end_frame: Last frame to process (optional, default=end of video)
-%   - original_script_dir: Automatically set by the Python wrapper to the
-%                         MATLAB scripts directory from paths.yaml configuration
+%   - orig_script_dir: Automatically set by the Python wrapper to the
+%                     MATLAB scripts directory from paths.yaml configuration
 
 % Add scripts directory to path
-scriptDir = fileparts(mfilename('fullpath'));
-addpath(fullfile(scriptDir, '..', 'scripts'));
+if exist('orig_script_dir', 'var')
+    projectRoot = orig_script_dir;
+else
+    projectRoot = fileparts(mfilename('fullpath'));
+end
+addpath(fullfile(projectRoot, 'scripts'));
 
 % Load paths configuration
 try


### PR DESCRIPTION
## Summary
- clarify orig_script_dir variable in docs and paths template
- use orig_script_dir in process_smoke_video
- update docs to point at orig_script_dir

## Testing
- `pytest -q` *(fails: reload() argument must be a module)*
- `bash test_paths_generation.sh`
- `bash test_paths_config.sh`
- `bash test_setup_dry_run.sh` *(fails: wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh)*