### PR TITLE
feat: log memory usage when reading videos

### DIFF
--- a/tests/test_extract_intensities_memory_logging.py
+++ b/tests/test_extract_intensities_memory_logging.py
@@ -1,0 +1,18 @@
+import logging
+import numpy as np
+import pytest
+
+imageio = pytest.importorskip("imageio.v3")
+
+from Code import video_intensity as vi
+
+
+def test_extract_intensities_logs_memory(tmp_path, caplog):
+    frames = np.zeros((3, 2, 2), dtype=np.uint8)
+    video_path = tmp_path / "small.mp4"
+    imageio.imwrite(video_path, frames, fps=1)
+
+    with caplog.at_level(logging.INFO):
+        vi.extract_intensities_from_video(str(video_path))
+
+    assert any("MB" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- report estimated and actual memory use in `extract_intensities_from_video`
- add helper `estimate_video_memory`
- log memory usage in tests
- mention memory reporting in module docstring

## Testing
- `./setup_env.sh --dev` *(fails: wget unable to fetch due to network)*
- `pre-commit run --files Code/video_intensity.py tests/test_extract_intensities_memory_logging.py` *(fails: pre-commit not installed)*
- `pytest -k test_extract_intensities_memory_logging -q` *(fails: ModuleNotFoundError: no module named 'loguru', 'numpy')*