### PR TITLE
Fix BYTES_PER_AGENT default for batch job

### DIFF
--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -51,7 +51,7 @@ JOBS_PER_COND=$(( (AGENTS_PER_CONDITION + AGENTS_PER_JOB -1)/AGENTS_PER_JOB ))
 TOTAL_JOBS=$(( NUM_CONDITIONS * JOBS_PER_COND ))
 
 ########################  disk space check  ########################
-BYTES_PER_AGENT=${BYTES_PER_AGENT:-50000000}
+: ${BYTES_PER_AGENT:=50000000} # BYTES_PER_AGENT=50000000
 REQUIRED=$(( AGENTS_PER_CONDITION * NUM_CONDITIONS * BYTES_PER_AGENT * 12 / 10 / 1024 ))
 FREE=$(df -k --output=avail "$OUTPUT_BASE" | tail -1)
 (( FREE >= REQUIRED )) || { echo "ERR not enough space"; exit 1; }


### PR DESCRIPTION
## Summary
- set BYTES_PER_AGENT default using a POSIX parameter expansion

## Testing
- `pytest -k run_batch_job_bytes_per_agent -q` *(fails: numpy missing)*