### PR TITLE
test: centralize path setup via conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+
+def pytest_configure():
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)

--- a/tests/test_intensity_stats.py
+++ b/tests/test_intensity_stats.py
@@ -1,13 +1,10 @@
-import os
 import sys
 import types
 import pytest
 
 np = pytest.importorskip("numpy")
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-from Code.intensity_stats import calculate_intensity_stats_dict, main
+from Code.intensity_stats import calculate_intensity_stats_dict, main  # noqa: E402
 
 
 def test_calculate_intensity_stats_dict():

--- a/tests/test_load_intensities.py
+++ b/tests/test_load_intensities.py
@@ -1,13 +1,8 @@
-import os
-import sys
-
 import pytest
 
 np = pytest.importorskip("numpy")
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-from Code import compare_intensity_stats as cis
+from Code import compare_intensity_stats as cis  # noqa: E402
 
 
 def test_h5_path_uses_crimaldi_loader(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add `tests/conftest.py` to automatically insert repo root on pytest startup
- drop inline `sys.path` modifications in two tests

## Testing
- `ruff check tests/conftest.py tests/test_intensity_stats.py tests/test_load_intensities.py`
- `pytest tests/test_intensity_stats.py tests/test_load_intensities.py -q`