### PR TITLE
Handle single quotes in MATLAB work directory

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -161,7 +161,8 @@ def get_intensities_from_video_via_matlab(
                 ]
             )
         if work_dir is not None:
-            header_lines.append(f"cd('{work_dir}')")
+            safe_wd = work_dir.replace("'", "''")
+            header_lines.append(f"cd('{safe_wd}')")
         # Write the header lines and script contents
         header = "\n".join(header_lines) + "\n\n" if header_lines else ""
         script_file.write((header + script_contents).encode())


### PR DESCRIPTION
## Summary
- escape single quotes in the work directory before inserting into MATLAB `cd` command
- test MATLAB invocation when the working directory contains a quote

## Testing
- `ruff check Code/video_intensity.py`
- `pytest tests/test_get_intensities_from_video_via_matlab.py -q`