### PR TITLE
Add _compute_dt error tests

### DIFF
--- a/tests/test_calculate_metrics.py
+++ b/tests/test_calculate_metrics.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 import pytest
 
 from Code.load_analysis_config import load_analysis_config
-from Code.calculate_metrics import calculate_metrics
+from Code.calculate_metrics import calculate_metrics, _compute_dt
 
 
 def test_calculate_metrics(tmp_path):
@@ -55,3 +55,31 @@ def test_calculate_metrics(tmp_path):
     assert metrics["net_upwind_displacement"] == pytest.approx(0.5)
     assert metrics["straightness"] == pytest.approx(math.dist((0, 0), (2, 0.5)) / expected_path_length)
     assert metrics["turning_rate"] == pytest.approx(1/3)
+
+
+def test_compute_dt_from_latency_missing_latency():
+    record = {"trajectories": [{"t": 0}, {"t": 1}]}
+    params = {"average_speed": {"dt_source": "from_latency"}}
+    with pytest.raises(ValueError):
+        _compute_dt(record, params)
+
+
+def test_compute_dt_from_config_missing_frame_rate():
+    record = {"trajectories": [{"t": 0}, {"t": 1}], "config": {}}
+    params = {"average_speed": {"dt_source": "from_config_used_yaml"}}
+    with pytest.raises(ValueError):
+        _compute_dt(record, params)
+
+
+def test_compute_dt_fixed_value_missing_parameter():
+    record = {"trajectories": [{"t": 0}]}
+    params = {"average_speed": {"dt_source": "fixed_value"}}
+    with pytest.raises(ValueError):
+        _compute_dt(record, params)
+
+
+def test_compute_dt_unknown_source():
+    record = {"trajectories": [{"t": 0}]}
+    params = {"average_speed": {"dt_source": "bogus"}}
+    with pytest.raises(ValueError):
+        _compute_dt(record, params)


### PR DESCRIPTION
## Summary
- add failing cases for `_compute_dt`

## Testing
- `pytest tests/test_calculate_metrics.py -k compute_dt -vv` *(fails: collected 0 items / 1 skipped)*