### PR TITLE
Add missing file test for load_analysis_config

### DIFF
--- a/tests/test_load_analysis_config.py
+++ b/tests/test_load_analysis_config.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from Code.load_analysis_config import load_analysis_config
@@ -13,3 +15,10 @@ def test_load_analysis_config():
     assert 'output_paths' in cfg
     assert 'statistical_analysis' in cfg
     assert 'statistical_tests' not in cfg
+
+
+def test_load_analysis_config_missing_file():
+    """load_analysis_config should raise when file is absent."""
+    nonexistent = os.path.join('configs', 'i_do_not_exist.yaml')
+    with pytest.raises(FileNotFoundError):
+        load_analysis_config(nonexistent)


### PR DESCRIPTION
## Summary
- ensure load_analysis_config raises FileNotFoundError on missing path

## Testing
- `pytest tests/test_load_analysis_config.py::test_load_analysis_config_missing_file -vv`
