### PR TITLE
Remove video_file prefix

### DIFF
--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -48,9 +48,6 @@ def load_video_script_intensities(path: str, matlab_exec_path: str) -> np.ndarra
     with open(script_path, "r") as f:
         script_contents = f.read()
 
-    # Add the video file path to the MATLAB workspace
-    video_file = str(script_dir / "data" / "10302017_10cms_bounded_2.h5")
-    script_contents = f"video_file = '{video_file}';\n\n{script_contents}"
 
     return get_intensities_from_video_via_matlab(
         script_contents,

--- a/tests/test_compare_intensity_stats.py
+++ b/tests/test_compare_intensity_stats.py
@@ -180,3 +180,17 @@ def test_json_output_and_directory_creation(monkeypatch, tmp_path):
     assert data[0]['statistics']['mean'] == pytest.approx(stats_vid['mean'])
     assert data[1]['statistics']['mean'] == pytest.approx(stats_crim['mean'])
 
+
+
+def test_video_script_does_not_prepend_video_file(monkeypatch, tmp_path):
+    script = tmp_path / 'vid.m'
+    script.write_text("disp('x')")
+    captured = {}
+
+    def fake_get(script_contents, m='matlab', orig_script_path=None, **kwargs):
+        captured['script'] = script_contents
+        return np.array([1.0], dtype=float)
+
+    monkeypatch.setattr(cis, 'get_intensities_from_video_via_matlab', fake_get)
+    cis.load_video_script_intensities(str(script), 'matlab')
+    assert not captured['script'].startswith('video_file =')


### PR DESCRIPTION
## Summary
- ensure compare intensity stats doesn't pass a video_file assignment
- remove hard-coded video path from video script preprocessing

## Testing
- `python -m pytest tests/test_compare_intensity_stats.py -k test_video_script_does_not_prepend_video_file -vv` *(fails: collected 0 items / 1 skipped)*
