### PR TITLE
Resolve bash path dynamically in tests

### DIFF
--- a/tests/test_paths_script.py
+++ b/tests/test_paths_script.py
@@ -1,5 +1,7 @@
 import subprocess
 import shutil
+
+BASH = shutil.which("bash") or "/bin/bash"
 import pytest
 
 
@@ -10,7 +12,7 @@ def test_paths_script(tmp_path):
 
     env_result = subprocess.run(
         [
-            "bash",
+            BASH,
             "./setup_env.sh",
             "--skip-conda-lock",
             "--no-tests",
@@ -21,7 +23,7 @@ def test_paths_script(tmp_path):
     assert env_result.returncode == 0, env_result.stderr
 
     result = subprocess.run([
-        "bash",
+        BASH,
         "./paths.sh",
     ], cwd=tmp_path, capture_output=True, text=True)
     assert result.returncode == 0

--- a/tests/test_paths_sh_module.py
+++ b/tests/test_paths_sh_module.py
@@ -3,6 +3,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+BASH = shutil.which("bash") or "/bin/bash"
+
 
 def test_paths_sh_uses_module(tmp_path):
     repo_root = Path(__file__).resolve().parents[1]
@@ -67,7 +69,7 @@ fi
     env["PATH"] = f"{system_matlab.parent}:{bin_dir}"
 
     result = subprocess.run(
-        ["/usr/bin/bash", "-c", "source ./paths.sh && echo $MATLAB_EXEC"],
+        [BASH, "-c", "source ./paths.sh && echo $MATLAB_EXEC"],
         cwd=tmp_path,
         capture_output=True,
         text=True,

--- a/tests/test_paths_sh_noninteractive.py
+++ b/tests/test_paths_sh_noninteractive.py
@@ -3,6 +3,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+BASH = shutil.which("bash") or "/bin/bash"
+
 
 def test_paths_sh_noninteractive_quiet(tmp_path):
     repo_root = Path(__file__).resolve().parents[1]
@@ -32,7 +34,7 @@ def test_paths_sh_noninteractive_quiet(tmp_path):
 
     log_file = tmp_path / "log"
     result = subprocess.run(
-        ["/usr/bin/bash", "-c", f"source ./paths.sh > {log_file} 2>&1 && echo $MATLAB_EXEC"],
+        [BASH, "-c", f"source ./paths.sh > {log_file} 2>&1 && echo $MATLAB_EXEC"],
         cwd=tmp_path,
         capture_output=True,
         text=True,

--- a/tests/test_paths_sh_regression.py
+++ b/tests/test_paths_sh_regression.py
@@ -1,5 +1,7 @@
 import shutil
 import subprocess
+
+BASH = shutil.which("bash") or "/bin/bash"
 from pathlib import Path
 
 
@@ -17,7 +19,7 @@ def test_paths_sh_runs_without_syntaxerror(tmp_path):
         tmp_path, "scripts", repo_root, "make_paths_relative.py"
     )
     result = subprocess.run(
-        ["bash", str(tmp_path / "paths.sh")],
+        [BASH, str(tmp_path / "paths.sh")],
         capture_output=True,
         text=True,
         cwd=tmp_path,

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -5,6 +5,8 @@ import shutil
 import pytest
 from pathlib import Path
 
+BASH = shutil.which("bash") or "/bin/bash"
+
 
 def test_setup_env_script_exists():
     assert os.path.isfile('setup_env.sh'), 'setup_env.sh does not exist'
@@ -89,7 +91,7 @@ fi
     monkeypatch.setenv("PYTHONUSERBASE", str(user_base))
     monkeypatch.delenv("CONDA_PREFIX", raising=False)
 
-    cmd = ["bash", "./setup_env.sh", "--skip-conda-lock", "--no-tests"]
+    cmd = [BASH, "./setup_env.sh", "--skip-conda-lock", "--no-tests"]
 
     result1 = subprocess.run(cmd, capture_output=True, text=True)
     assert result1.returncode == 0
@@ -194,7 +196,7 @@ fi
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
 
     result = subprocess.run(
-        ["bash", "./setup_env.sh", "--skip-conda-lock", "--no-tests"],
+        [BASH, "./setup_env.sh", "--skip-conda-lock", "--no-tests"],
         capture_output=True,
         text=True,
     )
@@ -265,7 +267,7 @@ exit 0
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
 
     result = subprocess.run(
-        ["bash", "./setup_env.sh", "--dev", "--skip-conda-lock", "--no-tests"],
+        [BASH, "./setup_env.sh", "--dev", "--skip-conda-lock", "--no-tests"],
         capture_output=True,
         text=True,
     )
@@ -378,7 +380,7 @@ fi
     monkeypatch.setenv("PATH", f"{user_bin}:{bin_dir}:{os.environ['PATH']}")
 
     result = subprocess.run(
-        ["bash", "./setup_env.sh", "--no-tests"],
+        [BASH, "./setup_env.sh", "--no-tests"],
         capture_output=True,
         text=True,
     )
@@ -389,7 +391,7 @@ def test_setup_env_exits_when_active(monkeypatch):
     """Script should fail if run inside an active environment."""
     monkeypatch.setenv("CONDA_PREFIX", os.path.abspath("dev_env"))
     result = subprocess.run([
-        "bash",
+        BASH,
         "./setup_env.sh",
         "--dev",
     ], capture_output=True, text=True)
@@ -454,7 +456,7 @@ fi
     monkeypatch.delenv("CONDA_PREFIX", raising=False)
 
     result = subprocess.run(
-        ["bash", "./setup_env.sh", "--skip-conda-lock", "--no-tests"],
+        [BASH, "./setup_env.sh", "--skip-conda-lock", "--no-tests"],
         capture_output=True,
         text=True,
     )
@@ -539,7 +541,7 @@ fi
     monkeypatch.delenv("CONDA_PREFIX", raising=False)
 
     result = subprocess.run([
-        "bash",
+        BASH,
         "./setup_env.sh",
         "--skip-conda-lock",
         "--no-tests",
@@ -610,7 +612,7 @@ fi
     conda_lock_script.chmod(0o755)
 
     result = subprocess.run(
-        ["bash", "./setup_env.sh", "--no-tests"],
+        [BASH, "./setup_env.sh", "--no-tests"],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Summary
- use `shutil.which("bash") or "/bin/bash"` to locate bash
- apply dynamic bash path in test subprocess calls

## Testing
- `pytest tests/test_paths_sh_regression.py::test_paths_sh_runs_without_syntaxerror -q`
- `pytest tests/test_paths_script.py tests/test_paths_sh_module.py tests/test_paths_sh_noninteractive.py tests/test_setup_env_script.py -q` *(fails: Installing conda-lock not skipped)*
- `pre-commit run --files tests/test_paths_sh_regression.py tests/test_paths_script.py tests/test_paths_sh_module.py tests/test_paths_sh_noninteractive.py tests/test_setup_env_script.py` *(fails: command not found)*