### PR TITLE
Stub matplotlib module in intensity stats test

### DIFF
--- a/tests/test_intensity_stats.py
+++ b/tests/test_intensity_stats.py
@@ -40,7 +40,8 @@ def test_main_plot_histogram(monkeypatch, tmp_path):
                                   xlabel=lambda *a, **k: None,
                                   ylabel=lambda *a, **k: None,
                                   show=lambda *a, **k: None)
-    monkeypatch.setitem(sys.modules, 'matplotlib.pyplot', dummy)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", dummy)
+    monkeypatch.setitem(sys.modules, "matplotlib", types.SimpleNamespace(pyplot=dummy))
     stats = main(["plumeB", str(f), "--plot_histogram"])
     assert stats["count"] == 5
 


### PR DESCRIPTION
## Summary
- patch `tests/test_intensity_stats.py` so the `matplotlib` module exists when the CLI tries to import it

## Testing
- `./setup_env.sh --dev` *(fails: wget https://repo.anaconda.com/miniconda/...)*
- `pre-commit run --files tests/test_intensity_stats.py` *(fails: command not found)*
- `pytest -k intensity_stats -q` *(fails: ModuleNotFoundError: No module named 'numpy')*