### PR TITLE
Update MATLAB path detection

### DIFF
--- a/paths.sh
+++ b/paths.sh
@@ -38,6 +38,15 @@ find_matlab() {
         return 0
     fi
     
+    # Try module system if available before searching common paths
+    if command -v module >/dev/null 2>&1; then
+        module load "$MATLAB_MODULE" >/dev/null 2>&1 || module load MATLAB >/dev/null 2>&1 || true
+        if command -v matlab >/dev/null 2>&1; then
+            command -v matlab
+            return 0
+        fi
+    fi
+
     # Try common MATLAB executable locations
     local matlab_paths=(
         "/usr/local/MATLAB/*/bin/matlab"
@@ -56,18 +65,7 @@ find_matlab() {
             fi
         done
     done
-    
-    # Try module system if available
-    if command -v module >/dev/null 2>&1; then
-        if ! module load "$MATLAB_MODULE" >/dev/null 2>&1; then
-            module load MATLAB >/dev/null 2>&1 || true
-        fi
-        if command -v matlab >/dev/null 2>&1; then
-            command -v matlab
-            return 0
-        fi
-    fi
-    
+
     return 1
 }
 

--- a/tests/test_paths_sh_module.py
+++ b/tests/test_paths_sh_module.py
@@ -22,6 +22,12 @@ def test_paths_sh_uses_module(tmp_path):
         tmp_path / "scripts" / "make_paths_relative.py",
     )
 
+    # create a dummy MATLAB installation that would be found via common paths
+    system_matlab = Path("/usr/local/MATLAB/test_module/bin/matlab")
+    system_matlab.parent.mkdir(parents=True, exist_ok=True)
+    system_matlab.write_text("#!/bin/sh\nexit 0\n")
+    system_matlab.chmod(0o755)
+
     # create fake module command
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -67,6 +73,8 @@ fi
         text=True,
         env=env,
     )
+
+    shutil.rmtree(system_matlab.parents[1])
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(fake_matlab)


### PR DESCRIPTION
## Summary
- ensure `find_matlab` loads modules before scanning default locations
- add dummy MATLAB install in module test

## Testing
- `pytest tests/test_paths_sh_module.py::test_paths_sh_uses_module -q`
- `pre-commit run --files paths.sh tests/test_paths_sh_module.py` *(fails: command not found)*