### PR TITLE
Add plume orientation notebook

### DIFF
--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -467,3 +467,7 @@ executable, so no manual export is required.
 - All commands assume the development environment created via `./setup_env.sh --dev`
 - Output paths are controlled by `configs/project_paths.yaml`
 - The MATLAB script `process_smoke_video.m` is pre-configured to work with the default paths
+- To preview example frames from both datasets, run `notebooks/orient_plumes.ipynb`:
+  ```bash
+  conda run --prefix ./dev_env jupyter notebook notebooks/orient_plumes.ipynb
+  ```

--- a/notebooks/orient_plumes.ipynb
+++ b/notebooks/orient_plumes.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Orientation Plume Visualisation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import random\n",
+    "import numpy as np\n",
+    "import h5py\n",
+    "import imageio.v2 as imageio\n",
+    "import matplotlib.pyplot as plt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Load datasets (update paths as needed)\n",
+    "h5_path = 'data/10302017_10cms_bounded_2.h5'\n",
+    "video_path = 'data/smoke_video.avi'\n",
+    "with h5py.File(h5_path, 'r') as f:\n",
+    "    plume = f['intensity'][...]\n",
+    "video = imageio.get_reader(video_path)\n",
+    "idx_h5 = random.randrange(plume.shape[0])\n",
+    "idx_vid = random.randrange(len(video))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 4))\n",
+    "axes[0].imshow(plume[idx_h5], cmap='gray')\n",
+    "axes[0].set_title(f'HDF5 Frame {idx_h5}')\n",
+    "axes[1].imshow(video.get_data(idx_vid))\n",
+    "axes[1].set_title(f'Video Frame {idx_vid}')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_orient_plumes_notebook.py
+++ b/tests/test_orient_plumes_notebook.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+NOTEBOOK_PATH = Path('notebooks/orient_plumes.ipynb')
+
+
+def test_notebook_exists():
+    assert NOTEBOOK_PATH.exists(), 'Notebook not found'
+
+
+def test_notebook_imports():
+    data = json.loads(NOTEBOOK_PATH.read_text())
+    src = ''.join(''.join(cell.get('source', [])) for cell in data.get('cells', []))
+    assert 'h5py' in src, 'Notebook must import h5py'
+    assert 'imageio' in src, 'Notebook must import imageio'


### PR DESCRIPTION
## Summary
- add a lightweight notebook for viewing frames from the Crimaldi plume and a video
- provide notebook instructions in intensity comparison docs
- test for the new notebook

## Testing
- `ruff check tests/test_orient_plumes_notebook.py`
- `pytest tests/test_orient_plumes_notebook.py -q`
- `./setup_env.sh --dev` *(fails: wget to repo.anaconda.com blocked)*