### PR TITLE
Add cleanup for NFS temp files

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -184,6 +184,10 @@ ensure_conda_lock() {
         fi
     fi
 }
+cleanup_nfs_temp_files() {
+    find "./${LOCAL_ENV_DIR}" -name '.nfs*' -type f -exec rm -f {} +
+}
+
 
 # --- Main setup function ---
 setup_environment() {
@@ -269,6 +273,7 @@ setup_environment() {
     else
       log INFO "Old conda detected - removing existing environment"
       run_command_verbose conda env remove --prefix "./${LOCAL_ENV_DIR}" -y || true
+  cleanup_nfs_temp_files || true
       run_command_verbose conda env create --prefix "./${LOCAL_ENV_DIR}" --file conda-lock.yml
     fi
   else
@@ -278,6 +283,7 @@ setup_environment() {
     else
       log INFO "Old conda detected - removing existing environment"
       run_command_verbose conda env remove --prefix "./${LOCAL_ENV_DIR}" -y || true
+  cleanup_nfs_temp_files || true
       run_command_verbose conda env create --prefix "./${LOCAL_ENV_DIR}" -f "${BASE_ENV_FILE}"
     fi
   fi

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import shutil
 import pytest
@@ -213,4 +214,26 @@ exit 0
     assert result.returncode == 0
     executed = log_file.read_text()
     assert "pip install pre-commit" in executed
+
+
+def test_cleanup_nfs_temp_files_function_exists():
+    """Ensure cleanup_nfs_temp_files function is defined with correct command."""
+    with open('setup_env.sh') as f:
+        content = f.read()
+    assert 'cleanup_nfs_temp_files()' in content
+    assert "find \"./${LOCAL_ENV_DIR}\" -name '.nfs*' -type f -exec rm -f {} +" in content
+
+
+def test_cleanup_nfs_called_after_remove():
+    """cleanup_nfs_temp_files should run after environment removal and before creation."""
+    with open('setup_env.sh') as f:
+        content = f.read()
+    remove_line = 'conda env remove --prefix "./${LOCAL_ENV_DIR}" -y'
+    occurrences = [m.start() for m in re.finditer(re.escape(remove_line), content)]
+    assert occurrences, "remove command not found"
+    for start in occurrences:
+        after = content[start:]
+        cleanup_idx = after.index('cleanup_nfs_temp_files')
+        create_idx = after.index('conda env create')
+        assert cleanup_idx < create_idx
 


### PR DESCRIPTION
## Summary
- clean up stale `.nfs*` files after removing the Conda environment
- verify cleanup call order in setup tests

## Testing
- `pytest tests/test_setup_env_script.py -q`