### PR TITLE
Add envsubst step to run_test_batch script

### DIFF
--- a/run_test_batch.sh
+++ b/run_test_batch.sh
@@ -43,6 +43,10 @@ MATLAB_OPTIONS="-nodisplay -nosplash"
 EOV
 )
 
+# expand any environment variables in EXPORT_VARS (e.g., from the user's
+# shell) before passing to sbatch
+EXPORT_VARS=$(envsubst <<<"$EXPORT_VARS")
+
 JOB_ID=$(sbatch \
   --job-name="$TEST_NAME" \
   --output="$TEST_OUTPUT/slurm_%A_%a.out" \


### PR DESCRIPTION
## Summary
- expand environment variables before launching test batch

## Testing
- `pytest tests/test_run_test_batch_envsubst.py -q`
- `pre-commit` *(fails: command not found)*
