### PR TITLE
Fix duplicate pyyaml entry

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,3 @@ dependencies:
   - pytest
   - matplotlib
   - scipy
-  - pyyaml


### PR DESCRIPTION
## Summary
- remove redundant pyyaml from environment.yml

## Testing
- `pre-commit run --files environment.yml` *(fails: command not found)*