### PR TITLE
Fix intensity stats helper

### DIFF
--- a/Code/plume_utils.py
+++ b/Code/plume_utils.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from typing import Any, Dict
 from pathlib import Path
-from typing import Any, Dict
 
 import numpy as np
 
@@ -54,18 +53,22 @@ with _YAML_PATH.open("r", encoding="utf-8") as fh:
     _INTENSITY_STATS: Dict[str, Dict[str, Any]] = yaml.safe_load(fh)
 
 
-def get_intensity_stats() -> Dict[str, Dict[str, Any]]:
-    """Return stored intensity statistics for the default plumes."""
+def get_intensity_stats(path: str | Path | None = None) -> Dict[str, Dict[str, Any]]:
+    """Return stored intensity statistics for the default plumes.
+
+    Parameters
+    ----------
+    path:
+        Optional path to a YAML file with intensity statistics. When ``None``,
+        returns cached stats from ``configs/plume_intensity_stats.yaml``.
+    """
     if path is None:
-        path = (
-            Path(__file__).resolve().parent.parent
-            / "configs"
-            / "plume_intensity_stats.yaml"
-        )
+        return _INTENSITY_STATS
     path = Path(path)
-    with open(path, "r", encoding="utf-8") as fh:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    with path.open("r", encoding="utf-8") as fh:
         return yaml.safe_load(fh)
-    return _INTENSITY_STATS
 
 
 def _rescale(arr: np.ndarray, target_min: float, target_max: float) -> np.ndarray:
@@ -81,3 +84,4 @@ def rescale_to_crim_range(arr: np.ndarray) -> np.ndarray:
     """Linearly rescale ``arr`` to match the Crimaldi min and max."""
     stats = get_intensity_stats()
     return _rescale(arr, stats["CRIM"]["min"], stats["CRIM"]["max"])
+

--- a/tests/test_plume_intensity_stats_yaml.py
+++ b/tests/test_plume_intensity_stats_yaml.py
@@ -1,5 +1,7 @@
 import sys
 import types
+from pathlib import Path
+
 import pytest
 
 
@@ -21,9 +23,50 @@ def load_yaml_simple(path):
     return data
 
 
-def test_stats_match_yaml(monkeypatch):
+def _patch_numpy(monkeypatch):
     fake_np = types.SimpleNamespace(min=lambda a: 0, max=lambda a: 0, full_like=lambda arr, v: arr)
-    monkeypatch.setitem(sys.modules, 'numpy', fake_np)
+    monkeypatch.setitem(sys.modules, "numpy", fake_np)
+
+
+def test_stats_match_yaml(monkeypatch):
+    _patch_numpy(monkeypatch)
+    import importlib
     import Code.plume_utils as pu
-    stats_yaml = load_yaml_simple('configs/plume_intensity_stats.yaml')
+    importlib.reload(pu)
+    stats_yaml = load_yaml_simple("configs/plume_intensity_stats.yaml")
     assert pu.get_intensity_stats() == stats_yaml
+
+
+def test_get_stats_from_explicit_path(monkeypatch, tmp_path):
+    _patch_numpy(monkeypatch)
+    import importlib
+    import Code.plume_utils as pu
+    importlib.reload(pu)
+    src = Path("configs/plume_intensity_stats.yaml")
+    tmp_copy = tmp_path / "copy.yaml"
+    tmp_copy.write_text(src.read_text())
+    expected = load_yaml_simple(src)
+    assert pu.get_intensity_stats(tmp_copy) == expected
+
+
+def test_get_stats_file_not_found(monkeypatch, tmp_path):
+    _patch_numpy(monkeypatch)
+    import importlib
+    import Code.plume_utils as pu
+    importlib.reload(pu)
+    with pytest.raises(FileNotFoundError):
+        pu.get_intensity_stats(tmp_path / "missing.yaml")
+
+
+def test_cached_stats_reused(monkeypatch):
+    _patch_numpy(monkeypatch)
+    import importlib
+    import Code.plume_utils as pu
+    importlib.reload(pu)
+    stats = pu.get_intensity_stats()
+
+    def fail(*args, **kwargs):
+        raise AssertionError("should not reload")
+
+    monkeypatch.setattr(pu.yaml, "safe_load", fail)
+    assert pu.get_intensity_stats() == stats


### PR DESCRIPTION
## Summary
- make `get_intensity_stats` accept a path, reuse cached stats
- validate path existence and improve docstring
- test fetching stats from paths and fallback behaviour

## Testing
- `./setup_env.sh --dev` *(fails: wget not available)*
- `pre-commit run --files Code/plume_utils.py tests/test_plume_intensity_stats_yaml.py` *(fails: command not found)*
- `pytest -q tests/test_plume_intensity_stats_yaml.py`
- `pytest` *(fails: missing numpy)*