### PR TITLE
feat: always print intensity comparison results

### DIFF
--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -250,8 +250,7 @@ def main(argv: List[str] | None = None) -> None:  # pragma: no cover - CLI wrapp
         write_csv(results, ns.csv_path, diff)
     if ns.json_path:
         write_json(results, ns.json_path, diff)
-    if not ns.csv_path and not ns.json_path:
-        print(format_table(results, diff))
+    print(format_table(results, diff))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_compare_intensity_stats_diff.py
+++ b/tests/test_compare_intensity_stats_diff.py
@@ -1,10 +1,10 @@
+import csv
 import importlib
 import os
 import sys
 import types
 
 import pytest
-import csv
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -129,27 +129,29 @@ def test_diff_option_prints_table(cis, monkeypatch, capsys):
     monkeypatch.setattr(cis, "calculate_intensity_stats_dict", simple_stats)
     cis.main(["A", "path1", "B", "path2", "--diff"])
     out_lines = capsys.readouterr().out.strip().splitlines()
-    assert out_lines[-1].startswith('DIFF')
+    assert out_lines[-1].startswith("DIFF")
+
 
 def test_diff_option_writes_csv(cis, monkeypatch, tmp_path, capsys):
     arr_a = [1.0, 2.0]
     arr_b = [3.0, 5.0]
 
     def fake_load(path, *_, **__):
-        return arr_a if path == 'path1' else arr_b
+        return arr_a if path == "path1" else arr_b
 
-    monkeypatch.setattr(cis, 'load_intensities', fake_load)
-    monkeypatch.setattr(cis, 'calculate_intensity_stats_dict', simple_stats)
+    monkeypatch.setattr(cis, "load_intensities", fake_load)
+    monkeypatch.setattr(cis, "calculate_intensity_stats_dict", simple_stats)
 
-    csv_path = tmp_path / 'stats.csv'
-    cis.main(['A', 'path1', 'B', 'path2', '--diff', '--csv', str(csv_path)])
+    csv_path = tmp_path / "stats.csv"
+    cis.main(["A", "path1", "B", "path2", "--diff", "--csv", str(csv_path)])
 
     out_lines = capsys.readouterr().out.strip().splitlines()
+    assert out_lines[0].startswith("identifier")
 
-    with csv_path.open(newline='') as f:
+    with csv_path.open(newline="") as f:
         rows = list(csv.reader(f))
 
-    assert rows[-1][0] == 'DIFF'
+    assert rows[-1][0] == "DIFF"
     assert float(rows[-1][1]) == pytest.approx(-2.5)
     assert float(rows[-1][2]) == pytest.approx(-2.5)
     diff_row = out_lines[-1].split("\t")


### PR DESCRIPTION
## Summary
- print table output for compare_intensity_stats regardless of `--csv`/`--json`
- verify stdout output when writing CSV in tests

## Testing
- `black Code/compare_intensity_stats.py tests/test_compare_intensity_stats_diff.py`
- `isort Code/compare_intensity_stats.py tests/test_compare_intensity_stats_diff.py`
- `ruff check Code/compare_intensity_stats.py tests/test_compare_intensity_stats_diff.py`
- `mypy Code/compare_intensity_stats.py tests/test_compare_intensity_stats_diff.py` *(fails: missing dependencies)*
- `pytest -k test_diff_option_writes_csv tests/test_compare_intensity_stats_diff.py` *(fails: ModuleNotFoundError: loguru)*
- `pre-commit run --files Code/compare_intensity_stats.py tests/test_compare_intensity_stats_diff.py` *(fails: command not found)*