### PR TITLE
Add safety check for active env

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -185,6 +185,14 @@ ensure_conda_lock() {
     fi
 }
 
+check_not_in_active_env() {
+    local env_path="$(cd "./${LOCAL_ENV_DIR}" && pwd)"
+    if [ "${CONDA_PREFIX:-}" = "$env_path" ]; then
+        log ERROR "dev_env is currently active. Please 'conda deactivate' before running setup_env.sh"
+        return 1
+    fi
+}
+
 # --- Main setup function ---
 setup_environment() {
   section "Starting environment setup"
@@ -257,6 +265,11 @@ setup_environment() {
       run_command_verbose conda-lock lock -f "${BASE_ENV_FILE}" -p "${PLATFORM}" --lockfile conda-lock.yml --overwrite 2>/dev/null || \
         run_command_verbose conda-lock lock -f "${BASE_ENV_FILE}" -p "${PLATFORM}" --lockfile conda-lock.yml
     fi
+  fi
+
+  # Abort if dev_env is currently active
+  if ! check_not_in_active_env; then
+    return 1
   fi
 
   # Create/update the local prefix environment

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import shutil
 import pytest
+from pathlib import Path
 
 
 def test_setup_env_script_exists():
@@ -214,3 +215,59 @@ exit 0
     executed = log_file.read_text()
     assert "pip install pre-commit" in executed
 
+
+def test_check_not_in_active_env_function_present():
+    with open('setup_env.sh') as f:
+        content = f.read()
+    assert 'check_not_in_active_env()' in content
+    assert "dev_env is currently active" in content
+
+
+def test_check_not_in_active_env_called_before_creation():
+    with open('setup_env.sh') as f:
+        content = f.read()
+    def_idx = content.index('check_not_in_active_env()')
+    call_idx = content.index('check_not_in_active_env', def_idx + 1)
+    env_idx = content.index('section "Setting up Conda environment"')
+    assert call_idx < env_idx
+
+
+def test_setup_aborts_if_env_active(tmp_path, monkeypatch):
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+
+    conda_base = tmp_path / 'conda'
+    (conda_base / 'etc/profile.d').mkdir(parents=True)
+    (conda_base / 'etc/profile.d/conda.sh').write_text('')
+
+    conda_script = bin_dir / 'conda'
+    conda_script.write_text(
+        f"""#!/bin/bash
+if [ \"$1\" = \"info\" ] && [ \"$2\" = \"--base\" ]; then
+  echo \"{conda_base}\"
+elif [ \"$1\" = \"info\" ] && [ \"$2\" = \"--json\" ]; then
+  echo '{{"platform":"linux-64"}}'
+elif [ \"$1\" = \"env\" ] && [ \"$2\" = \"create\" ] && [ \"$3\" = \"--help\" ]; then
+  echo "--force"
+  exit 0
+elif [ \"$1\" = \"env\" ]; then
+  exit 0
+else
+  exit 0
+fi
+"""
+    )
+    conda_script.chmod(0o755)
+
+    monkeypatch.setenv('PATH', f"{bin_dir}:{os.environ['PATH']}")
+    dev_env = Path("dev_env")
+    dev_env.mkdir(exist_ok=True)
+    monkeypatch.setenv("CONDA_PREFIX", str(dev_env.resolve()))
+
+    result = subprocess.run(
+        ['bash', './setup_env.sh', '--skip-conda-lock', '--no-tests'],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert 'dev_env is currently active' in result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- add tests for detecting active env before running setup
- abort setup when `dev_env` is already activated

## Testing
- `pytest tests/test_setup_env_script.py::test_check_not_in_active_env_function_present tests/test_setup_env_script.py::test_check_not_in_active_env_called_before_creation tests/test_setup_env_script.py::test_setup_aborts_if_env_active -q`
- `pytest -q` *(fails: 18 failed, 58 passed, 19 skipped)*