### PR TITLE
docs: detail run_statistical_tests return dictionaries

### DIFF
--- a/Code/comparative_analysis.py
+++ b/Code/comparative_analysis.py
@@ -103,6 +103,8 @@ def run_statistical_tests(
     -------
     list of dict
         Each entry contains ``metric``, ``groups``, ``t_stat`` and ``p_value``.
+        Returns a list of result dictionaries containing metrics, groups,
+        t-statistics and p-values.
 
     Examples
     --------

--- a/tests/test_run_statistical_tests_docstring.py
+++ b/tests/test_run_statistical_tests_docstring.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 
 from Code.comparative_analysis import run_statistical_tests
 
@@ -10,4 +11,9 @@ def test_run_statistical_tests_docstring_details():
     assert "cfg['statistical_analysis']" in doc
     assert 'metric_name' in doc
     assert 'groups_to_compare' in doc
-    assert 'list of result dictionaries' in doc
+    expected = (
+        'returns a list of result dictionaries containing '
+        'metrics, groups, t-statistics and p-values.'
+    )
+    normalized = re.sub(' +', ' ', doc.replace('\n', ' '))
+    assert expected in normalized


### PR DESCRIPTION
## Summary
- clarify return description in `run_statistical_tests`
- test for the updated docstring

## Testing
- `pytest tests/test_run_statistical_tests_docstring.py -q`