### PR TITLE
Add video triallength test and document new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,15 @@ Example snippet from `configs/my_complex_plume_config.yaml`:
 px_per_mm: 6.536
 # Frame rate of the video in Hz
 frame_rate: 60
+# Automatically repeat the movie when triallength exceeds its length
+# loop: true
+# Override the movie length with a specific number of frames
+# triallength: 7200
 ```
+
+The optional `loop` flag repeats the movie when `triallength` is longer than the
+source video. Setting `triallength` lets you cut or extend each trial to an
+explicit number of frames.
 
 
 ## Running Tests

--- a/configs/my_complex_plume_config.yaml
+++ b/configs/my_complex_plume_config.yaml
@@ -12,3 +12,8 @@ plotting: 0
 ntrials: 10
 # Wind speed in arbitrary units
 ws: 1
+# Automatically repeat the movie when triallength exceeds its length
+# loop: true
+
+# Override the movie length with a specific number of frames
+# triallength: 7200

--- a/tests/test_video_triallength.m
+++ b/tests/test_video_triallength.m
@@ -1,0 +1,31 @@
+function tests = test_video_triallength
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmp = tempname;
+    mkdir(tmp);
+    vw = VideoWriter(fullfile(tmp, 'tl.avi'));
+    open(vw);
+    writeVideo(vw, uint8(zeros(2,2,2))); % two-frame video
+    close(vw);
+    testCase.TestData.video = fullfile(tmp, 'tl.avi');
+    testCase.TestData.tmp = tmp;
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmp, 's');
+end
+
+function testRespectsTriallength(testCase)
+    cfg.environment = 'video';
+    cfg.plume_video = testCase.TestData.video;
+    cfg.px_per_mm = 10;
+    cfg.frame_rate = 50;
+    cfg.plotting = 0;
+    cfg.ntrials = 1;
+    cfg.triallength = 5;
+    out = run_navigation_cfg(cfg);
+    verifySize(testCase, out.x, [cfg.triallength, cfg.ntrials]);
+end


### PR DESCRIPTION
## Summary
- document `loop` and `triallength` in config
- add MATLAB test covering `triallength`

## Testing
- `./setup_env.sh --dev` *(fails: conda not found)*
- `conda run --prefix dev_env pre-commit run --files README.md configs/my_complex_plume_config.yaml tests/test_video_triallength.m` *(fails: command not found)*