### PR TITLE
Add explicit rethrow logic for smoke video helpers

### DIFF
--- a/process_smoke_video.m
+++ b/process_smoke_video.m
@@ -18,6 +18,7 @@
 %   process_smoke_video:LoadPathsFailed   - load_paths_config raised an error
 %   process_smoke_video:LoadConfigFailed  - load_config raised an error
 %   process_smoke_video:LoadPlumeFailed   - load_plume_video raised an error
+%   Errors from these helpers are rethrown with the identifiers above.
 
 % Add project directories to MATLAB path
 if exist('orig_script_dir', 'var')
@@ -47,8 +48,10 @@ end
 try
     paths = load_paths_config();
 catch ME
-    error('process_smoke_video:LoadPathsFailed', ...
+    newME = MException('process_smoke_video:LoadPathsFailed', ...
         'Failed to load paths configuration: %s', ME.message);
+    newME = addCause(newME, ME);
+    throw(newME);
 end
 
 % Load plume configuration
@@ -58,8 +61,10 @@ end
 try
     cfg = load_config(paths.configs.plume);
 catch ME
-    error('process_smoke_video:LoadConfigFailed', ...
+    newME = MException('process_smoke_video:LoadConfigFailed', ...
         'Failed to load plume configuration: %s', ME.message);
+    newME = addCause(newME, ME);
+    throw(newME);
 end
 
 % Process the smoke video
@@ -72,8 +77,10 @@ fprintf('Processing video: %s\n', paths.data.video);
 try
     plume = load_plume_video(paths.data.video, cfg.px_per_mm, cfg.frame_rate);
 catch ME
-    error('process_smoke_video:LoadPlumeFailed', ...
+    newME = MException('process_smoke_video:LoadPlumeFailed', ...
         'Failed to load plume video: %s', ME.message);
+    newME = addCause(newME, ME);
+    throw(newME);
 end
 
 % Validate plume dimensions

--- a/tests/test_process_smoke_video.m
+++ b/tests/test_process_smoke_video.m
@@ -13,4 +13,6 @@ function testHelpContainsExample(~)
         'Help text missing Python example call');
     assert(contains(txt, 'process_smoke_video:LoadPathsFailed'), ...
         'Help text missing error identifier');
+    assert(contains(txt, 'rethrow'), ...
+        'Help text missing rethrow note');
 end

--- a/tests/test_process_smoke_video_load_errors.m
+++ b/tests/test_process_smoke_video_load_errors.m
@@ -26,7 +26,13 @@ function testPathsLoadFailure(testCase)
     fclose(fid);
     orig_script_dir = tmpRoot; %#ok<NASGU>
     f = @() run(fullfile(tmpRoot, 'process_smoke_video.m'));
-    verifyError(testCase, f, 'process_smoke_video:LoadPathsFailed');
+    try
+        f();
+        verifyFail(testCase, 'Expected error');
+    catch ME
+        verifyEqual(testCase, ME.identifier, 'process_smoke_video:LoadPathsFailed');
+        verifyEqual(testCase, ME.cause{1}.identifier, 'stub:fail');
+    end
 end
 
 function testConfigLoadFailure(testCase)
@@ -43,7 +49,13 @@ function testConfigLoadFailure(testCase)
     fclose(fid);
     orig_script_dir = tmpRoot; %#ok<NASGU>
     f = @() run(fullfile(tmpRoot, 'process_smoke_video.m'));
-    verifyError(testCase, f, 'process_smoke_video:LoadConfigFailed');
+    try
+        f();
+        verifyFail(testCase, 'Expected error');
+    catch ME
+        verifyEqual(testCase, ME.identifier, 'process_smoke_video:LoadConfigFailed');
+        verifyEqual(testCase, ME.cause{1}.identifier, 'stub:fail');
+    end
 end
 
 function testPlumeLoadFailure(testCase)
@@ -63,5 +75,11 @@ function testPlumeLoadFailure(testCase)
     fclose(fid);
     orig_script_dir = tmpRoot; %#ok<NASGU>
     f = @() run(fullfile(tmpRoot, 'process_smoke_video.m'));
-    verifyError(testCase, f, 'process_smoke_video:LoadPlumeFailed');
+    try
+        f();
+        verifyFail(testCase, 'Expected error');
+    catch ME
+        verifyEqual(testCase, ME.identifier, 'process_smoke_video:LoadPlumeFailed');
+        verifyEqual(testCase, ME.cause{1}.identifier, 'stub:fail');
+    end
 end


### PR DESCRIPTION
## Summary
- document custom error identifiers in `process_smoke_video`
- rethrow errors from `load_paths_config`, `load_config`, and `load_plume_video`
- extend smoke video tests to check rethrow note and error causes

## Testing
- `./setup_env.sh --dev` *(fails: conda download blocked)*
- `matlab -batch "disp('hello')"` *(fails: command not found)*