### PR TITLE
Update docs on MATLAB module loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ source ./paths.sh
 `paths.sh` attempts to locate MATLAB automatically and sets `MATLAB_EXEC`.
 Set this variable yourself or use the `--matlab_exec` option to override the
 auto-detected path.
+If MATLAB is not found, `paths.sh` tries to load a module named
+`MATLAB/$MATLAB_VERSION` (or `MATLAB_MODULE` if set). Set these variables
+before sourcing to override the default.
 
 With the environment active you can run MATLAB and Python scripts from the `Code` directory using the module syntax:
 

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -23,7 +23,11 @@ This page describes how to characterise the intensity of individual odour plumes
    ```bash
    source ./paths.sh
    ```
-   This sets up all necessary environment variables and paths. You can run this anytime to update paths without rebuilding the conda environment.
+   This sets up all necessary environment variables and paths. If `matlab` isn't on your `PATH`,
+   `paths.sh` attempts to load a module named `MATLAB/$MATLAB_VERSION` (or the
+   value in `MATLAB_MODULE`). Set either variable before sourcing when working on
+   HPC clusters. You can run this anytime to update paths without rebuilding the
+   conda environment.
 
 3. **Running scripts**:
    Use the module form when executing Python scripts to ensure the repository root is on `sys.path`:


### PR DESCRIPTION
## Summary
- document module loading via `paths.sh` in README
- explain module-based MATLAB detection on HPC clusters in `intensity_comparison.md`

## Testing
- `./setup_env.sh --dev` *(fails: wget network access)*
- `conda run --prefix ./dev-env pytest -q` *(fails: command not found)*