### PR TITLE
Add test for long video looping

### DIFF
--- a/tests/test_video_looping_behavior.m
+++ b/tests/test_video_looping_behavior.m
@@ -1,0 +1,26 @@
+function tests = test_video_looping_behavior
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir, 'loop.avi'));
+    open(vw);
+    writeVideo(vw, uint8(zeros(2,2,1)));
+    close(vw);
+    testCase.TestData.video = fullfile(tmpDir, 'loop.avi');
+    testCase.TestData.tmpDir = tmpDir;
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir, 's');
+end
+
+function testLoopingLongTrial(testCase)
+    cfg = load_config(fullfile('configs', 'my_complex_plume_loop2min.yaml'));
+    cfg.plume_video = testCase.TestData.video;
+    run_navigation_cfg(cfg);
+    assert(true);
+end


### PR DESCRIPTION
## Summary
- add `test_video_looping_behavior.m` to ensure looping works with long trial lengths

## Testing
- `bash setup_env.sh --dev --no-tests` *(fails: wget to repo.anaconda.com blocked)*
- `conda run --prefix ./dev-env pytest` *(fails: `conda` not found)*
- `conda run --prefix ./dev-env matlab -batch "results=runTests('tests'); exit(any([results.Failed]));"` *(fails: `conda` not found)*