### PR TITLE
Add pure-python intensity extraction

### DIFF
--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -190,6 +190,22 @@ The MATLAB executable is auto-detected when you source `paths.sh`. Pass
 `--matlab_exec` only if you need to override the detected path.
 Use `--allow-mismatch` if the intensity vectors have different lengths.
 
+### Pure Python Workflow
+
+Video files can be processed without MATLAB using the `--pure-python` flag. The
+helper function reads frames via `imageio` and stores the resulting intensities
+in a NumPy ``.npy`` file. Install ``imageio`` with ``pip install imageio`` if it
+isn't already available.
+
+Example:
+
+```bash
+conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
+    SMOKE data/smoke_1a_bgsub_raw.avi \
+    CRIM data/10302017_10cms_bounded_2.h5 \
+    --pure-python
+```
+
 #### When MATLAB cannot be found
 
 If `compare_intensity_stats` cannot locate MATLAB it prints an error:

--- a/tests/test_extract_intensities_from_video.py
+++ b/tests/test_extract_intensities_from_video.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+imageio = pytest.importorskip("imageio.v3")
+
+from Code import video_intensity as vi
+
+
+def test_extract_intensities_from_video(tmp_path):
+    frames = np.array([
+        [[0, 255], [128, 64]],
+        [[255, 128], [64, 0]],
+    ], dtype=np.uint8)
+    video_path = tmp_path / "tiny.mp4"
+    imageio.imwrite(video_path, frames, fps=1)
+
+    expected = frames.reshape(-1) / 255.0
+    result = vi.extract_intensities_from_video(str(video_path))
+    assert np.allclose(result, expected)


### PR DESCRIPTION
## Summary
- implement `extract_intensities_from_video` using `imageio`
- make `compare_intensity_stats` support a `--pure-python` mode
- add tests for pure-python intensity workflow
- document pure-python workflow in intensity comparison docs

## Testing
- `conda run --prefix ./dev_env pre-commit run --files Code/video_intensity.py Code/compare_intensity_stats.py tests/test_extract_intensities_from_video.py tests/test_compare_intensity_stats.py tests/test_load_intensities.py docs/intensity_comparison.md` *(fails: `conda: command not found`)*