### PR TITLE
Ensure numpy in setup script

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -274,6 +274,19 @@ setup_environment() {
   
   log SUCCESS "Base environment './${LOCAL_ENV_DIR}' created/updated successfully."
 
+  # Verify NumPy is available in the environment
+  if ! conda run --prefix "./${LOCAL_ENV_DIR}" python -c "import numpy" >/dev/null 2>&1; then
+    log INFO "NumPy not found, installing into ${LOCAL_ENV_DIR}..."
+    if ! conda run --prefix "./${LOCAL_ENV_DIR}" conda install -y numpy; then
+      log WARNING "conda install numpy failed, attempting pip fallback"
+      if ! conda run --prefix "./${LOCAL_ENV_DIR}" python -m pip install numpy; then
+        log ERROR "Failed to install NumPy via conda or pip"
+        return 1
+      fi
+    fi
+    log SUCCESS "NumPy installed successfully"
+  fi
+
   # Install development dependencies and set up pre-commit if --dev flag is present
   if [ "$INSTALL_DEV_EXTRAS" -eq 1 ]; then
     setup_development_environment

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -123,3 +123,10 @@ fi
     assert "Unknown option" not in output
     assert "conda-lock lock" not in output
 
+
+def test_setup_env_checks_numpy_presence():
+    """Script should verify numpy import after environment creation."""
+    with open('setup_env.sh') as f:
+        content = f.read()
+    assert 'conda run --prefix "./${LOCAL_ENV_DIR}" python -c "import numpy"' in content
+


### PR DESCRIPTION
## Summary
- verify numpy import after conda env creation in `setup_env.sh`
- fallback to install numpy with conda or pip
- test that script includes numpy import check

## Testing
- `python -m pytest tests/test_setup_env_script.py::test_setup_env_checks_numpy_presence -q`
- `pytest -q` *(fails: AGENTS_PER_CONDITION should be environment overridable, etc.)*
