### PR TITLE
Update docs for MATLAB path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ For detailed instructions on environment setup and intensity comparison workflow
 source ./paths.sh
 ```
 
+`paths.sh` attempts to locate MATLAB automatically and sets `MATLAB_EXEC`.
+Set this variable yourself or use the `--matlab_exec` option to override the
+auto-detected path.
+
 With the environment active you can run MATLAB and Python scripts from the `Code` directory using the module syntax:
 
 ```bash

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -181,6 +181,16 @@ conda run --prefix ./dev-env python -m Code.compare_intensity_stats \
     ${MATLAB_EXEC:+--matlab_exec "$MATLAB_EXEC"}
 ```
 
+If MATLAB is not auto-detected or you want to use a specific version, supply the
+path explicitly:
+
+```bash
+conda run --prefix ./dev-env python -m Code.compare_intensity_stats \
+    CRIM data/10302017_10cms_bounded_2.h5 \
+    SMOKE video_script.m \
+    --matlab_exec /path/to/matlab
+```
+
 #### MATLAB Configuration
 
 The MATLAB configuration is stored in `configs/project_paths.yaml` under the `matlab` section. You can edit this file directly or let the system auto-detect MATLAB.


### PR DESCRIPTION
## Summary
- document how MATLAB is auto-detected via `paths.sh`
- show how to override MATLAB path with `--matlab_exec`

## Testing
- `pytest -k 'nothing' -q`
- `bash test_setup_dry_run.sh` *(fails: wget: unable to resolve host address)*