### PR TITLE
Implement clean install option in setup_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Check if the conda environment exists, if not, create it.
 
  - Check: `./dev_env` exists
  - If not, run: `./setup_env.sh --dev`
+   - Use `--clean-install` for a fresh reinstall if needed
 
 Check if pre commit hooks are installed, if not, install them.
 
@@ -60,6 +61,7 @@ conda run --prefix ./dev_env python -m Code.some_script
 1 and 2 are only *as required* -- check if there's evidence they've already run
 
 1. Run `./setup_env.sh --dev` to create `./dev_env`.
+   - Add `--clean-install` to force removal of the existing environment.
 2. Source `./paths.sh` to generate `configs/project_paths.yaml` and detect MATLAB. `paths.sh` uses this file and falls back to default paths when `yq` is missing.
 3. Execute `conda run --prefix ./dev_env python -m Code.compare_intensity_stats`.
 

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -637,3 +637,85 @@ fi
     assert "Installing conda-lock" not in output
     executed = log_file.read_text()
     assert "conda install -y -c conda-forge conda-lock" not in executed
+
+def test_clean_install_removes_env_before_create(tmp_path, monkeypatch):
+    """--clean-install should remove dev_env before creation."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    conda_base = tmp_path / "conda"
+    (conda_base / "etc/profile.d").mkdir(parents=True)
+    (conda_base / "etc/profile.d/conda.sh").write_text("")
+
+    log_file = tmp_path / "conda_log"
+    (Path("dev_env") / "conda-meta").mkdir(parents=True, exist_ok=True)
+
+    conda_script = bin_dir / "conda"
+    conda_script.write_text(
+        f"""#!/bin/bash
+echo "$@" >> "{log_file}"
+if [ \"$1\" = \"info\" ] && [ \"$2\" = \"--base\" ]; then
+  echo \"{conda_base}\"
+elif [ \"$1\" = \"info\" ] && [ \"$2\" = \"--json\" ]; then
+  echo '{{"platform":"linux-64"}}'
+elif [ \"$1\" = \"env\" ] && [ \"$2\" = \"remove\" ]; then
+  echo remove >> \"{log_file}\"
+  exit 0
+elif [ \"$1\" = \"env\" ] && [ \"$2\" = \"create\" ]; then
+  echo create >> \"{log_file}\"
+  exit 0
+elif [ \"$1\" = \"env\" ] && [ \"$2\" = \"update\" ]; then
+  echo update >> \"{log_file}\"
+  exit 0
+elif [ \"$1\" = \"run\" ]; then
+  exit 0
+else
+  exit 0
+fi
+"""
+    )
+    conda_script.chmod(0o755)
+
+    conda_lock_script = bin_dir / "conda-lock"
+    conda_lock_script.write_text("#!/bin/bash\necho 'conda-lock 1.0.0'")
+    conda_lock_script.chmod(0o755)
+
+    user_base = tmp_path / "user"
+    (user_base / "bin").mkdir(parents=True)
+
+    python_script = bin_dir / "python"
+    python_script.write_text(
+        f"""#!/bin/bash
+if [ \"$1\" = \"-m\" ] && [ \"$2\" = \"site\" ] && [ \"$3\" = \"--user-base\" ]; then
+  echo '{user_base}'
+elif [ \"$1\" = \"-m\" ] && [ \"$2\" = \"pip\" ] && [ \"$3\" = \"install\" ]; then
+  exit 0
+else
+  /usr/bin/env python \"$@\"
+fi
+"""
+    )
+    python_script.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.setenv("PYTHONUSERBASE", str(user_base))
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+
+    result = subprocess.run(
+        ["bash", "./setup_env.sh", "--clean-install", "--skip-conda-lock", "--no-tests"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    log = log_file.read_text()
+    assert "remove" in log
+    assert "create" in log
+    assert "update" not in log
+
+
+def test_env_update_uses_prune_flag():
+    """Update step should include --prune option."""
+    with open("setup_env.sh") as f:
+        content = f.read()
+    lines = [l for l in content.splitlines() if "conda env update" in l]
+    assert any("--prune" in l for l in lines)


### PR DESCRIPTION
## Summary
- support `--clean-install` flag for the environment setup script
- document the new flag in the README
- test that the flag removes the environment before creation
- ensure updates use `--prune` and adjust conda-lock installation logic

## Testing
- `pytest tests/test_setup_env_script.py::test_clean_install_removes_env_before_create tests/test_setup_env_script.py::test_env_update_uses_prune_flag -q`
