### PR TITLE
Update CLI intensity tests with monkeypatch

### DIFF
--- a/tests/test_characterize_plume_intensities_cli.py
+++ b/tests/test_characterize_plume_intensities_cli.py
@@ -44,19 +44,22 @@ def _stub_intensity_stats(monkeypatch):
         types.SimpleNamespace(calculate_intensity_stats_dict=simple_stats),
     )
 
+
 from Code import characterize_plume_intensities as cpi
 
 
-def test_video_requires_px_per_mm_and_frame_rate(tmp_path):
+def test_video_requires_px_per_mm_and_frame_rate(monkeypatch, tmp_path):
     script = tmp_path / "script.m"
     script.write_text("disp('hi')")
     out_json = tmp_path / "out.json"
     fake_crim = types.SimpleNamespace(get_intensities_from_crimaldi=lambda p: [1])
     fake_vid = types.SimpleNamespace(
-        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate, orig_script_path=None: [1]
+        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate, orig_script_path=None: [
+            1
+        ]
     )
-    sys.modules["Code.analyze_crimaldi_data"] = fake_crim
-    sys.modules["Code.video_intensity"] = fake_vid
+    monkeypatch.setitem(sys.modules, "Code.analyze_crimaldi_data", fake_crim)
+    monkeypatch.setitem(sys.modules, "Code.video_intensity", fake_vid)
     with pytest.raises(SystemExit):
         cpi.main(
             [
@@ -89,8 +92,8 @@ def test_video_valid_arguments(monkeypatch, tmp_path):
     fake_vid = types.SimpleNamespace(
         get_intensities_from_video_via_matlab=fake_vid_func
     )
-    sys.modules["Code.analyze_crimaldi_data"] = fake_crim
-    sys.modules["Code.video_intensity"] = fake_vid
+    monkeypatch.setitem(sys.modules, "Code.analyze_crimaldi_data", fake_crim)
+    monkeypatch.setitem(sys.modules, "Code.video_intensity", fake_vid)
 
     cpi.main(
         [
@@ -125,10 +128,12 @@ def test_crimaldi_valid_arguments(monkeypatch, tmp_path):
         get_intensities_from_crimaldi=lambda path: [4.0, 5.0]
     )
     fake_vid = types.SimpleNamespace(
-        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate, orig_script_path=None: [1]
+        get_intensities_from_video_via_matlab=lambda s, m, px_per_mm, frame_rate, orig_script_path=None: [
+            1
+        ]
     )
-    sys.modules["Code.analyze_crimaldi_data"] = fake_crim
-    sys.modules["Code.video_intensity"] = fake_vid
+    monkeypatch.setitem(sys.modules, "Code.analyze_crimaldi_data", fake_crim)
+    monkeypatch.setitem(sys.modules, "Code.video_intensity", fake_vid)
     out_json = tmp_path / "out.json"
 
     cpi.main(
@@ -148,25 +153,39 @@ def test_crimaldi_valid_arguments(monkeypatch, tmp_path):
     assert data[0]["plume_id"] == "pid"
     assert data[0]["statistics"]["count"] == 2
 
+
 def test_matlab_exec_option(monkeypatch, tmp_path):
     script = tmp_path / "script.m"
     script.write_text("disp('hi')")
     out_json = tmp_path / "out.json"
     fake_crim = types.SimpleNamespace(get_intensities_from_crimaldi=lambda p: [1])
     captured = {}
+
     def fake_vid_func(s, m, px_per_mm, frame_rate, orig_script_path=None):
         captured["matlab_exec"] = m
         return [1]
-    fake_vid = types.SimpleNamespace(get_intensities_from_video_via_matlab=fake_vid_func)
-    sys.modules["Code.analyze_crimaldi_data"] = fake_crim
-    sys.modules["Code.video_intensity"] = fake_vid
-    cpi.main([
-        "--plume_type", "video",
-        "--file_path", str(script),
-        "--output_json", str(out_json),
-        "--plume_id", "pid",
-        "--px_per_mm", "10",
-        "--frame_rate", "25",
-        "--matlab_exec", "/custom/matlab",
-    ])
+
+    fake_vid = types.SimpleNamespace(
+        get_intensities_from_video_via_matlab=fake_vid_func
+    )
+    monkeypatch.setitem(sys.modules, "Code.analyze_crimaldi_data", fake_crim)
+    monkeypatch.setitem(sys.modules, "Code.video_intensity", fake_vid)
+    cpi.main(
+        [
+            "--plume_type",
+            "video",
+            "--file_path",
+            str(script),
+            "--output_json",
+            str(out_json),
+            "--plume_id",
+            "pid",
+            "--px_per_mm",
+            "10",
+            "--frame_rate",
+            "25",
+            "--matlab_exec",
+            "/custom/matlab",
+        ]
+    )
     assert captured["matlab_exec"] == "/custom/matlab"


### PR DESCRIPTION
## Summary
- mock `Code.analyze_crimaldi_data` and `Code.video_intensity` using `monkeypatch.setitem`
- keep patches isolated per test in `test_characterize_plume_intensities_cli`

## Testing
- `ruff check .` *(fails: E402 and F401 errors across repository)*
- `black --check tests/test_characterize_plume_intensities_cli.py` *(fails then reformatted)*
- `pytest -k characterize_plume_intensities_cli -q` *(fails: `numpy` missing)*
