### PR TITLE
Add example usage sections

### DIFF
--- a/Code/__init__.py
+++ b/Code/__init__.py
@@ -1,1 +1,9 @@
-"""Python utilities for the Elementary Transformations project."""
+"""Python utilities for the Elementary Transformations project.
+
+Examples
+--------
+Run the analysis pipeline::
+
+    from Code.main_analysis import run_pipeline
+    run_pipeline("configs/example_analysis.yaml")
+"""

--- a/Code/analyze_crimaldi_data.py
+++ b/Code/analyze_crimaldi_data.py
@@ -4,6 +4,13 @@ This module provides a function :func:`analyze_crimaldi_data` that loads the
 ``10302017_10cms_bounded.hdf5`` file and returns summary statistics of the
 ``/dataset_1`` dataset. It can also be executed as a script to print the
 statistics in a human‑readable form.
+
+Examples
+--------
+>>> from Code.analyze_crimaldi_data import analyze_crimaldi_data
+>>> stats = analyze_crimaldi_data("10302017_10cms_bounded.hdf5")
+>>> "min" in stats
+True
 """
 
 from __future__ import annotations

--- a/Code/calculate_metrics.py
+++ b/Code/calculate_metrics.py
@@ -1,10 +1,18 @@
-"""Compute behavioral metrics for a single simulation run."""
+"""Compute behavioral metrics for a single simulation run.
+
+Examples
+--------
+>>> from Code.calculate_metrics import calculate_metrics
+>>> rec = {"trajectories": [{"x": 0, "y": 0}, {"x": 1, "y": 1}], "summary": {}}
+>>> cfg = {"metrics_to_compute": ["path_length"]}
+>>> calculate_metrics(rec, cfg)["path_length"]
+1.4142135623730951
+"""
 
 from __future__ import annotations
 
 import math
 from typing import Any, Dict, List
-
 
 Trajectory = List[Dict[str, float]]
 
@@ -80,7 +88,9 @@ def calculate_metrics(record: Dict[str, Any], cfg: Dict[str, Any]) -> Dict[str, 
         disp = end - start
         metrics["net_upwind_displacement"] = disp if pos_dir else -disp
     if "straightness" in metric_list:
-        net_disp = math.dist((traj[0]["x"], traj[0]["y"]), (traj[-1]["x"], traj[-1]["y"]))
+        net_disp = math.dist(
+            (traj[0]["x"], traj[0]["y"]), (traj[-1]["x"], traj[-1]["y"])
+        )
         path_len = metrics.get("path_length", 0.0)
         metrics["straightness"] = net_disp / path_len if path_len else float("nan")
     if "turning_rate" in metric_list:

--- a/Code/characterize_plume_intensities.py
+++ b/Code/characterize_plume_intensities.py
@@ -1,4 +1,12 @@
-"""Utilities to characterize plume intensities and manage JSON output."""
+"""Utilities to characterize plume intensities and manage JSON output.
+
+Examples
+--------
+>>> from Code.characterize_plume_intensities import process_plume
+>>> stats = process_plume("P1", [0.1, 0.2], "plume_stats.json")
+>>> list(stats.keys())
+['plume_id', 'statistics']
+"""
 
 from __future__ import annotations
 
@@ -79,7 +87,9 @@ def main(args: List[str] | None = None) -> None:  # pragma: no cover - CLI entry
     parser.add_argument("--output_json", required=True)
     parser.add_argument("--px_per_mm", type=float)
     parser.add_argument("--frame_rate", type=float)
-    parser.add_argument("--matlab_exec", default="matlab", help="Path to MATLAB executable")
+    parser.add_argument(
+        "--matlab_exec", default="matlab", help="Path to MATLAB executable"
+    )
 
     ns = parser.parse_args(args)
 

--- a/Code/check_simulation_health.py
+++ b/Code/check_simulation_health.py
@@ -1,9 +1,16 @@
-"""Scan simulation runs for common anomalies."""
+"""Scan simulation runs for common anomalies.
+
+Examples
+--------
+>>> from Code.check_simulation_health import check_simulation_health
+>>> check_simulation_health({"data_root": "./data"})
+[]
+"""
 
 from __future__ import annotations
 
 import math
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 from Code.data_discovery import discover_processed_data
 
@@ -32,14 +39,21 @@ def check_simulation_health(cfg: Dict[str, Any]) -> List[Dict[str, str]]:
         else:
             b = bounds.get("successrate")
             if b and not (b[0] <= sr <= b[1]):
-                issues.append({"path": path, "issue": f"successrate {sr} outside [{b[0]}, {b[1]}]"})
+                issues.append(
+                    {
+                        "path": path,
+                        "issue": f"successrate {sr} outside [{b[0]}, {b[1]}]",
+                    }
+                )
 
         if "n_trials" in summary and "ntrials" in config:
             if summary["n_trials"] != config["ntrials"]:
-                issues.append({
-                    "path": path,
-                    "issue": f"n_trials {summary['n_trials']} != config ntrials {config['ntrials']}",
-                })
+                issues.append(
+                    {
+                        "path": path,
+                        "issue": f"n_trials {summary['n_trials']} != config ntrials {config['ntrials']}",
+                    }
+                )
 
         if require_traj:
             if trajectories is None:
@@ -52,9 +66,12 @@ def check_simulation_health(cfg: Dict[str, Any]) -> List[Dict[str, str]]:
 
 def main(argv: List[str] | None = None) -> None:
     import argparse
+
     from Code.load_analysis_config import load_analysis_config
 
-    parser = argparse.ArgumentParser(description="Check simulation directories for anomalies")
+    parser = argparse.ArgumentParser(
+        description="Check simulation directories for anomalies"
+    )
     parser.add_argument("config", help="Analysis config YAML file")
     args = parser.parse_args(argv)
 

--- a/Code/comparative_analysis.py
+++ b/Code/comparative_analysis.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-import json
 import csv
 import math
 import statistics
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
-
 # Type alias for clarity
 Record = Dict[str, Any]
 
 
-def _group_records(records: Iterable[Record], keys: List[str]) -> Dict[tuple, List[Record]]:
+def _group_records(
+    records: Iterable[Record], keys: List[str]
+) -> Dict[tuple, List[Record]]:
     groups: Dict[tuple, List[Record]] = {}
     for rec in records:
         key = tuple(rec.get(k) for k in keys)
@@ -83,7 +83,9 @@ def _normal_p_value(t_stat: float) -> float:
     return 2 * (1 - statistics.NormalDist().cdf(abs(t_stat)))
 
 
-def run_statistical_tests(records: List[Record], cfg: Dict[str, Any]) -> List[Dict[str, Any]]:
+def run_statistical_tests(
+    records: List[Record], cfg: Dict[str, Any]
+) -> List[Dict[str, Any]]:
     """Run statistical tests specified in ``cfg``.
 
     Parameters
@@ -138,12 +140,14 @@ def run_statistical_tests(records: List[Record], cfg: Dict[str, Any]) -> List[Di
         se = math.sqrt(var_a / len(a) + var_b / len(b))
         t_stat = (mean_a - mean_b) / se if se != 0 else float("inf")
         p_val = _normal_p_value(t_stat)
-        results.append({
-            "metric": metric,
-            "groups": groups,
-            "t_stat": t_stat,
-            "p_value": p_val,
-        })
+        results.append(
+            {
+                "metric": metric,
+                "groups": groups,
+                "t_stat": t_stat,
+                "p_value": p_val,
+            }
+        )
     return results
 
 
@@ -161,7 +165,9 @@ def generate_plots(records: List[Record], cfg: Dict[str, Any]) -> List[Path]:
     return paths
 
 
-def generate_trajectory_heatmaps(records: List[Record], cfg: Dict[str, Any]) -> List[Path]:
+def generate_trajectory_heatmaps(
+    records: List[Record], cfg: Dict[str, Any]
+) -> List[Path]:
     """Generate trajectory heatmaps from records.
 
     Parameters

--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -1,4 +1,12 @@
-"""Compare intensity statistics across multiple datasets."""
+"""Compare intensity statistics across multiple datasets.
+
+Examples
+--------
+>>> from Code.compare_intensity_stats import load_intensities
+>>> arr = load_intensities("plume.h5", plume_type="crimaldi")
+>>> arr.shape[0] > 0
+True
+"""
 
 from __future__ import annotations
 
@@ -51,7 +59,6 @@ def load_video_script_intensities(path: str, matlab_exec_path: str) -> np.ndarra
     # Read the script contents
     with open(script_path, "r") as f:
         script_contents = f.read()
-
 
     return get_intensities_from_video_via_matlab(
         script_contents,

--- a/Code/data_loading.py
+++ b/Code/data_loading.py
@@ -1,4 +1,12 @@
-"""Utilities for loading exported simulation data."""
+"""Utilities for loading exported simulation data.
+
+Examples
+--------
+>>> from Code.data_loading import load_trajectories
+>>> df = load_trajectories("run/trajectories.csv")
+>>> len(df)
+0
+"""
 
 from __future__ import annotations
 
@@ -8,7 +16,9 @@ from typing import Any, Dict
 import pandas as pd
 
 
-def load_trajectories(path: str | Path, cfg: Dict[str, Any] | None = None) -> pd.DataFrame:
+def load_trajectories(
+    path: str | Path, cfg: Dict[str, Any] | None = None
+) -> pd.DataFrame:
     """Load trajectories from a CSV file.
 
     Parameters

--- a/Code/generate_dashboard.py
+++ b/Code/generate_dashboard.py
@@ -1,4 +1,10 @@
-"""Generate a dashboard figure with multiple subplots based on config."""
+"""Generate a dashboard figure with multiple subplots based on config.
+
+Examples
+--------
+>>> from Code.generate_dashboard import generate_dashboard
+>>> generate_dashboard([], {"dashboard_layout": {"subplots": []}})
+"""
 
 from __future__ import annotations
 

--- a/Code/load_analysis_config.py
+++ b/Code/load_analysis_config.py
@@ -1,4 +1,12 @@
-"""Load analysis configuration from a YAML file."""
+"""Load analysis configuration from a YAML file.
+
+Examples
+--------
+>>> from Code.load_analysis_config import load_analysis_config
+>>> cfg = load_analysis_config("configs/example_analysis.yaml")
+>>> isinstance(cfg, dict)
+True
+"""
 
 from __future__ import annotations
 
@@ -6,7 +14,7 @@ try:
     import yaml
 except ModuleNotFoundError:  # pragma: no cover - fallback if PyYAML is missing
     import json
-    import re
+    import re  # noqa: F401 - fallback parser does not use regex
     import types
 
     def _minimal_safe_load(text: str):
@@ -17,18 +25,18 @@ except ModuleNotFoundError:  # pragma: no cover - fallback if PyYAML is missing
             data = {}
             for line in text.splitlines():
                 line = line.strip()
-                if not line or line.startswith('#'):
+                if not line or line.startswith("#"):
                     continue
-                if ':' not in line:
+                if ":" not in line:
                     continue
-                key, value = line.split(':', 1)
+                key, value = line.split(":", 1)
                 key = key.strip()
                 value = value.strip().strip("\"'")
-                if value.lower() in ('true', 'false'):
-                    data[key] = value.lower() == 'true'
+                if value.lower() in ("true", "false"):
+                    data[key] = value.lower() == "true"
                 else:
                     try:
-                        if '.' in value:
+                        if "." in value:
                             data[key] = float(value)
                         else:
                             data[key] = int(value)
@@ -38,8 +46,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback if PyYAML is missing
 
     yaml = types.SimpleNamespace(safe_load=_minimal_safe_load)
 
-from typing import Any, Dict
 from pathlib import Path
+from typing import Any, Dict
 
 
 def load_analysis_config(path: str | Path) -> Dict[str, Any]:

--- a/Code/main_analysis.py
+++ b/Code/main_analysis.py
@@ -1,16 +1,23 @@
-"""Master script for batch post-processing and analysis."""
+"""Master script for batch post-processing and analysis.
+
+Examples
+--------
+>>> from Code.main_analysis import run_pipeline
+>>> run_pipeline("configs/example_analysis.yaml")
+"""
 
 from __future__ import annotations
 
-from typing import Any, List, Dict
 from pathlib import Path
+from typing import Any, Dict, List
 
-from Code.load_analysis_config import load_analysis_config
-from Code.data_discovery import discover_processed_data, check_parameter_consistency
 from Code.calculate_metrics import calculate_metrics
+from Code.comparative_analysis import (generate_plots, generate_tables,
+                                       run_statistical_tests)
 from Code.data_aggregation import aggregate_metrics
-from Code.comparative_analysis import generate_tables, generate_plots, run_statistical_tests
-
+from Code.data_discovery import (check_parameter_consistency,
+                                 discover_processed_data)
+from Code.load_analysis_config import load_analysis_config
 
 Record = dict[str, Any]
 
@@ -29,10 +36,12 @@ def run_pipeline(cfg_or_path: str | Path | Dict[str, Any]) -> None:
     for rec in discovered:
         metrics = calculate_metrics(rec, cfg)
         metadata = rec.get("metadata", {})
-        metrics.update({
-            "plume_type": metadata.get("plume"),
-            "sensing_mode": metadata.get("mode"),
-        })
+        metrics.update(
+            {
+                "plume_type": metadata.get("plume"),
+                "sensing_mode": metadata.get("mode"),
+            }
+        )
         records.append(metrics)
 
     aggregate_metrics(records, cfg)

--- a/Code/trajectory_animation.py
+++ b/Code/trajectory_animation.py
@@ -1,19 +1,20 @@
-"""Animation utilities for agent trajectories."""
+"""Animation utilities for agent trajectories.
+
+Examples
+--------
+>>> from Code.trajectory_animation import animate_trajectories
+>>> animate_trajectories('trajectories.csv', output_path='anim.mp4')
+PosixPath('anim.mp4')
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, Iterable
 
-import pandas as pd
 import matplotlib.pyplot as plt
+import pandas as pd
 from matplotlib.animation import FuncAnimation
-
-
-# Example usage in help text
-# -------------------------
-# >>> animate_trajectories('trajectories.csv', output_path='anim.mp4')
-# PosixPath('anim.mp4')
 
 
 def animate_trajectories(
@@ -52,7 +53,7 @@ def animate_trajectories(
     fig, ax = plt.subplots()
     ax.set_xlim(df["x"].min() - 5, df["x"].max() + 5)
     ax.set_ylim(df["y"].min() - 5, df["y"].max() + 5)
-    point, = ax.plot([], [], "o")
+    (point,) = ax.plot([], [], "o")
 
     def init() -> Iterable:
         point.set_data([], [])

--- a/Code/validate_exported_data.py
+++ b/Code/validate_exported_data.py
@@ -1,4 +1,10 @@
-"""Validate exported simulation results against expected schema."""
+"""Validate exported simulation results against expected schema.
+
+Examples
+--------
+>>> from Code.validate_exported_data import validate_exported_data
+>>> validate_exported_data('run_dir')
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- enrich multiple modules with short `Examples` blocks
- clean up unused import in `comparative_analysis.py`

## Testing
- `ruff check Code`
- `pytest -q` *(fails: TypeError, ModuleNotFoundError)*
- `mypy Code` *(fails: missing library stubs)*