### PR TITLE
Add skip flag for slow environment tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,12 @@ conda run --prefix ./dev_env python -m Code.some_script
 - `docs/` – project documentation
 
 For citations and metadata, see `CITATION.cff` and `codemeta.json`.
+
+## Running Tests
+
+Invoke `pytest` from the repository root. Slow tests that set up a full
+environment are skipped unless the `--runslow` flag is supplied:
+
+```bash
+conda run --prefix ./dev_env pytest --runslow
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,29 @@
 import sys
 from pathlib import Path
+import pytest
 
 
-def pytest_configure():
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow",
+        action="store_true",
+        default=False,
+        help="run tests marked as slow",
+    )
+
+
+def pytest_configure(config):
     repo_root = Path(__file__).resolve().parents[1]
     repo_root_str = str(repo_root)
     if repo_root_str not in sys.path:
         sys.path.insert(0, repo_root_str)
+    config.addinivalue_line("markers", "slow: mark test as slow to skip by default")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="slow test, use --runslow to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/test_paths_script.py
+++ b/tests/test_paths_script.py
@@ -7,6 +7,7 @@ import pytest
 BASH = shutil.which("bash") or "/bin/bash"
 
 
+@pytest.mark.slow
 @pytest.mark.usefixtures("tmp_path")
 def test_paths_script(tmp_path):
     if shutil.which("conda") is None:


### PR DESCRIPTION
## Summary
- mark tests that run setup_env.sh as `slow`
- provide `--runslow` pytest option to control skipping
- document slow test flag in the README

## Testing
- `pytest -k test_paths_script -vv` *(fails: ModuleNotFoundError: No module named 'loguru')*