### PR TITLE
Fix conda activation in batch job

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -65,7 +65,7 @@ MATLAB_OPTIONS=${MATLAB_OPTIONS:--nodisplay -nosplash}
 # Setup conda environment if available
 if [ -f setup_env.sh ]; then
     bash ./setup_env.sh --dev
-    conda activate .env
+    conda activate ./dev_env
 fi
 
 # Load MATLAB module


### PR DESCRIPTION
## Summary
- use the dev environment in `run_batch_job.sh`

## Testing
- `pytest -q`
- `pre-commit run --files run_batch_job.sh` *(fails: command not found)*