### PR TITLE
Add docs for frame rate scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ conda run --prefix ./dev_env python -m Code.some_script
 
 For citations and metadata, see `CITATION.cff` and `codemeta.json`.
 
+## Frame Rate and Spatial Scale
+
+Video-based simulations rely on two parameters defined in your plume configuration: `px_per_mm` sets the conversion from pixels to millimetres and `frame_rate` specifies the number of frames per second. The navigation model automatically scales velocities using these values so that fly speeds remain in millimetres per second regardless of the video's native frame rate or scale.
+
+Example snippet from `configs/my_complex_plume_config.yaml`:
+
+```yaml
+# Pixels per millimeter conversion factor
+px_per_mm: 6.536
+# Frame rate of the video in Hz
+frame_rate: 60
+```
+
+
 ## Running Tests
 
 Invoke `pytest` from the repository root. Slow tests that set up a full

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -190,6 +190,20 @@ The MATLAB executable is auto-detected when you source `paths.sh`. Pass
 `--matlab_exec` only if you need to override the detected path. When datasets
 have different lengths the tool logs a warning but still computes statistics.
 
+#### Frame Rate and Spatial Scale
+
+`px_per_mm` sets how many pixels correspond to one millimetre and `frame_rate` defines the video sampling rate. Velocities are now scaled using these values so movement speeds remain in millimetres per second regardless of the original frame rate or resolution.
+
+Example excerpt from `configs/my_complex_plume_config.yaml`:
+
+```yaml
+# Pixels per millimeter conversion factor
+px_per_mm: 6.536
+# Frame rate of the video in Hz
+frame_rate: 60
+```
+
+
 ### Pure Python Workflow
 
 Video files can be processed without MATLAB using the `--pure-python` flag. The


### PR DESCRIPTION
## Summary
- explain how `frame_rate` and `px_per_mm` shape simulations
- describe velocity scaling

## Testing
- `pytest tests/test_maybe_float.py`
- `pre-commit` *(fails: command not found)*