### PR TITLE
Add kwargs handling for MATLAB subprocess

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -123,6 +123,7 @@ def get_intensities_from_video_via_matlab(
     px_per_mm: Optional[float] = None,
     frame_rate: Optional[float] = None,
     work_dir: Optional[str] = None,
+    timeout: Optional[float] = None,
     orig_script_path: Optional[str] = None,
 ) -> np.ndarray:
     """Run a MATLAB script and return the extracted intensity vector.
@@ -142,6 +143,9 @@ def get_intensities_from_video_via_matlab(
         embedded in the temporary MATLAB script for use by helper routines.
     work_dir : str, optional
         Directory MATLAB should change into before running the temporary script.
+    timeout : float, optional
+        Maximum time in seconds to allow MATLAB to run. If ``None``, no timeout
+        is enforced.
     orig_script_path : str, optional
         Original path of the MATLAB script. When provided, the generated
         temporary script defines ``orig_script_path`` and ``orig_script_dir`` so
@@ -229,14 +233,19 @@ def get_intensities_from_video_via_matlab(
             " ".join(f'"{x}"' if " " in x else x for x in matlab_cmd),
         )
 
-        # Run MATLAB with timeout (30 minutes)
+        # Run MATLAB
         try:
+            kwargs = {}
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            if work_dir is not None:
+                kwargs["cwd"] = work_dir
+
             proc = subprocess.run(
                 matlab_cmd,
                 capture_output=True,
                 text=True,
-                timeout=1800,  # 30 minute timeout
-                cwd=work_dir or os.getcwd(),
+                **kwargs,
             )
 
             # Log MATLAB output for debugging
@@ -257,9 +266,12 @@ def get_intensities_from_video_via_matlab(
                 )
 
         except subprocess.TimeoutExpired as exc:
-            raise RuntimeError(
-                "MATLAB script execution timed out after 30 minutes"
-            ) from exc
+            msg = (
+                f"MATLAB script execution timed out after {timeout} seconds"
+                if timeout is not None
+                else "MATLAB script execution timed out"
+            )
+            raise RuntimeError(msg) from exc
 
         for line in proc.stdout.splitlines():
             if line.startswith("TEMP_MAT_FILE_SUCCESS:"):

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -37,7 +37,7 @@ def test_get_intensities_from_video_via_matlab(monkeypatch, tmp_path):
         captured["script_path"] = tmp.name
         return tmp
 
-    def fake_run(cmd, capture_output, text):
+    def fake_run(cmd, capture_output, text, **kwargs):
         assert cmd[0] == matlab_exec
         assert cmd[1] == "-batch"
         assert cmd[2] == f"run('{captured['script_path']}')"
@@ -82,7 +82,7 @@ def test_path_with_spaces_and_quotes(monkeypatch, tmp_path):
         captured["script_path"] = str(file_path)
         return fh
 
-    def fake_run(cmd, capture_output, text):
+    def fake_run(cmd, capture_output, text, **kwargs):
         assert cmd[0] == matlab_exec
         expected = captured["script_path"].replace("'", "''")
         assert cmd[2] == f"run('{expected}')"
@@ -105,7 +105,7 @@ def test_error_message_includes_path_and_workdir(monkeypatch, tmp_path, caplog):
     matlab_exec = "/usr/local/MATLAB/R2023b/bin/matlab"
     script_content = "disp('fail')"
 
-    def fake_run(cmd, capture_output, text):
+    def fake_run(cmd, capture_output, text, **kwargs):
         return subprocess.CompletedProcess(cmd, 1, stdout="oops", stderr="bad")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -145,8 +145,8 @@ def test_workdir_with_single_quote(monkeypatch, tmp_path):
         captured["script_path"] = tmp.name
         return tmp
 
-    def fake_run(cmd, capture_output, text, timeout, cwd):
-        assert cwd == work_dir
+    def fake_run(cmd, capture_output, text, **kwargs):
+        assert kwargs.get("cwd") == work_dir
         expected = captured["script_path"].replace("'", "''")
         assert cmd[0] == matlab_exec
         assert cmd[2] == f"run('{expected}')"
@@ -190,7 +190,7 @@ def test_logs_stdout_on_failure(monkeypatch, caplog):
 def test_matlab_batch_command_uses_brackets(monkeypatch):
     captured = {}
 
-    def fake_run(cmd, capture_output, text, timeout, cwd):
+    def fake_run(cmd, capture_output, text, **kwargs):
         captured["cmd"] = cmd
         return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
 
@@ -227,7 +227,7 @@ def test_reads_v7_3_mat_file(monkeypatch, tmp_path):
         captured["script_path"] = tmp.name
         return tmp
 
-    def fake_run(cmd, capture_output, text, timeout, cwd):
+    def fake_run(cmd, capture_output, text, **kwargs):
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", fake_ntf)

--- a/tests/test_video_intensity_error.py
+++ b/tests/test_video_intensity_error.py
@@ -1,75 +1,80 @@
+import importlib
 import os
 import subprocess
-import tempfile
 import sys
-import importlib
+import tempfile
 import types
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 def test_error_message_contains_hint(monkeypatch, tmp_path):
     # Provide fake numpy/scipy so the module can be imported
-    monkeypatch.setitem(sys.modules, 'numpy', types.SimpleNamespace(asarray=lambda x: x))
-    fake_scipy_io = types.SimpleNamespace(loadmat=lambda p: {'all_intensities': []})
-    monkeypatch.setitem(sys.modules, 'scipy', types.SimpleNamespace(io=fake_scipy_io))
-    monkeypatch.setitem(sys.modules, 'scipy.io', fake_scipy_io)
+    monkeypatch.setitem(
+        sys.modules, "numpy", types.SimpleNamespace(asarray=lambda x: x)
+    )
+    fake_scipy_io = types.SimpleNamespace(loadmat=lambda p: {"all_intensities": []})
+    monkeypatch.setitem(sys.modules, "scipy", types.SimpleNamespace(io=fake_scipy_io))
+    monkeypatch.setitem(sys.modules, "scipy.io", fake_scipy_io)
 
-    vi = importlib.reload(importlib.import_module('Code.video_intensity'))
+    vi = importlib.reload(importlib.import_module("Code.video_intensity"))
     func = vi.get_intensities_from_video_via_matlab
 
     captured = {}
     orig_ntf = tempfile.NamedTemporaryFile
 
     def fake_ntf(*args, **kwargs):
-        kwargs.setdefault('delete', False)
+        kwargs.setdefault("delete", False)
         fh = orig_ntf(*args, **kwargs)
-        captured['path'] = fh.name
+        captured["path"] = fh.name
         return fh
 
-    def fake_run(cmd, capture_output, text):
-        with open(captured['path']) as fh:
-            captured['contents'] = fh.read()
-        return subprocess.CompletedProcess(cmd, 1, stdout='', stderr='Configuration file not found')
+    def fake_run(cmd, capture_output, text, **kwargs):
+        with open(captured["path"]) as fh:
+            captured["contents"] = fh.read()
+        return subprocess.CompletedProcess(
+            cmd, 1, stdout="", stderr="Configuration file not found"
+        )
 
-    monkeypatch.setattr(tempfile, 'NamedTemporaryFile', fake_ntf)
-    monkeypatch.setattr(subprocess, 'run', fake_run)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", fake_ntf)
+    monkeypatch.setattr(subprocess, "run", fake_run)
 
     with pytest.raises(RuntimeError) as exc:
         func(
             'disp("hi")',
-            'matlab',
-            work_dir='.',
-            orig_script_path='/path/to/script.m',
+            "matlab",
+            work_dir=".",
+            orig_script_path="/path/to/script.m",
         )
 
     msg = str(exc.value)
-    assert '/path/to/script.m' in msg
-    assert 'orig_script_dir' in msg
+    assert "/path/to/script.m" in msg
+    assert "orig_script_dir" in msg
 
-    assert "orig_script_path = '/path/to/script.m';" in captured['contents']
-    assert 'orig_script_dir = fileparts(orig_script_path);' in captured['contents']
+    assert "orig_script_path = '/path/to/script.m';" in captured["contents"]
+    assert "orig_script_dir = fileparts(orig_script_path);" in captured["contents"]
 
 
 def test_missing_matlab_exec_raises(monkeypatch):
-    monkeypatch.setitem(sys.modules, 'numpy', types.SimpleNamespace(asarray=lambda x: x))
-    fake_scipy_io = types.SimpleNamespace(loadmat=lambda p: {'all_intensities': []})
-    monkeypatch.setitem(sys.modules, 'scipy', types.SimpleNamespace(io=fake_scipy_io))
-    monkeypatch.setitem(sys.modules, 'scipy.io', fake_scipy_io)
+    monkeypatch.setitem(
+        sys.modules, "numpy", types.SimpleNamespace(asarray=lambda x: x)
+    )
+    fake_scipy_io = types.SimpleNamespace(loadmat=lambda p: {"all_intensities": []})
+    monkeypatch.setitem(sys.modules, "scipy", types.SimpleNamespace(io=fake_scipy_io))
+    monkeypatch.setitem(sys.modules, "scipy.io", fake_scipy_io)
 
-    vi = importlib.reload(importlib.import_module('Code.video_intensity'))
+    vi = importlib.reload(importlib.import_module("Code.video_intensity"))
 
-    monkeypatch.setattr(vi.glob, 'glob', lambda pattern: [])
-    monkeypatch.setattr(vi.os.path, 'isfile', lambda p: False)
-    monkeypatch.setattr(vi.os, 'access', lambda p, x: False)
-    monkeypatch.setattr(vi.shutil, 'which', lambda name: None)
+    monkeypatch.setattr(vi.glob, "glob", lambda pattern: [])
+    monkeypatch.setattr(vi.os.path, "isfile", lambda p: False)
+    monkeypatch.setattr(vi.os, "access", lambda p, x: False)
+    monkeypatch.setattr(vi.shutil, "which", lambda name: None)
 
     with pytest.raises(FileNotFoundError) as exc:
         vi.find_matlab_executable()
 
     msg = str(exc.value)
-    assert 'MATLAB_EXEC' in msg
-    assert '--matlab_exec' in msg
+    assert "MATLAB_EXEC" in msg
+    assert "--matlab_exec" in msg


### PR DESCRIPTION
## Summary
- allow custom timeout and cwd when launching MATLAB
- update tests for subprocess kwargs

## Testing
- `ruff check Code/video_intensity.py tests/test_get_intensities_from_video_via_matlab.py tests/test_video_intensity_error.py`
- `pytest -q` *(fails: numpy missing)*
- `pre-commit run --files Code/video_intensity.py tests/test_get_intensities_from_video_via_matlab.py tests/test_video_intensity_error.py` *(fails: command not found)*