### PR TITLE
Handle existing conda environments

### DIFF
--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -428,3 +428,80 @@ def test_setup_env_invokes_nfs_cleanup():
     cleanup_indices = [i for i in range(len(content.splitlines())) if "cleanup_nfs_temp_files" in content.splitlines()[i]]
     for idx in remove_indices:
         assert any(c > idx for c in cleanup_indices)
+
+def test_conda_env_update_when_env_exists(tmp_path, monkeypatch):
+    """Existing dev_env should trigger conda env update instead of create."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    conda_base = tmp_path / "conda"
+    (conda_base / "etc/profile.d").mkdir(parents=True)
+    (conda_base / "etc/profile.d/conda.sh").write_text("")
+
+    log_file = tmp_path / "conda_log"
+    dev_env_path = Path("dev_env").resolve()
+    Path("dev_env").mkdir(exist_ok=True)
+
+    conda_script = bin_dir / "conda"
+    conda_script.write_text(
+        f"""#!/bin/bash
+if [ \"$1\" = \"info\" ] && [ \"$2\" = \"--base\" ]; then
+  echo \"{conda_base}\"
+elif [ \"$1\" = \"info\" ] && [ \"$2\" = \"--json\" ]; then
+  echo '{{"platform":"linux-64"}}'
+elif [ \"$1\" = \"env\" ] && [ \"$2\" = \"list\" ]; then
+  echo '# conda environments:'
+  echo 'dev_env {dev_env_path}'
+  exit 0
+elif [ \"$1\" = \"env\" ] && [ \"$2\" = \"create\" ]; then
+  echo create >> \"{log_file}\"
+  exit 0
+elif [ \"$1\" = \"env\" ] && [ \"$2\" = \"update\" ]; then
+  echo update >> \"{log_file}\"
+  exit 0
+elif [ \"$1\" = \"env\" ] && [ \"$2\" = \"remove\" ]; then
+  exit 0
+elif [ \"$1\" = \"run\" ]; then
+  exit 0
+else
+  exit 0
+fi
+"""
+    )
+    conda_script.chmod(0o755)
+
+    conda_lock_script = bin_dir / "conda-lock"
+    conda_lock_script.write_text("#!/bin/bash\necho 'conda-lock 1.0.0'")
+    conda_lock_script.chmod(0o755)
+
+    user_base = tmp_path / "user"
+    (user_base / "bin").mkdir(parents=True)
+
+    python_script = bin_dir / "python"
+    python_script.write_text(
+        f"""#!/bin/bash
+if [ \"$1\" = \"-m\" ] && [ \"$2\" = \"site\" ] && [ \"$3\" = \"--user-base\" ]; then
+  echo '{user_base}'
+elif [ \"$1\" = \"-m\" ] && [ \"$2\" = \"pip\" ] && [ \"$3\" = \"install\" ]; then
+  exit 0
+else
+  /usr/bin/env python \"$@\"
+fi
+"""
+    )
+    python_script.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.setenv("PYTHONUSERBASE", str(user_base))
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+
+    result = subprocess.run([
+        "bash",
+        "./setup_env.sh",
+        "--skip-conda-lock",
+        "--no-tests",
+    ], capture_output=True, text=True)
+    assert result.returncode == 0
+    log = log_file.read_text()
+    assert "update" in log
+    assert "create" not in log


### PR DESCRIPTION
## Summary
- ensure `setup_env.sh` updates existing environments instead of recreating them
- exit early when conda isn't available but the environment is active
- adapt active-environment checks
- add regression test for environment update

## Testing
- `pytest tests/test_setup_env_script.py::test_conda_env_update_when_env_exists -q`
- `pytest tests/test_setup_env_script.py -q`
