### PR TITLE
Fix MATLAB error message quoting

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -216,7 +216,7 @@ def get_intensities_from_video_via_matlab(
             "-nodesktop",
             "-noFigureWindows",
             "-batch",
-            f"try, run('{safe_path}'), catch ME, disp('MATLAB Error: ' + getReport(ME, 'extended')); exit(1); end",
+            f"try, run('{safe_path}'), catch ME, disp(['MATLAB Error: ' getReport(ME, 'extended')]); exit(1); end",
         ]
 
         logger.info(


### PR DESCRIPTION
## Summary
- update the MATLAB batch command so the error handler uses bracket notation

## Testing
- `pytest -k matlab_batch_command_uses_brackets -q` *(fails: ModuleNotFoundError: No module named 'numpy')*