### PR TITLE
fix: iterate random seeds with index

### DIFF
--- a/run_batch_job.sh
+++ b/run_batch_job.sh
@@ -157,7 +157,8 @@ MATLAB_SCRIPT=$(mktemp /tmp/batch_job_XXXX.m)
 
 # Reset starting agent for loop iteration
 START_AGENT=$ORIGINAL_START_AGENT
-for SEED in "${RANDOM_SEEDS[@]}"; do
+for ((i=0; i<${#RANDOM_SEEDS[@]}; i++)); do
+    SEED=${RANDOM_SEEDS[i]}
     AGENT_INDEX=$((START_AGENT++))
     AGENT_DIR="${OUTPUT_BASE}/${PLUME_NAME}_${CONDITION_NAME}/${AGENT_INDEX}_${SEED}"
 

--- a/tests/test_run_batch_job_variable_expansion.py
+++ b/tests/test_run_batch_job_variable_expansion.py
@@ -6,7 +6,7 @@ def test_variables_expanded_in_loop():
     with open('run_batch_job.sh') as f:
         content = f.read()
     # Expect a loop that sets SEED and AGENT_DIR for each agent
-    loop_pattern = re.compile(r'for .*in.*RANDOM_SEEDS')
+    loop_pattern = re.compile(r'for \(\(i=0; i<\$\{#RANDOM_SEEDS\[@\]\}; i\+\+\)\)')
     assert loop_pattern.search(content), 'run_batch_job.sh should loop over RANDOM_SEEDS'
     assert 'AGENT_DIR=' in content, 'AGENT_DIR should be defined within the loop'
     assert 'SEED=' in content, 'SEED should be defined within the loop'


### PR DESCRIPTION
## Summary
- iterate over RANDOM_SEEDS using index-based loop in `run_batch_job.sh`
- adjust variable expansion test for new loop syntax

## Testing
- `pytest tests/test_run_batch_job_heredoc.py tests/test_run_batch_job_variable_expansion.py -q`