### PR TITLE
Add return value for intensity stats CLI

### DIFF
--- a/Code/intensity_stats.py
+++ b/Code/intensity_stats.py
@@ -6,12 +6,22 @@ Run the CLI inside the project environment::
 
     ./setup_env.sh --dev
     conda run --prefix ./dev_env python -m Code.intensity_stats plumeA intensities.txt
+
+The :func:`main` entry point returns the computed statistics so it can be
+invoked programmatically:
+
+>>> from Code.intensity_stats import main
+>>> stats = main(["plumeX", "intensities.txt"])
+>>> stats["count"]
+3
 """
 
 from __future__ import annotations
 
 import argparse
 from typing import Sequence, Dict
+
+__all__ = ["calculate_intensity_stats_dict", "main"]
 
 try:
     import numpy as np
@@ -57,7 +67,7 @@ def _print_stats(identifier: str, file_path: str, stats: Dict[str, float]) -> No
         print(f"{key}: {stats[key]}")
 
 
-def main(args: Sequence[str] | None = None) -> None:  # pragma: no cover - CLI
+def main(args: Sequence[str] | None = None) -> Dict[str, float]:  # pragma: no cover - CLI
     parser = argparse.ArgumentParser(description="Calculate intensity statistics")
     parser.add_argument("identifier", help="Plume identifier")
     parser.add_argument("file", help="Path to text file containing intensities")
@@ -78,6 +88,8 @@ def main(args: Sequence[str] | None = None) -> None:  # pragma: no cover - CLI
         plt.xlabel("Intensity")
         plt.ylabel("Frequency")
         plt.show()
+
+    return stats
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_characterize_plume_intensities.py
+++ b/tests/test_characterize_plume_intensities.py
@@ -36,9 +36,16 @@ def simple_stats(values):
     return stats
 
 
-sys.modules["Code.intensity_stats"] = types.SimpleNamespace(
-    calculate_intensity_stats_dict=simple_stats
-)
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_intensity_stats(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "Code.intensity_stats",
+        types.SimpleNamespace(calculate_intensity_stats_dict=simple_stats),
+    )
 
 from Code.characterize_plume_intensities import process_plume
 

--- a/tests/test_characterize_plume_intensities_cli.py
+++ b/tests/test_characterize_plume_intensities_cli.py
@@ -36,9 +36,13 @@ def simple_stats(values):
     }
 
 
-sys.modules["Code.intensity_stats"] = types.SimpleNamespace(
-    calculate_intensity_stats_dict=simple_stats
-)
+@pytest.fixture(autouse=True)
+def _stub_intensity_stats(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "Code.intensity_stats",
+        types.SimpleNamespace(calculate_intensity_stats_dict=simple_stats),
+    )
 
 from Code import characterize_plume_intensities as cpi
 

--- a/tests/test_intensity_stats.py
+++ b/tests/test_intensity_stats.py
@@ -26,7 +26,8 @@ def test_main_prints_stats(tmp_path, capsys):
     data = np.arange(10)
     f = tmp_path / "data.txt"
     np.savetxt(f, data)
-    main(["plumeA", str(f)])
+    stats = main(["plumeA", str(f)])
+    assert stats["count"] == 10
     out = capsys.readouterr().out
     assert "Plume: plumeA" in out
     assert f"File: {f}" in out
@@ -43,7 +44,8 @@ def test_main_plot_histogram(monkeypatch, tmp_path):
                                   ylabel=lambda *a, **k: None,
                                   show=lambda *a, **k: None)
     monkeypatch.setitem(sys.modules, 'matplotlib.pyplot', dummy)
-    main(["plumeB", str(f), "--plot_histogram"])
+    stats = main(["plumeB", str(f), "--plot_histogram"])
+    assert stats["count"] == 5
 
 
 def test_empty_intensity_stats_returns_nans():


### PR DESCRIPTION
## Summary
- expose `main` return value in `intensity_stats`
- update tests for new return value
- prevent cross test pollution by patching `intensity_stats` with fixtures

## Testing
- `pytest -k intensity_stats -vv` *(fails: ImportError: numpy is required)*
- `pre-commit run --files Code/intensity_stats.py tests/test_intensity_stats.py tests/test_characterize_plume_intensities.py tests/test_characterize_plume_intensities_cli.py` *(fails: command not found)*