### PR TITLE
feat: load MATLAB module by version

### DIFF
--- a/configs/project_paths.yaml.template
+++ b/configs/project_paths.yaml.template
@@ -41,6 +41,8 @@ output:
   matlab_temp: "${TMPDIR:-/tmp}"
 
 # MATLAB configuration
+# matlab:
+#   module: "MATLAB/2023b"
 matlab:
   # Path to MATLAB executable (auto-detected if not specified)
   # executable: "/Applications/MATLAB_R2023a.app/bin/matlab"

--- a/paths.sh
+++ b/paths.sh
@@ -11,6 +11,9 @@ if [ "$SOURCED" -eq 0 ]; then
 else
     set -u  # Only fail on undefined variables when sourced
 fi
+MATLAB_VERSION=${MATLAB_VERSION:-2023b}
+MATLAB_MODULE=${MATLAB_MODULE:-MATLAB/$MATLAB_VERSION}
+
 
 # Function to safely exit or return
 safe_exit() {
@@ -48,7 +51,9 @@ find_matlab() {
     
     # Try module system if available
     if command -v module >/dev/null 2>&1; then
-        module load MATLAB 2>/dev/null || true
+        if ! module load "$MATLAB_MODULE" >/dev/null 2>&1; then
+            module load MATLAB >/dev/null 2>&1 || true
+        fi
         if command -v matlab >/dev/null 2>&1; then
             command -v matlab
             return 0


### PR DESCRIPTION
## Summary
- support MATLAB_VERSION and MATLAB_MODULE in `paths.sh`
- attempt to load the configured MATLAB module first
- show example module configuration in `project_paths.yaml.template`

## Testing
- `pytest tests/test_find_matlab_executable.py::test_find_matlab_executable_from_project_paths -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pre-commit --version` *(fails: command not found)*