### PR TITLE
Remove duplicate active-env check

### DIFF
--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -415,39 +415,6 @@ fi
 
     assert result.returncode == 0
 
-def test_setup_env_exits_when_active(tmp_path, monkeypatch):
-    """Script should fail if run inside an active environment."""
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-
-    conda_script = bin_dir / "conda"
-    conda_script.write_text(
-        f"""#!/bin/bash
-if [ \"$1\" = \"info\" ] && [ \"$2\" = \"--base\" ]; then
-  echo \"{tmp_path}\"
-elif [ \"$1\" = \"info\" ] && [ \"$2\" = \"--json\" ]; then
-  echo '{{"platform":"linux-64"}}'
-else
-  exit 0
-fi
-"""
-    )
-    conda_script.chmod(0o755)
-
-    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
-
-    dev_env = Path("dev_env")
-    dev_env.mkdir(exist_ok=True)
-    monkeypatch.setenv("CONDA_PREFIX", str(dev_env.resolve()))
-
-    result = subprocess.run(
-        [BASH, "./setup_env.sh", "--dev", "--skip-conda-lock"],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode != 0
-    assert "deactivate" in result.stdout + result.stderr
-
 
 def test_setup_succeeds_when_dev_env_missing(tmp_path, monkeypatch):
     """Script should not abort if dev_env directory is absent and no environment is active."""


### PR DESCRIPTION
## Summary
- remove unused `test_setup_env_exits_when_active` from setup env tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files tests/test_setup_env_script.py` *(fails: pre-commit: command not found)*