### PR TITLE
feat: support MATLAB_EXEC override

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -51,10 +51,22 @@ def find_matlab_executable(user_path: Optional[str] = None) -> str:
 
     Raises:
         FileNotFoundError: If MATLAB executable cannot be found.
+
+    Notes
+    -----
+    If the environment variable ``MATLAB_EXEC`` points to an executable
+    file, it is used ahead of any auto-detection logic.
     """
     # Check user-provided path first
     if user_path and os.path.isfile(user_path) and os.access(user_path, os.X_OK):
         return user_path
+
+    # Environment variable override
+    env_exec = os.environ.get("MATLAB_EXEC")
+    if env_exec:
+        if os.path.isfile(env_exec) and os.access(env_exec, os.X_OK):
+            return env_exec
+        logger.debug("MATLAB_EXEC set but is not executable: %s", env_exec)
 
     # Look for configs/project_paths.yaml relative to repo root
     project_yaml = Path(__file__).resolve().parents[1] / "configs" / "project_paths.yaml"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ auto-detected path.
 If MATLAB is not found, `paths.sh` tries to load a module named
 `MATLAB/$MATLAB_VERSION` (or `MATLAB_MODULE` if set). Set these variables
 before sourcing to override the default.
+Python utilities such as `Code.video_intensity` also honour `MATLAB_EXEC` when
+it points to a valid executable.
 
 With the environment active you can run MATLAB and Python scripts from the `Code` directory using the module syntax:
 


### PR DESCRIPTION
## Summary
- search for MATLAB executable from `MATLAB_EXEC` env var in `find_matlab_executable`
- document the override in `README`

## Testing
- `./setup_env.sh --dev` *(fails: wget could not run without network)*
- `conda run --prefix ./dev-env pre-commit run --files Code/video_intensity.py README.md` *(fails: `conda` not found)*