### PR TITLE
Add test for pytest in environment

### DIFF
--- a/tests/test_environment_includes_pytest.py
+++ b/tests/test_environment_includes_pytest.py
@@ -1,0 +1,27 @@
+try:
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback parser
+    yaml = None
+
+
+def _parse_deps() -> list[str]:
+    if yaml is not None:
+        with open("environment.yml") as f:
+            env = yaml.safe_load(f)
+            if isinstance(env, dict):
+                entries = env.get("dependencies", [])
+                if isinstance(entries, list):
+                    return [str(d).split("=")[0] for d in entries]
+            return []
+    deps: list[str] = []
+    with open("environment.yml") as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith("- "):
+                deps.append(line[2:].split("=")[0])
+    return deps
+
+
+def test_environment_includes_pytest() -> None:
+    dependencies = _parse_deps()
+    assert "pytest" in dependencies


### PR DESCRIPTION
## Summary
- ensure `pytest` dependency is listed in `environment.yml`

## Testing
- `ruff check tests/test_environment_includes_pytest.py`
- `black tests/test_environment_includes_pytest.py`
- `isort tests/test_environment_includes_pytest.py`
- `mypy --strict tests/test_environment_includes_pytest.py`
- `interrogate -v tests/test_environment_includes_pytest.py` *(fails: command not found)*
- `pytest tests/test_environment_includes_pytest.py -q`