### PR TITLE
docs: note automatic MATLAB module loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ If MATLAB is not found, `paths.sh` tries to load a module named
 `MATLAB/$MATLAB_VERSION` (or `MATLAB_MODULE` if set). Set these variables
 before sourcing to override the default.
 
+See [docs/intensity_comparison.md](docs/intensity_comparison.md#initial-setup)
+for a detailed explanation of the path setup process.
+
 With the environment active you can run MATLAB and Python scripts from the `Code` directory using the module syntax:
 
 ```bash

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -29,6 +29,11 @@ This page describes how to characterise the intensity of individual odour plumes
    HPC clusters. You can run this anytime to update paths without rebuilding the
    conda environment.
 
+   When MATLAB still cannot be found, the script runs `module load
+   MATLAB/$MATLAB_VERSION` automatically. The `MATLAB_VERSION` variable defaults
+   to `2023b` but can be set to any available module version before sourcing
+   `paths.sh`.
+
 3. **Running scripts**:
    Use the module form when executing Python scripts to ensure the repository root is on `sys.path`:
    ```bash


### PR DESCRIPTION
## Summary
- explain MATLAB module loading in `paths.sh`
- link from Quick Start to details in intensity comparison docs

## Testing
- `pre-commit run --files README.md docs/intensity_comparison.md` *(fails: command not found)*