### PR TITLE
Fix quoting test

### DIFF
--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -165,7 +165,8 @@ def test_workdir_with_single_quote(monkeypatch, tmp_path):
     )
     assert np.array_equal(arr, np.array([7], dtype=np.float32))
 
-    expected_cd = f"cd('{work_dir.replace("'", "''")}')"
+    escaped = work_dir.replace("'", "''")
+    expected_cd = f"cd('{escaped}')"
     assert expected_cd in captured["script_contents"]
     assert not Path(captured["script_path"]).exists()
     assert not mat_file.exists()


### PR DESCRIPTION
## Summary
- update test to store escaped directory variable before building expected cd command
- compile tests to ensure syntax is valid

## Testing
- `python -m py_compile tests/test_get_intensities_from_video_via_matlab.py`
- `python -m py_compile Code/video_intensity.py`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*