### PR TITLE
Update matlab finder to return requested path

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -57,8 +57,11 @@ def find_matlab_executable(user_path: Optional[str] = None) -> str:
     If the environment variable ``MATLAB_EXEC`` points to an executable
     file, it is used ahead of any auto-detection logic.
     """
-    # Check user-provided path first
-    if user_path and os.path.isfile(user_path) and os.access(user_path, os.X_OK):
+    # Check user-provided path first. If supplied, prefer it even when not
+    # executable so callers can handle the failure themselves.
+    if user_path:
+        if not (os.path.isfile(user_path) and os.access(user_path, os.X_OK)):
+            logger.debug("User provided MATLAB path is not executable: %s", user_path)
         return user_path
 
     # Environment variable override

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -239,9 +239,8 @@ def test_reads_v7_3_mat_file(monkeypatch, tmp_path):
     assert not mat_file.exists()
 
 
-def test_command_uses_found_matlab_executable(monkeypatch):
-    found = "/opt/matlab/bin/matlab"
-    passed = "/usr/bin/ignored"
+def test_command_uses_given_matlab_executable(monkeypatch):
+    passed = "/usr/bin/custom"
 
     captured = {}
 
@@ -250,13 +249,8 @@ def test_command_uses_found_matlab_executable(monkeypatch):
         return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(
-        sys.modules["Code.video_intensity"],
-        "find_matlab_executable",
-        lambda p=None: found,
-    )
 
     with pytest.raises(RuntimeError):
         get_intensities_from_video_via_matlab("disp('fail')", passed)
 
-    assert captured["cmd"][0] == found
+    assert captured["cmd"][0] == passed


### PR DESCRIPTION
## Summary
- allow `find_matlab_executable` to always return a supplied path
- expect `get_intensities_from_video_via_matlab` to invoke MATLAB using the
  caller provided executable
- update tests accordingly

## Testing
- `./setup_env.sh --dev` *(fails: wget cannot run without network)*
- `pytest tests/test_get_intensities_from_video_via_matlab.py -k given_matlab -q` *(skipped: numpy not installed)*
- `pytest tests/test_find_matlab_executable.py -q` *(fails: ModuleNotFoundError: No module named 'h5py')*