### PR TITLE
Update path config handling

### DIFF
--- a/process_smoke_video.m
+++ b/process_smoke_video.m
@@ -4,7 +4,8 @@
 % and save the results to a MAT file for further analysis.
 % 
 % Paths are resolved via ``load_paths_config``, which reads the project's
-% ``configs/paths.yaml``. When invoked from Python, the wrapper sets
+% ``configs/project_paths.yaml`` (falling back to ``configs/paths.yaml``).
+% When invoked from Python, the wrapper sets
 % ``orig_script_dir`` to the MATLAB scripts directory specified in that
 % configuration. No ``video_path`` or ``output_path`` variables are required.
 %

--- a/scripts/load_paths_config.m
+++ b/scripts/load_paths_config.m
@@ -1,14 +1,19 @@
 function config = load_paths_config()
 % LOAD_PATHS_CONFIG Load the project paths configuration
-%   Loads the paths.yaml configuration file, expanding any environment variables.
-%   Returns a struct with the configuration values.
+%   Loads the project_paths.yaml configuration file (falling back to
+%   paths.yaml for backward compatibility), expanding any environment
+%   variables. Returns a struct with the configuration values.
 
     % Get the directory of the currently executing script
     scriptDir = fileparts(mfilename('fullpath'));
     projectRoot = fullfile(scriptDir, '..');
     
     % Path to the configuration file
-    configFile = fullfile(projectRoot, 'configs', 'paths.yaml');
+    configFile = fullfile(projectRoot, 'configs', 'project_paths.yaml');
+    if ~exist(configFile, 'file')
+        % Backward compatibility for older paths.yaml
+        configFile = fullfile(projectRoot, 'configs', 'paths.yaml');
+    end
     
     % Check if the file exists
     if ~exist(configFile, 'file')

--- a/scripts/setup_local_config.py
+++ b/scripts/setup_local_config.py
@@ -2,8 +2,8 @@
 """
 Set up local configuration files for the project.
 
-This script creates a local paths.yaml configuration file based on the template,
-with paths adjusted for the current environment.
+This script creates a local project_paths.yaml configuration file based on the
+template, with paths adjusted for the current environment.
 """
 
 import os
@@ -16,8 +16,8 @@ def main():
     project_root = Path(__file__).parent.parent.resolve()
 
     # Define template and output paths
-    template_path = project_root / "configs" / "paths.yaml.template"
-    output_path = project_root / "configs" / "paths.yaml"
+    template_path = project_root / "configs" / "project_paths.yaml.template"
+    output_path = project_root / "configs" / "project_paths.yaml"
 
     # Check if the file already exists
     if output_path.exists():

--- a/tests/test_load_paths_config_project_yaml.m
+++ b/tests/test_load_paths_config_project_yaml.m
@@ -1,0 +1,23 @@
+function tests = test_load_paths_config_project_yaml
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'scripts'));
+    addpath(fullfile(pwd, 'Code'));
+    cfgFile = fullfile('configs', 'project_paths.yaml');
+    copyfile(fullfile('configs', 'project_paths.yaml.template'), cfgFile);
+    testCase.TestData.cfgFile = cfgFile;
+end
+
+function teardownOnce(testCase)
+    if exist(testCase.TestData.cfgFile, 'file')
+        delete(testCase.TestData.cfgFile);
+    end
+end
+
+function testLoadsProjectPathsYaml(testCase)
+    cfg = load_paths_config();
+    verifyTrue(testCase, isstruct(cfg));
+    verifyTrue(testCase, isfield(cfg, 'scripts'));
+end


### PR DESCRIPTION
## Summary
- generate `configs/project_paths.yaml` with setup script
- load `project_paths.yaml` in MATLAB with fallback for old `paths.yaml`
- document updated config name in `process_smoke_video.m`
- test `load_paths_config` reads `project_paths.yaml`

## Testing
- `bash ./setup_env.sh --dev --no-tests --skip-conda-lock` *(fails: conda not found and network required)*
- `matlab -batch "addpath('scripts'); runtests('tests/test_load_paths_config_project_yaml.m'); exit"` *(fails: command not found)*