### PR TITLE
Clarify debug usage in setup script

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -70,7 +70,8 @@ Options:
   --no-tests           Skip running tests after setup
   --skip-conda-lock    Skip conda-lock installation and lock file generation
   --help               Show this help message
-  --debug              Enable debug output
+
+Set DEBUG=1 to enable verbose logging.
 
 When sourced, the script will set up the environment but not run any installation steps.
 When executed directly, it will perform the full setup process.

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -17,6 +17,8 @@ def test_setup_env_script_contains_expected_commands():
     assert 'setup_utils.sh' in content
     assert 'conda-lock' in content
     assert 'log ' in content
+    assert '--debug' not in content
+    assert 'DEBUG=1' in content
 
 
 def test_setup_env_script_runs_idempotently():


### PR DESCRIPTION
## Summary
- clean up setup_env.sh usage text by removing the `--debug` flag
- advise using `DEBUG=1` for verbose logging
- update unit test expectations

## Testing
- `pytest tests/test_setup_env_script.py -q`
- `pytest -q` *(fails: MATLAB executable not found and other dependency issues)*