### PR TITLE
Fix numpy patching via monkeypatch

### DIFF
--- a/tests/test_load_intensities_work_dir.py
+++ b/tests/test_load_intensities_work_dir.py
@@ -1,32 +1,47 @@
+import importlib
 import os
 import sys
-import importlib
 import types
-
-fake_np = types.SimpleNamespace(array=lambda x: x)
-fake_h5py = types.SimpleNamespace(File=lambda *a, **k: None)
-fake_scipy = types.SimpleNamespace(io=types.SimpleNamespace(loadmat=lambda p: {"all_intensities": [1]}))
-sys.modules['numpy'] = fake_np
-sys.modules['h5py'] = fake_h5py
-sys.modules['scipy'] = fake_scipy
-sys.modules['scipy.io'] = fake_scipy.io
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from Code import compare_intensity_stats as cis
 
 def test_work_dir_passed_to_video_loader(monkeypatch, tmp_path):
-    mfile = tmp_path / 'nested' / 'script.m'
+    fake_np = types.SimpleNamespace(array=lambda x: x)
+    fake_h5py = types.SimpleNamespace(File=lambda *a, **k: None)
+    fake_scipy = types.SimpleNamespace(
+        io=types.SimpleNamespace(loadmat=lambda p: {"all_intensities": [1]})
+    )
+    fake_yaml = types.SimpleNamespace(
+        safe_load=lambda *a, **k: {},
+        safe_dump=lambda *a, **k: None,
+    )
+    monkeypatch.setitem(sys.modules, "numpy", fake_np)
+    monkeypatch.setitem(sys.modules, "h5py", fake_h5py)
+    monkeypatch.setitem(sys.modules, "scipy", fake_scipy)
+    monkeypatch.setitem(sys.modules, "scipy.io", fake_scipy.io)
+    monkeypatch.setitem(sys.modules, "yaml", fake_yaml)
+    cis = importlib.reload(importlib.import_module("Code.compare_intensity_stats"))
+    mfile = tmp_path / "nested" / "script.m"
     mfile.parent.mkdir()
     mfile.write_text('disp("hi")')
     captured = {}
 
-    def fake_video(contents, matlab_exec_path='matlab', px_per_mm=None, frame_rate=None, work_dir=None, orig_script_path=None):
-        captured['work_dir'] = work_dir
+    def fake_video(
+        contents,
+        matlab_exec_path="matlab",
+        px_per_mm=None,
+        frame_rate=None,
+        work_dir=None,
+        orig_script_path=None,
+    ):
+        captured["work_dir"] = work_dir
         return [1]
 
-    monkeypatch.setattr(cis, 'get_intensities_from_crimaldi', lambda *a, **k: [_ for _ in ()])
-    monkeypatch.setattr(cis, 'get_intensities_from_video_via_matlab', fake_video)
+    monkeypatch.setattr(
+        cis, "get_intensities_from_crimaldi", lambda *a, **k: [_ for _ in ()]
+    )
+    monkeypatch.setattr(cis, "get_intensities_from_video_via_matlab", fake_video)
 
-    cis.load_intensities(str(mfile), plume_type='video')
-    assert captured['work_dir'] == str(mfile.parent)
+    cis.load_intensities(str(mfile), plume_type="video")
+    assert captured["work_dir"] == str(mfile.parent)

--- a/tests/test_video_work_dir_no_numpy.py
+++ b/tests/test_video_work_dir_no_numpy.py
@@ -5,53 +5,58 @@ import subprocess
 import tempfile
 import types
 
-import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-# Insert fake numpy and scipy modules so Code.video_intensity imports
+
 class DummyArray(list):
-    def flatten(self):
+    def flatten(self) -> "DummyArray":
         return self
 
-fake_np = types.SimpleNamespace(asarray=lambda x: DummyArray(x))
+
 def fake_loadmat(path):
     return {"all_intensities": [1]}
-
-fake_scipy_io = types.SimpleNamespace(loadmat=fake_loadmat)
-sys.modules['numpy'] = fake_np
-sys.modules['scipy'] = types.SimpleNamespace(io=fake_scipy_io)
-sys.modules['scipy.io'] = fake_scipy_io
-
-vi = importlib.reload(importlib.import_module('Code.video_intensity'))
 
 
 def test_work_dir_inserts_cd(monkeypatch, tmp_path):
     captured = {}
 
+    fake_np = types.SimpleNamespace(asarray=lambda x: DummyArray(x))
+    fake_scipy_io = types.SimpleNamespace(loadmat=fake_loadmat)
+    fake_h5py = types.SimpleNamespace(File=lambda *a, **k: None)
+    fake_yaml = types.SimpleNamespace(
+        safe_load=lambda *a, **k: {}, safe_dump=lambda *a, **k: None
+    )
+    monkeypatch.setitem(sys.modules, "numpy", fake_np)
+    monkeypatch.setitem(sys.modules, "scipy", types.SimpleNamespace(io=fake_scipy_io))
+    monkeypatch.setitem(sys.modules, "scipy.io", fake_scipy_io)
+    monkeypatch.setitem(sys.modules, "h5py", fake_h5py)
+    monkeypatch.setitem(sys.modules, "yaml", fake_yaml)
+    vi = importlib.reload(importlib.import_module("Code.video_intensity"))
+    monkeypatch.setattr(vi, "find_matlab_executable", lambda p=None: p or "matlab")
+
     orig_ntf = tempfile.NamedTemporaryFile
 
     def fake_ntf(*args, **kwargs):
-        kwargs.setdefault('delete', False)
+        kwargs.setdefault("delete", False)
         fh = orig_ntf(*args, **kwargs)
-        captured['path'] = fh.name
+        captured["path"] = fh.name
         return fh
 
-    def fake_run(cmd, capture_output, text):
-        with open(captured['path']) as fh:
-            captured['contents'] = fh.read()
-        mat_file = tmp_path / 'dummy.mat'
-        mat_file.write_bytes(b'')
+    def fake_run(cmd, capture_output, text, **kwargs):
+        with open(captured["path"]) as fh:
+            captured["contents"] = fh.read()
+        mat_file = tmp_path / "dummy.mat"
+        mat_file.write_bytes(b"")
         return subprocess.CompletedProcess(
-            cmd,
-            0,
-            stdout=f'TEMP_MAT_FILE_SUCCESS:{mat_file}\n',
-            stderr=''
+            cmd, 0, stdout=f"TEMP_MAT_FILE_SUCCESS:{mat_file}\n", stderr=""
         )
 
-    monkeypatch.setattr(tempfile, 'NamedTemporaryFile', fake_ntf)
-    monkeypatch.setattr(subprocess, 'run', fake_run)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", fake_ntf)
+    monkeypatch.setattr(subprocess, "run", fake_run)
 
-    arr = vi.get_intensities_from_video_via_matlab('disp("hi")', 'matlab', work_dir=str(tmp_path))
+    arr = vi.get_intensities_from_video_via_matlab(
+        'disp("hi")', "matlab", work_dir=str(tmp_path)
+    )
     assert arr == [1]
-    assert captured['contents'].splitlines()[0] == f"cd('{tmp_path}')"
+    assert captured["contents"].splitlines()[0] == f"cd('{tmp_path}')"


### PR DESCRIPTION
## Summary
- clean up numpy fake modules in tests
- switch to using monkeypatch fixture inside tests

## Testing
- `ruff check tests/test_video_work_dir_no_numpy.py tests/test_load_intensities_work_dir.py`
- `black tests/test_video_work_dir_no_numpy.py tests/test_load_intensities_work_dir.py --check`
- `pytest -q tests/test_video_work_dir_no_numpy.py tests/test_load_intensities_work_dir.py`