### PR TITLE
Fix video writing macroblock size in tests

### DIFF
--- a/tests/test_extract_intensities_from_video.py
+++ b/tests/test_extract_intensities_from_video.py
@@ -12,7 +12,7 @@ def test_extract_intensities_from_video(tmp_path):
         [[255, 128], [64, 0]],
     ], dtype=np.uint8)
     video_path = tmp_path / "tiny.mp4"
-    imageio.imwrite(video_path, frames, fps=1)
+    imageio.imwrite(video_path, frames, fps=1, macro_block_size=None)
 
     expected = frames.reshape(-1) / 255.0
     result = vi.extract_intensities_from_video(str(video_path))

--- a/tests/test_extract_intensities_memory_logging.py
+++ b/tests/test_extract_intensities_memory_logging.py
@@ -10,7 +10,7 @@ from Code import video_intensity as vi
 def test_extract_intensities_logs_memory(tmp_path, caplog):
     frames = np.zeros((3, 2, 2), dtype=np.uint8)
     video_path = tmp_path / "small.mp4"
-    imageio.imwrite(video_path, frames, fps=1)
+    imageio.imwrite(video_path, frames, fps=1, macro_block_size=None)
 
     with caplog.at_level(logging.INFO):
         vi.extract_intensities_from_video(str(video_path))


### PR DESCRIPTION
## Summary
- ensure imageio writes mp4s without resizing to macroblocks in tests

## Testing
- `pytest tests/test_extract_intensities_from_video.py -vv` *(fails: ModuleNotFoundError: No module named 'numpy')*