### PR TITLE
Add log check for auto dataset selection

### DIFF
--- a/Code/analyze_crimaldi_data.py
+++ b/Code/analyze_crimaldi_data.py
@@ -16,12 +16,15 @@ True
 from __future__ import annotations
 
 import argparse
+import logging
 import os
-from typing import Dict
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
 
 try:
-    import h5py
-    import numpy as np
+    import h5py  # type: ignore
+    import numpy as np  # type: ignore
 except ImportError as exc:  # pragma: no cover - dependencies missing
     raise ImportError(
         "analyze_crimaldi_data requires numpy and h5py to be installed"
@@ -60,7 +63,7 @@ def analyze_crimaldi_data(path: str) -> Dict[str, float | dict]:
 
 
 def get_intensities_from_crimaldi(
-    hdf5_path: str, dataset_name: str = None
+    hdf5_path: str, dataset_name: Optional[str] = None
 ) -> np.ndarray:
     """Return a flat array of intensity values from the Crimaldi plume file.
 
@@ -108,7 +111,7 @@ def get_intensities_from_crimaldi(
                 # If no obvious match, use the first dataset
                 dataset_name = available_datasets[0]
 
-            print(f"Using dataset: {dataset_name}")
+            logger.info("Using dataset: %s", dataset_name)
 
         # Check if the dataset exists
         if dataset_name not in f:
@@ -134,7 +137,7 @@ def main() -> None:  # pragma: no cover - CLI wrapper
     print("Max:", stats["max"])
     print("Mean:", stats["mean"])
     print("Std:", stats["std"])
-    for p, v in stats["percentiles"].items():
+    for p, v in stats["percentiles"].items():  # type: ignore[union-attr]
         print(f"{p}th percentile: {v}")
 
 

--- a/tests/test_get_intensities_from_crimaldi.py
+++ b/tests/test_get_intensities_from_crimaldi.py
@@ -1,19 +1,27 @@
+import logging
 import os
+import sys
 import unittest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)  # noqa: E402
 
 import pytest
 
 np = pytest.importorskip("numpy")
 h5py = pytest.importorskip("h5py")
 
-from Code.analyze_crimaldi_data import get_intensities_from_crimaldi
+from Code.analyze_crimaldi_data import \
+    get_intensities_from_crimaldi  # noqa: E402
+
 
 class TestGetIntensitiesFromCrimaldi(unittest.TestCase):
     def setUp(self):
-        self.tmpfile = 'tests/sample_crimaldi.hdf5'
-        data = np.arange(27, dtype=np.float32).reshape(3,3,3)
-        with h5py.File(self.tmpfile, 'w') as f:
-            f.create_dataset('dataset_1', data=data)
+        self.tmpfile = "tests/sample_crimaldi.hdf5"
+        data = np.arange(27, dtype=np.float32).reshape(3, 3, 3)
+        with h5py.File(self.tmpfile, "w") as f:
+            f.create_dataset("dataset_1", data=data)
         self.data = data
 
     def tearDown(self):
@@ -29,7 +37,21 @@ class TestGetIntensitiesFromCrimaldi(unittest.TestCase):
 
     def test_missing_dataset_raises(self):
         with self.assertRaises(KeyError):
-            get_intensities_from_crimaldi(self.tmpfile, 'missing')
+            get_intensities_from_crimaldi(self.tmpfile, "missing")
 
-if __name__ == '__main__':
+
+def test_logs_autoselected_dataset(tmp_path, caplog):
+    data = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+    hfile = tmp_path / "sample.hdf5"
+    with h5py.File(hfile, "w") as f:
+        f.create_dataset("dataset_1", data=data)
+
+    with caplog.at_level(logging.INFO):
+        arr = get_intensities_from_crimaldi(str(hfile))
+
+    assert arr.size == data.size
+    assert any("Using dataset: dataset_1" in r.getMessage() for r in caplog.records)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure dataset auto-selection logs dataset name
- capture log message in new get_intensities_from_crimaldi test

## Testing
- `mypy Code/analyze_crimaldi_data.py tests/test_get_intensities_from_crimaldi.py`
- `pytest -k test_logs_autoselected_dataset -vv tests/test_get_intensities_from_crimaldi.py` *(fails: collected 0 items / 1 skipped)*