### PR TITLE
Add logging to load_plume_video

### DIFF
--- a/Code/load_plume_video.m
+++ b/Code/load_plume_video.m
@@ -44,6 +44,8 @@ while hasFrame(v)
     frameCount = frameCount + 1;
 end
 
+fprintf('%d x %d, %d frames\n', height, width, frameCount);
+
 % Reset the video reader to the beginning
 v = VideoReader(filename);
 

--- a/tests/test_load_plume_video_logging.m
+++ b/tests/test_load_plume_video_logging.m
@@ -1,0 +1,26 @@
+function tests = test_load_plume_video_logging
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir, 'tiny.avi'));
+    open(vw);
+    writeVideo(vw, uint8(zeros(2,3,1)));
+    writeVideo(vw, uint8(255*ones(2,3,1)));
+    close(vw);
+    testCase.TestData.video = fullfile(tmpDir, 'tiny.avi');
+    testCase.TestData.tmpDir = tmpDir;
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir, 's');
+end
+
+function testLogsDimensions(testCase)
+    out = evalc('load_plume_video(testCase.TestData.video, 1, 1)');
+    hasDims = ~isempty(regexp(out, '2\s*x\s*3', 'once'));
+    verifyTrue(testCase, hasDims, 'Output should include frame dimensions');
+end


### PR DESCRIPTION
## Summary
- add failing test expecting load_plume_video to log dimensions
- log first frame dimensions and frame count when loading plume video

## Testing
- `./setup_env.sh --dev` *(fails: wget unable to fetch Miniconda installer)*
- `conda run --prefix ./dev-env pytest -q` *(fails: conda command not found)*