### PR TITLE
Fix MATLAB path usage

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -211,7 +211,7 @@ def get_intensities_from_video_via_matlab(
         # Create a safe path for MATLAB
         safe_path = script_file.name.replace("'", "''")
         matlab_cmd = [
-            matlab_exec_path,
+            matlab_path,
             "-nosplash",
             "-nodesktop",
             "-noFigureWindows",


### PR DESCRIPTION
## Summary
- ensure MATLAB path returned by `find_matlab_executable` is used when launching scripts
- test subprocess command uses discovered MATLAB path

## Testing
- `ruff check tests/test_get_intensities_from_video_via_matlab.py Code/video_intensity.py`
- `black --check tests/test_get_intensities_from_video_via_matlab.py Code/video_intensity.py`
- `pytest tests/test_get_intensities_from_video_via_matlab.py -k command_uses_found_matlab_executable -vv` *(fails: numpy missing)*
- `./setup_env.sh --dev` *(fails: network unreachable)*
- `pre-commit` *(fails: command not found)*