### PR TITLE
Add ffmpeg plugin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ it points to a valid executable.
 Use `--allow-mismatch` with `Code.compare_intensity_stats` if your datasets have
 different lengths.
 
-`imageio` is included in the default environment so the `--pure-python` option
-works without any extra installation.
+`imageio` together with its `imageio-ffmpeg` backend is included in the default
+environment so the `--pure-python` option works without any extra
+installation when reading ``.avi`` files.
 
 See [docs/intensity_comparison.md](docs/intensity_comparison.md#initial-setup)
 for a detailed explanation of the path setup process.

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - matplotlib
   - scipy
   - imageio
+  - imageio-ffmpeg
   
   # Development tools
   - conda-lock>=2.0.0

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -194,8 +194,9 @@ Use `--allow-mismatch` if the intensity vectors have different lengths.
 
 Video files can be processed without MATLAB using the `--pure-python` flag. The
 helper function reads frames via `imageio` and stores the resulting intensities
-in a NumPy ``.npy`` file. ``imageio`` is included in the default environment, so
-this workflow works out of the box.
+in a NumPy ``.npy`` file. ``imageio`` along with the ``imageio-ffmpeg`` plugin
+is included in the default environment so this workflow works out of the box
+for ``.avi`` files.
 
 Example:
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - scipy
   - ruff
   - imageio
+  - imageio-ffmpeg

--- a/tests/test_env_dependencies.py
+++ b/tests/test_env_dependencies.py
@@ -21,3 +21,10 @@ def test_envs_require_imageio() -> None:
     base_env_text = _read_env("environment.yml")
     assert "imageio" in dev_env_text
     assert "imageio" in base_env_text
+
+
+def test_envs_require_imageio_ffmpeg() -> None:
+    dev_env_text = _read_env("dev-environment.yml")
+    base_env_text = _read_env("environment.yml")
+    assert "imageio-ffmpeg" in dev_env_text
+    assert "imageio-ffmpeg" in base_env_text


### PR DESCRIPTION
## Summary
- include `imageio-ffmpeg` in both environment files
- assert the new dependency in `test_env_dependencies`
- document ffmpeg plugin for `.avi` support

## Testing
- `pytest -q tests/test_env_dependencies.py`
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*
- `ruff check .`