### PR TITLE
Fix script path detection

### DIFF
--- a/tests/test_video_script_paths.py
+++ b/tests/test_video_script_paths.py
@@ -1,0 +1,9 @@
+import pathlib
+
+
+def test_video_script_uses_orig_script_dir():
+    content = pathlib.Path('video_script.m').read_text()
+    assert "if exist('orig_script_dir', 'var')" in content
+    assert "scriptDir = orig_script_dir;" in content
+    assert "fileparts(mfilename('fullpath'))" in content
+    assert "fprintf('Script directory:" in content

--- a/video_script.m
+++ b/video_script.m
@@ -1,5 +1,9 @@
 % Get the directory where this script is located
-scriptDir = fileparts(mfilename('fullpath'));
+if exist('orig_script_dir', 'var')
+    scriptDir = orig_script_dir;
+else
+    scriptDir = fileparts(mfilename('fullpath'));
+end
 fprintf('Script directory: %s\n', scriptDir);
 
 % Add necessary directories to MATLAB path


### PR DESCRIPTION
## Summary
- add failing test expecting video_script.m to use `orig_script_dir`
- modify video_script.m to respect `orig_script_dir`

## Testing
- `pytest -q tests/test_video_script_paths.py`
- `./setup_env.sh --dev` *(fails: wget not found or network)*