### PR TITLE
Update env dir to dev_env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ ENV/
 env.bak/
 venv.bak/
 external/
-dev-env/
+dev_env/
 
 # IDE specific files
 .idea/

--- a/Code/data_discovery.py
+++ b/Code/data_discovery.py
@@ -5,7 +5,7 @@ Examples
 Run discovery using the project environment::
 
     ./setup_env.sh --dev
-    conda run --prefix ./dev-env python - <<'PY'
+    conda run --prefix ./dev_env python - <<'PY'
     from Code.data_discovery import discover_processed_data
     cfg = {'data_paths': {'processed_base_dirs': ['data/processed']}}
     list(discover_processed_data(cfg))

--- a/Code/intensity_stats.py
+++ b/Code/intensity_stats.py
@@ -5,7 +5,7 @@ Examples
 Run the CLI inside the project environment::
 
     ./setup_env.sh --dev
-    conda run --prefix ./dev-env python -m Code.intensity_stats plumeA intensities.txt
+    conda run --prefix ./dev_env python -m Code.intensity_stats plumeA intensities.txt
 """
 
 from __future__ import annotations

--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -13,7 +13,7 @@ Examples
 Create the development environment and run a short Python snippet inside it::
 
     ./setup_env.sh --dev
-    conda run --prefix ./dev-env python - <<'PY'
+    conda run --prefix ./dev_env python - <<'PY'
     from Code.video_intensity import get_intensities_from_video_via_matlab
     arr = get_intensities_from_video_via_matlab('myscript.m', 'matlab')
     print(arr.shape)

--- a/README.md
+++ b/README.md
@@ -52,16 +52,16 @@ for a detailed explanation of the path setup process.
 With the environment active you can run MATLAB and Python scripts from the `Code` directory using the module syntax:
 
 ```bash
-conda run --prefix ./dev-env python -m Code.some_script
+conda run --prefix ./dev_env python -m Code.some_script
 ```
 
 ## Step-by-Step
 
 1 and 2 are only *as required* -- check if there's evidence they've already run
 
-1. Run `./setup_env.sh --dev` to create `./dev-env`.
+1. Run `./setup_env.sh --dev` to create `./dev_env`.
 2. Source `./paths.sh` to generate `configs/project_paths.yaml` and detect MATLAB. `paths.sh` uses this file and falls back to default paths when `yq` is missing.
-3. Execute `conda run --prefix ./dev-env python -m Code.compare_intensity_stats`.
+3. Execute `conda run --prefix ./dev_env python -m Code.compare_intensity_stats`.
 
 ## Directory Overview
 

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -14,9 +14,9 @@ This page describes how to characterise the intensity of individual odour plumes
 
 ## Step-by-Step
 
-1. Run `./setup_env.sh --dev` to create `./dev-env`.
+1. Run `./setup_env.sh --dev` to create `./dev_env`.
 2. Source `./paths.sh` to generate `configs/project_paths.yaml` and detect MATLAB. The script uses this file and falls back to default paths when `yq` is missing.
-3. Execute `conda run --prefix ./dev-env python -m Code.compare_intensity_stats`.
+3. Execute `conda run --prefix ./dev_env python -m Code.compare_intensity_stats`.
 
 ## Initial Setup
 
@@ -70,7 +70,7 @@ Key paths are available as environment variables after sourcing `paths.sh`:
 To obtain intensity statistics for a single plume, use the `analyze_crimaldi_data.py` script. The command prints summary statistics such as the minimum, maximum and percentile values.
 
 ```bash
-conda run --prefix ./dev-env python -m Code.analyze_crimaldi_data data/raw/plume1.hdf5
+conda run --prefix ./dev_env python -m Code.analyze_crimaldi_data data/raw/plume1.hdf5
 ```
 
 Expected output:
@@ -91,19 +91,19 @@ Std: 0.8
 Use the `compare_intensity_stats.py` script with multiple input files. The script computes cross‑dataset statistics and produces a plot showing the distribution of intensities.
 
 ```bash
-conda run --prefix ./dev-env python -m Code.compare_intensity_stats data/raw/plume1.hdf5 data/raw/plume2.hdf5
+conda run --prefix ./dev_env python -m Code.compare_intensity_stats data/raw/plume1.hdf5 data/raw/plume2.hdf5
 ```
 
 To see the mean and median differences when exactly two datasets are provided, add the `--diff` option:
 
 ```bash
-conda run --prefix ./dev-env python -m Code.compare_intensity_stats A data/raw/plume1.hdf5 B data/raw/plume2.hdf5 --diff
+conda run --prefix ./dev_env python -m Code.compare_intensity_stats A data/raw/plume1.hdf5 B data/raw/plume2.hdf5 --diff
 ```
 
 To save the computed statistics, provide a path via `--csv` or `--json`:
 
 ```bash
-conda run --prefix ./dev-env python -m Code.compare_intensity_stats A data/raw/plume1.hdf5 B data/raw/plume2.hdf5 --json results/stats.json
+conda run --prefix ./dev_env python -m Code.compare_intensity_stats A data/raw/plume1.hdf5 B data/raw/plume2.hdf5 --json results/stats.json
 ```
 The JSON file contains a list of objects with ``identifier`` and ``statistics`` keys for each plume.
 
@@ -146,7 +146,7 @@ Follow these steps to run a simple comparison using the bundled datasets.
 3. **Run the comparison**
 
    ```bash
-   conda run --prefix ./dev-env python -m Code.compare_intensity_stats \
+   conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
        CRIM data/10302017_10cms_bounded_2.h5 \
        SMOKE process_smoke_video.m
    ```
@@ -181,7 +181,7 @@ The `process_smoke_video.m` script is designed to work with the smoke video data
 Run the comparison using the development environment:
 
 ```bash
-conda run --prefix ./dev-env python -m Code.compare_intensity_stats \
+conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
     CRIM data/10302017_10cms_bounded_2.h5 \
     SMOKE process_smoke_video.m
 ```
@@ -201,7 +201,7 @@ ERROR: MATLAB executable not found. Set $MATLAB_EXEC or use --matlab_exec
 For example, running the command without a detected MATLAB might look like:
 
 ```bash
-conda run --prefix ./dev-env python -m Code.compare_intensity_stats \
+conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
     CRIM data/10302017_10cms_bounded_2.h5 \
     SMOKE process_smoke_video.m
 ```
@@ -215,7 +215,7 @@ export MATLAB_EXEC=/path/to/matlab
 or pass it explicitly:
 
 ```bash
-conda run --prefix ./dev-env python -m Code.compare_intensity_stats \
+conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
     CRIM data/10302017_10cms_bounded_2.h5 \
     SMOKE process_smoke_video.m \
     --matlab_exec /path/to/matlab
@@ -227,7 +227,7 @@ Crimaldi dataset with a smoke plume script. The helper reads the MATLAB path
 from `configs/project_paths.yaml` if available.
 
 ```bash
-conda run --prefix ./dev-env python scripts/run_intensity_batch.py \
+conda run --prefix ./dev_env python scripts/run_intensity_batch.py \
     data/10302017_10cms_bounded_2.h5 process_smoke_video.m
 ```
 
@@ -267,7 +267,7 @@ Use the `compare_intensity_stats.py` script to process video data. The MATLAB co
 source ./paths.sh
 
 # Then run the comparison
-conda run --prefix ./dev-env python -m Code.compare_intensity_stats \
+conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
     CRIM data/10302017_10cms_bounded_2.h5 \
     SMOKE video_script.m \
     ${MATLAB_EXEC:+--matlab_exec "$MATLAB_EXEC"}
@@ -277,7 +277,7 @@ If MATLAB is not auto-detected or you want to use a specific version, supply the
 path explicitly:
 
 ```bash
-conda run --prefix ./dev-env python -m Code.compare_intensity_stats \
+conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
     CRIM data/10302017_10cms_bounded_2.h5 \
     SMOKE video_script.m \
     --matlab_exec /path/to/matlab

--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -109,7 +109,7 @@ matlab $MATLAB_OPTIONS -r "run('$MATLAB_SCRIPT');" || { echo "MATLAB failed"; ex
 
 ########################  export CSV/JSON  #########################
 # Use conda run -p for any Python commands
-# Example: conda run -p ./dev-env python script.py
+# Example: conda run -p ./dev_env python script.py
 
 # MATLAB-based export (kept as is since it's MATLAB-specific)
 EXPORT_SCRIPT=$(mktemp -p "$TMPDIR" export_job_XXXX.m)
@@ -123,6 +123,6 @@ echo "exit" >>"$EXPORT_SCRIPT"
 echo "Job finished successfully."
 
 # Example of how to run Python scripts with the conda environment:
-# if [ -d "./dev-env" ]; then
-#     conda run -p ./dev-env python your_script.py --input input_file --output output_dir
+# if [ -d "./dev_env" ]; then
+#     conda run -p ./dev_env python your_script.py --input input_file --output output_dir
 # fi

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -52,7 +52,7 @@ fi
 
 # --- Configuration ---
 # Readonly constants for better maintainability
-readonly LOCAL_ENV_DIR="dev-env"
+readonly LOCAL_ENV_DIR="dev_env"
 readonly BASE_ENV_FILE="environment.yml"
 readonly DEV_ENV_FILE="dev-environment.yml"
 readonly PRE_COMMIT_TEMPLATE=".pre-commit-config.yaml.template"

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -21,6 +21,13 @@ def test_setup_env_script_contains_expected_commands():
     assert 'DEBUG=1' in content
 
 
+def test_setup_env_uses_dev_env_directory():
+    """Ensure the script references the dev_env directory."""
+    with open('setup_env.sh') as f:
+        content = f.read()
+    assert 'dev_env' in content
+
+
 def test_setup_env_script_runs_idempotently():
     if shutil.which('conda') is None:
         pytest.skip('conda not available')


### PR DESCRIPTION
## Summary
- rename LOCAL_ENV_DIR to `dev_env`
- document new environment directory in README and docs
- replace examples using `dev-env`
- ignore `dev_env/` folder
- check for `dev_env` text in setup script

## Testing
- `pytest tests/test_setup_env_script.py::test_setup_env_uses_dev_env_directory -q`