### PR TITLE
Fix result struct saving

### DIFF
--- a/Code/run_agent_simulation.m
+++ b/Code/run_agent_simulation.m
@@ -68,9 +68,8 @@ try
     % Run the simulation
     result = run_navigation_cfg(sim_cfg);
     
-    % Save the results under a top-level ''out'' field for downstream tools
-    out = result;
-    save(fullfile(output_dir, 'result.mat'), 'out', '-v7');
+    % Save the results structure directly
+    save(fullfile(output_dir, 'result.mat'), '-struct', 'result');
     fprintf('Successfully completed simulation for agent %d (seed %d)\n', agent_id, seed);
     
     % Clear large variables to save memory

--- a/tests/test_result_file_contains_out.m
+++ b/tests/test_result_file_contains_out.m
@@ -33,7 +33,7 @@ function teardownOnce(testCase)
     rmdir(testCase.TestData.stubDir, 's');
 end
 
-function testResultFileHasOut(testCase)
+function testResultFileHasNoOut(testCase)
     cfg = testCase.TestData.cfg;
     outDirBase = cfg.experiment.output_base;
     if exist(outDirBase, 'dir')
@@ -42,5 +42,6 @@ function testResultFileHasOut(testCase)
     run_agent_simulation(1, 1, 'dummy.yaml');
     resultFile = fullfile(outDirBase, 'gaussian_bilateral', '1_1', 'result.mat');
     info = whos('-file', resultFile);
-    verifyTrue(testCase, any(strcmp({info.name}, 'out')), 'Variable ''out'' missing from result.mat');
+    verifyFalse(testCase, any(strcmp({info.name}, 'out')), 'Variable ''out'' should not be saved');
+    verifyGreaterThan(testCase, numel(info), 0, 'Result file should contain variables');
 end


### PR DESCRIPTION
## Summary
- save simulation results as a struct
- update MATLAB test to expect no `out` variable

## Testing
- `./setup_env.sh --dev` *(fails: conda not found, installation needs network)*
- `pytest -k run_agent_simulation_save_struct -q` *(fails: ModuleNotFoundError: No module named 'numpy')*