### PR TITLE
Add non-interactive mode detection for paths.sh

### DIFF
--- a/tests/test_paths_sh_noninteractive.py
+++ b/tests/test_paths_sh_noninteractive.py
@@ -1,0 +1,48 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def test_paths_sh_noninteractive_quiet(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    shutil.copy(repo_root / "paths.sh", tmp_path / "paths.sh")
+    shutil.copy(repo_root / "setup_utils.sh", tmp_path / "setup_utils.sh")
+
+    (tmp_path / "configs").mkdir()
+    shutil.copy(
+        repo_root / "configs" / "project_paths.yaml.template",
+        tmp_path / "configs" / "project_paths.yaml.template",
+    )
+    (tmp_path / "scripts").mkdir()
+    shutil.copy(
+        repo_root / "scripts" / "make_paths_relative.py",
+        tmp_path / "scripts" / "make_paths_relative.py",
+    )
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_matlab = bin_dir / "matlab"
+    fake_matlab.write_text("#!/bin/sh\nexit 0\n")
+    fake_matlab.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["PS4"] = "+"
+
+    log_file = tmp_path / "log"
+    result = subprocess.run(
+        ["/usr/bin/bash", "-c", f"source ./paths.sh > {log_file} 2>&1 && echo $MATLAB_EXEC"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(fake_matlab)
+    log_content = log_file.read_text()
+    assert "[INFO]" not in log_content
+    assert "[WARNING]" not in log_content
+    assert "[ERROR]" not in log_content
+    assert "[SUCCESS]" not in log_content


### PR DESCRIPTION
## Summary
- suppress log output from `paths.sh` when sourced non-interactively
- log MATLAB setup messages using the `log` helper
- add regression test for quiet non-interactive sourcing

## Testing
- `pytest tests/test_paths_sh_noninteractive.py::test_paths_sh_noninteractive_quiet -vv`
- `pytest -k paths_sh_module -vv` *(fails: ModuleNotFoundError: No module named 'numpy')*