### PR TITLE
Fix YAML parser used without PyYAML

### DIFF
--- a/Code/plume_utils.py
+++ b/Code/plume_utils.py
@@ -14,18 +14,19 @@ except ModuleNotFoundError:  # pragma: no cover - use a minimal parser
     import types
 
     def _minimal_load(path: Path) -> Dict[str, Dict[str, float]]:
+        """Very small YAML subset parser used when PyYAML is unavailable."""
         data: Dict[str, Dict[str, float]] = {}
         current: str | None = None
-        for line in path.read_text().splitlines():
-            line = line.strip()
-            if not line or line.startswith("#"):
+        for raw_line in path.read_text().splitlines():
+            stripped = raw_line.strip()
+            if not stripped or stripped.startswith("#"):
                 continue
-            if not line.startswith("  "):
-                current = line.rstrip(":")
+            if not raw_line.startswith("  "):
+                current = stripped.rstrip(":")
                 data[current] = {}
             else:
-                key, value = line.split(":", 1)
-                data[current][key.strip()] = float(value)
+                key, value = stripped.split(":", 1)
+                data[current][key] = float(value)
         return data
 
     yaml = types.SimpleNamespace(safe_load=lambda f: _minimal_load(Path(f.name)))

--- a/tests/test_plume_intensity_stats_yaml.py
+++ b/tests/test_plume_intensity_stats_yaml.py
@@ -5,19 +5,19 @@ import pytest
 
 def load_yaml_simple(path):
     data = {}
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         current = None
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith('#'):
+        for raw_line in f:
+            stripped = raw_line.strip()
+            if not stripped or stripped.startswith("#"):
                 continue
-            if not line.startswith('  '):
-                key = line.rstrip(':')
+            if not raw_line.startswith("  "):
+                key = stripped.rstrip(":")
                 current = key
                 data[current] = {}
             else:
-                k, v = line.split(':', 1)
-                data[current][k.strip()] = float(v)
+                k, v = stripped.split(":", 1)
+                data[current][k] = float(v)
     return data
 
 


### PR DESCRIPTION
## Summary
- improve minimal YAML parser when PyYAML isn't installed
- align helper used in tests

## Testing
- `./setup_env.sh --dev` *(fails: wget: unable to resolve host address)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*