### PR TITLE
Improve error handling for smoke video processing

### DIFF
--- a/process_smoke_video.m
+++ b/process_smoke_video.m
@@ -12,6 +12,11 @@
 % Example (Python)
 %   >>> from Code.video_intensity import get_intensities_from_video_via_matlab
 %   >>> arr = get_intensities_from_video_via_matlab('process_smoke_video.m', 'matlab')
+%
+% Errors
+%   process_smoke_video:LoadPathsFailed   - load_paths_config raised an error
+%   process_smoke_video:LoadConfigFailed  - load_config raised an error
+%   process_smoke_video:LoadPlumeFailed   - load_plume_video raised an error
 
 % Add project directories to MATLAB path
 if exist('orig_script_dir', 'var')
@@ -41,14 +46,20 @@ end
 try
     paths = load_paths_config();
 catch ME
-    error('Failed to load paths configuration: %s', ME.message);
+    error('process_smoke_video:LoadPathsFailed', ...
+        'Failed to load paths configuration: %s', ME.message);
 end
 
 % Load plume configuration
 if ~exist(paths.configs.plume, 'file')
     error('Plume config file not found: %s', paths.configs.plume);
 end
-cfg = load_config(paths.configs.plume);
+try
+    cfg = load_config(paths.configs.plume);
+catch ME
+    error('process_smoke_video:LoadConfigFailed', ...
+        'Failed to load plume configuration: %s', ME.message);
+end
 
 % Process the smoke video
 if ~exist(paths.data.video, 'file')
@@ -57,7 +68,12 @@ if ~exist(paths.data.video, 'file')
 end
 
 fprintf('Processing video: %s\n', paths.data.video);
-plume = load_plume_video(paths.data.video, cfg.px_per_mm, cfg.frame_rate);
+try
+    plume = load_plume_video(paths.data.video, cfg.px_per_mm, cfg.frame_rate);
+catch ME
+    error('process_smoke_video:LoadPlumeFailed', ...
+        'Failed to load plume video: %s', ME.message);
+end
 
 % Validate plume dimensions
 if isempty(plume.data) || ndims(plume.data) ~= 3

--- a/tests/test_process_smoke_video.m
+++ b/tests/test_process_smoke_video.m
@@ -11,4 +11,6 @@ function testHelpContainsExample(~)
     assert(~isempty(txt), 'Help text is empty');
     assert(contains(lower(txt), 'get_intensities_from_video_via_matlab'), ...
         'Help text missing Python example call');
+    assert(contains(txt, 'process_smoke_video:LoadPathsFailed'), ...
+        'Help text missing error identifier');
 end

--- a/tests/test_process_smoke_video_load_errors.m
+++ b/tests/test_process_smoke_video_load_errors.m
@@ -1,0 +1,67 @@
+function tests = test_process_smoke_video_load_errors
+    tests = functiontests(localfunctions);
+end
+
+function setup(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    addpath(fullfile(pwd, 'scripts'));
+    tmpRoot = tempname;
+    mkdir(tmpRoot);
+    mkdir(fullfile(tmpRoot, 'configs'));
+    mkdir(fullfile(tmpRoot, 'Code'));
+    mkdir(fullfile(tmpRoot, 'scripts'));
+    copyfile('process_smoke_video.m', tmpRoot);
+    testCase.TestData.tmpRoot = tmpRoot;
+end
+
+function teardown(testCase)
+    rmdir(testCase.TestData.tmpRoot, 's');
+end
+
+function testPathsLoadFailure(testCase)
+    tmpRoot = testCase.TestData.tmpRoot;
+    fid = fopen(fullfile(tmpRoot, 'configs', 'project_paths.yaml'), 'w'); fclose(fid);
+    fid = fopen(fullfile(tmpRoot, 'scripts', 'load_paths_config.m'), 'w');
+    fprintf(fid, 'function cfg = load_paths_config\nerror(''stub:fail'',''boom'');\nend');
+    fclose(fid);
+    orig_script_dir = tmpRoot; %#ok<NASGU>
+    f = @() run(fullfile(tmpRoot, 'process_smoke_video.m'));
+    verifyError(testCase, f, 'process_smoke_video:LoadPathsFailed');
+end
+
+function testConfigLoadFailure(testCase)
+    tmpRoot = testCase.TestData.tmpRoot;
+    pathsFile = fullfile(tmpRoot, 'configs', 'project_paths.yaml');
+    fid = fopen(pathsFile, 'w');
+    fprintf(fid, 'data:\n  video: %s\n', fullfile(tmpRoot, 'dummy.avi'));
+    fprintf(fid, 'configs:\n  plume: %s\n', fullfile(tmpRoot, 'configs', 'plume.yaml'));
+    fprintf(fid, 'output:\n  matlab_temp: %s\n', tmpRoot);
+    fclose(fid);
+    fid = fopen(fullfile(tmpRoot, 'configs', 'plume.yaml'), 'w'); fclose(fid);
+    fid = fopen(fullfile(tmpRoot, 'Code', 'load_config.m'), 'w');
+    fprintf(fid, 'function cfg = load_config(~)\nerror(''stub:fail'',''boom'');\nend');
+    fclose(fid);
+    orig_script_dir = tmpRoot; %#ok<NASGU>
+    f = @() run(fullfile(tmpRoot, 'process_smoke_video.m'));
+    verifyError(testCase, f, 'process_smoke_video:LoadConfigFailed');
+end
+
+function testPlumeLoadFailure(testCase)
+    tmpRoot = testCase.TestData.tmpRoot;
+    pathsFile = fullfile(tmpRoot, 'configs', 'project_paths.yaml');
+    fid = fopen(pathsFile, 'w');
+    fprintf(fid, 'data:\n  video: %s\n', fullfile(tmpRoot, 'dummy.avi'));
+    fprintf(fid, 'configs:\n  plume: %s\n', fullfile(tmpRoot, 'configs', 'plume.yaml'));
+    fprintf(fid, 'output:\n  matlab_temp: %s\n', tmpRoot);
+    fclose(fid);
+    fid = fopen(fullfile(tmpRoot, 'configs', 'plume.yaml'), 'w');
+    fprintf(fid, 'px_per_mm: 1\nframe_rate: 1\n');
+    fclose(fid);
+    fid = fopen(fullfile(tmpRoot, 'dummy.avi'), 'w'); fclose(fid);
+    fid = fopen(fullfile(tmpRoot, 'Code', 'load_plume_video.m'), 'w');
+    fprintf(fid, 'function plume = load_plume_video(varargin)\nerror(''stub:fail'',''boom'');\nend');
+    fclose(fid);
+    orig_script_dir = tmpRoot; %#ok<NASGU>
+    f = @() run(fullfile(tmpRoot, 'process_smoke_video.m'));
+    verifyError(testCase, f, 'process_smoke_video:LoadPlumeFailed');
+end


### PR DESCRIPTION
## Summary
- document new error identifiers in `process_smoke_video.m`
- rethrow `load_paths_config`, `load_config` and `load_plume_video` failures with specific identifiers
- assert help text includes the new identifier
- add regression tests for each failure mode

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `bash test_setup_dry_run.sh` *(fails: wget: unable to resolve host address)*