### PR TITLE
Add CLI error check for compare_intensity_stats diff option

### DIFF
--- a/Code/compare_intensity_stats.py
+++ b/Code/compare_intensity_stats.py
@@ -223,6 +223,11 @@ def main(argv: List[str] | None = None) -> None:  # pragma: no cover - CLI wrapp
     ns = parser.parse_args(argv)
     logging.basicConfig(level=getattr(logging, ns.log_level))
 
+    if ns.diff:
+        dataset_count = max(len(ns.items) // 2, len(ns.items) // 3)
+        if dataset_count != 2:
+            parser.error("Exactly two datasets are required to compute differences")
+
     if len(ns.items) % 3 == 0:
         entries = [
             (ns.items[i], ns.items[i + 2], ns.items[i + 1])

--- a/tests/test_compare_intensity_stats_diff_cli_error.py
+++ b/tests/test_compare_intensity_stats_diff_cli_error.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_compare_intensity_stats_diff import cis as cis_fixture
+
+
+def test_diff_with_three_datasets_errors(cis_fixture, monkeypatch, capsys):
+    cis = cis_fixture
+    monkeypatch.setattr(cis, "load_intensities", lambda *a, **k: [1.0])
+    with pytest.raises(SystemExit) as excinfo:
+        cis.main([
+            "A",
+            "path1",
+            "B",
+            "path2",
+            "C",
+            "path3",
+            "--diff",
+        ])
+    assert excinfo.value.code != 0
+    err = capsys.readouterr().err.lower()
+    assert "two datasets" in err


### PR DESCRIPTION
## Summary
- add regression test for error when `--diff` is used with more than two datasets
- enforce dataset count validation in `compare_intensity_stats.main`

## Testing
- `pytest tests/test_compare_intensity_stats_diff_cli_error.py::test_diff_with_three_datasets_errors -q`
- `pre-commit run --files Code/compare_intensity_stats.py tests/test_compare_intensity_stats_diff_cli_error.py` *(fails: command not found)*