### PR TITLE
Add validation blocks and examples to plume functions

### DIFF
--- a/Code/load_custom_plume.m
+++ b/Code/load_custom_plume.m
@@ -8,7 +8,12 @@ function plume = load_custom_plume(metadata_path)
 %       vid_mm_per_px    - millimeters per pixel for the video
 %       fps              - frame rate of the processed video
 %
-%   The returned structure is the same as produced by LOAD_PLUME_VIDEO.
+%   The returned structure is the same as produced by LOAD_PLUME_VIDEO. The
+%   plume data is rescaled to the CRIM intensity range using
+%   RESCALE_PLUME_RANGE.
+%
+%   Example:
+%       plume = load_custom_plume('meta.yaml');
 
 info = load_config(metadata_path);
 

--- a/Code/plume_intensity_stats.m
+++ b/Code/plume_intensity_stats.m
@@ -4,12 +4,20 @@ function stats = plume_intensity_stats(yamlPath)
 %   from the given YAML file. If omitted, the default configuration file
 %   'configs/plume_intensity_stats.yaml' relative to the repository root is
 %   used.
+%
+%   Example:
+%       stats = plume_intensity_stats;
+%       stats2 = plume_intensity_stats('my_stats.yaml');
 
-if nargin < 1 || isempty(yamlPath)
-    thisDir = fileparts(mfilename('fullpath'));
-    rootDir = fileparts(thisDir);
-    yamlPath = fullfile(rootDir, 'configs', 'plume_intensity_stats.yaml');
+arguments
+    yamlPath (1,:) char = defaultStatsYaml()
 end
 
 stats = load_yaml(yamlPath);
+end
+
+function p = defaultStatsYaml
+thisDir = fileparts(mfilename('fullpath'));
+rootDir = fileparts(thisDir);
+p = fullfile(rootDir, 'configs', 'plume_intensity_stats.yaml');
 end

--- a/Code/rescale_plume_range.m
+++ b/Code/rescale_plume_range.m
@@ -3,6 +3,15 @@ function data = rescale_plume_range(data, target_min, target_max)
 %   DATA = RESCALE_PLUME_RANGE(DATA, TARGET_MIN, TARGET_MAX) rescales the
 %   numeric array DATA so that its minimum value becomes TARGET_MIN and its
 %   maximum value becomes TARGET_MAX. Empty inputs are returned unchanged.
+%
+%   Example:
+%       scaled = rescale_plume_range(plume.data, 0, 1);
+
+arguments
+    data {mustBeNumeric}
+    target_min (1,1) {mustBeNumeric}
+    target_max (1,1) {mustBeNumeric}
+end
 
 if isempty(data)
     return;

--- a/tests/test_plume_intensity_stats_validation.m
+++ b/tests/test_plume_intensity_stats_validation.m
@@ -1,0 +1,18 @@
+function tests = test_plume_intensity_stats_validation
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testInvalidPathType(testCase)
+    f = @() plume_intensity_stats(123);
+    try
+        f();
+        verifyFail(testCase,'Expected error');
+    catch ME
+        verifyTrue(testCase, startsWith(ME.identifier,'MATLAB:'), ...
+            'Unexpected error identifier');
+    end
+end

--- a/tests/test_rescale_plume_range_validation.m
+++ b/tests/test_rescale_plume_range_validation.m
@@ -1,0 +1,29 @@
+function tests = test_rescale_plume_range_validation
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testNonNumericData(testCase)
+    f = @() rescale_plume_range('bad',0,1);
+    try
+        f();
+        verifyFail(testCase,'Expected error');
+    catch ME
+        verifyTrue(testCase, startsWith(ME.identifier,'MATLAB:'), ...
+            'Unexpected error identifier');
+    end
+end
+
+function testNonScalarTarget(testCase)
+    f = @() rescale_plume_range([1 2],[0 1],1);
+    try
+        f();
+        verifyFail(testCase,'Expected error');
+    catch ME
+        verifyTrue(testCase, startsWith(ME.identifier,'MATLAB:'), ...
+            'Unexpected error identifier');
+    end
+end


### PR DESCRIPTION
## Summary
- validate inputs for `rescale_plume_range` and `plume_intensity_stats`
- describe rescaling in `load_custom_plume`
- add basic usage examples in MATLAB help
- test argument validation logic

## Testing
- `pytest -k 'plume_intensity_stats_validation or rescale_plume_range_validation' -vv` *(fails: ModuleNotFoundError: No module named 'loguru')*