### PR TITLE
Add failing test for ruff dependency check

### DIFF
--- a/tests/test_env_dependencies.py
+++ b/tests/test_env_dependencies.py
@@ -1,0 +1,16 @@
+try:
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback parser
+    yaml = None
+
+
+def _read_env(path: str) -> str:
+    with open(path) as f:
+        return f.read()
+
+
+def test_envs_require_ruff() -> None:
+    dev_env_text = _read_env("dev-environment.yml")
+    base_env_text = _read_env("environment.yml")
+    assert "ruff" in dev_env_text
+    assert "ruff" in base_env_text


### PR DESCRIPTION
## Summary
- add test for `ruff` dependency in both environment files

## Testing
- `pytest tests/test_env_dependencies.py -q` *(fails: ruff dependency missing)*