### PR TITLE
Fix plume config test path

### DIFF
--- a/tests/test_load_complex_plume_config.m
+++ b/tests/test_load_complex_plume_config.m
@@ -9,7 +9,7 @@ end
 function testLoadComplexConfig(testCase)
     cfg = load_config(fullfile('configs', 'my_complex_plume_config.yaml'));
     verifyEqual(testCase, cfg.environment, 'video');
-    verifyEqual(testCase, cfg.plume_video, 'data/my_complex_plume.avi');
+    verifyEqual(testCase, cfg.plume_video, 'data/smoke_1a_bgsub_raw.avi');
     verifyEqual(testCase, cfg.px_per_mm, 6.536, 'AbsTol', 1e-8);
     verifyEqual(testCase, cfg.frame_rate, 60);
     verifyEqual(testCase, cfg.plotting, 0);


### PR DESCRIPTION
## Summary
- update test to check against the correct plume video file

## Testing
- `setup_env.sh --dev` *(fails: conda not found)*
- `pre-commit run --files tests/test_load_complex_plume_config.m` *(fails: command not found)*
- `matlab -batch "runtests('tests/test_load_complex_plume_config.m')"` *(fails: command not found)*