### PR TITLE
Add imageio to Conda envs

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pyyaml
   - matplotlib
   - scipy
+  - imageio
   
   # Development tools
   - conda-lock>=2.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - matplotlib
   - scipy
   - ruff
+  - imageio

--- a/tests/test_env_dependencies.py
+++ b/tests/test_env_dependencies.py
@@ -14,3 +14,10 @@ def test_envs_require_ruff() -> None:
     base_env_text = _read_env("environment.yml")
     assert "ruff" in dev_env_text
     assert "ruff" in base_env_text
+
+
+def test_envs_require_imageio() -> None:
+    dev_env_text = _read_env("dev-environment.yml")
+    base_env_text = _read_env("environment.yml")
+    assert "imageio" in dev_env_text
+    assert "imageio" in base_env_text


### PR DESCRIPTION
## Summary
- add `imageio` to Conda specs
- verify `imageio` is required in tests

## Testing
- `bash ./setup_env.sh --dev --no-tests --skip-conda-lock` *(fails: conda not found, installing Miniconda)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files environment.yml dev-environment.yml tests/test_env_dependencies.py` *(fails: command not found)*