### PR TITLE
Add test for matlab exec fallback

### DIFF
--- a/tests/test_video_intensity_error.py
+++ b/tests/test_video_intensity_error.py
@@ -4,6 +4,10 @@ import tempfile
 import sys
 import importlib
 import types
+from pathlib import Path
+import builtins
+import glob
+import shutil
 
 import pytest
 
@@ -52,3 +56,36 @@ def test_error_message_contains_hint(monkeypatch, tmp_path):
 
     assert "orig_script_path = '/path/to/script.m';" in captured['contents']
     assert 'orig_script_dir = fileparts(orig_script_path);' in captured['contents']
+
+
+def test_matlab_exec_from_project_paths(tmp_path, monkeypatch):
+    yaml_path = tmp_path / "project_paths.yaml"
+    yaml_path.write_text('matlab:\n  executable: "/tmp/fake_matlab"\n')
+
+    orig_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        path_str = os.fspath(path)
+        if path_str.endswith("project_paths.yaml"):
+            return orig_open(yaml_path, *args, **kwargs)
+        return orig_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    orig_read_text = Path.read_text
+    monkeypatch.setattr(
+        Path,
+        "read_text",
+        lambda self, *a, **kw: yaml_path.read_text()
+        if str(self).endswith("project_paths.yaml")
+        else orig_read_text(self, *a, **kw),
+    )
+
+    monkeypatch.setattr(glob, "glob", lambda pattern: [])
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    monkeypatch.setattr(os.path, "isfile", lambda p: p == "/tmp/fake_matlab")
+    monkeypatch.setattr(os, "access", lambda p, m: p == "/tmp/fake_matlab")
+
+    vi = importlib.reload(importlib.import_module("Code.video_intensity"))
+    assert vi.find_matlab_executable() == "/tmp/fake_matlab"
+


### PR DESCRIPTION
## Summary
- extend video intensity error tests with YAML fallback scenario

## Testing
- `./setup_env.sh --dev` *(fails: wget unable to download Miniconda)*
- `conda run --prefix ./dev-env pytest tests/test_video_intensity_error.py` *(fails: `conda` not found)*