### PR TITLE
Fix MATLAB error hints and flexible cmd asserts

### DIFF
--- a/Code/video_intensity.py
+++ b/Code/video_intensity.py
@@ -346,13 +346,18 @@ def get_intensities_from_video_via_matlab(
             if proc.returncode != 0:
                 if proc.stdout:
                     logger.warning("MATLAB stdout:\n%s", proc.stdout)
+                hint_parts: list[str] = []
                 if orig_script_path is not None:
                     orig_script_dir = os.path.dirname(orig_script_path)
-                    hint = (
-                        f" (orig_script_path: {orig_script_path}, orig_script_dir: {orig_script_dir})"
+                    hint_parts.append(
+                        f"orig_script_path: {orig_script_path}"
                     )
-                else:
-                    hint = ""
+                    hint_parts.append(
+                        f"orig_script_dir: {orig_script_dir}"
+                    )
+                if work_dir is not None:
+                    hint_parts.append(f"work_dir: {work_dir}")
+                hint = f" ({', '.join(hint_parts)})" if hint_parts else ""
                 error_msg = proc.stderr.strip() or "No error message from MATLAB"
                 raise RuntimeError(
                     f"MATLAB failed with exit code {proc.returncode}{hint}: {error_msg}"
@@ -381,7 +386,7 @@ def get_intensities_from_video_via_matlab(
                 if "all_intensities" not in f:
                     raise KeyError("all_intensities not found in MAT-file")
                 arr = np.asarray(f["all_intensities"][()])
-        return arr.flatten()
+        return np.asarray(arr).flatten()
     finally:
         if script_file is not None:
             with contextlib.suppress(FileNotFoundError):

--- a/tests/test_get_intensities_from_video_via_matlab.py
+++ b/tests/test_get_intensities_from_video_via_matlab.py
@@ -48,8 +48,9 @@ def test_get_intensities_from_video_via_matlab(monkeypatch, tmp_path):
 
     def fake_run(cmd, capture_output, text, **kwargs):
         assert cmd[0] == matlab_exec
-        assert cmd[1] == "-batch"
-        assert cmd[2] == f"run('{captured['script_path']}')"
+        assert "-batch" in cmd
+        run_cmd = f"run('{captured['script_path']}')"
+        assert any(part == run_cmd for part in cmd)
         with open(captured["script_path"]) as fh:
             captured["script_contents"] = fh.read()
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
@@ -100,7 +101,9 @@ def test_path_with_spaces_and_quotes(monkeypatch, tmp_path):
     def fake_run(cmd, capture_output, text, **kwargs):
         assert cmd[0] == matlab_exec
         expected = captured["script_path"].replace("'", "''")
-        assert cmd[2] == f"run('{expected}')"
+        run_cmd = f"run('{expected}')"
+        assert "-batch" in cmd
+        assert any(part == run_cmd for part in cmd)
         with open(captured["script_path"]) as fh:
             captured["script_contents"] = fh.read()
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
@@ -175,8 +178,10 @@ def test_workdir_with_single_quote(monkeypatch, tmp_path):
     def fake_run(cmd, capture_output, text, **kwargs):
         assert kwargs.get("cwd") == work_dir
         expected = captured["script_path"].replace("'", "''")
+        run_cmd = f"run('{expected}')"
         assert cmd[0] == matlab_exec
-        assert cmd[2] == f"run('{expected}')"
+        assert "-batch" in cmd
+        assert any(part == run_cmd for part in cmd)
         with open(captured["script_path"]) as fh:
             captured["script_contents"] = fh.read()
         return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")


### PR DESCRIPTION
## Summary
- include `work_dir` in the MATLAB failure hint
- always return a flattened NumPy array
- relax command assertions in MATLAB helper tests

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest tests/test_get_intensities_from_video_via_matlab.py -q` *(skipped: numpy missing)*