### PR TITLE
Add ipykernel support for notebooks

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -5,6 +5,8 @@ channels:
 dependencies:
   # Base environment dependencies
   - python=3.11
+  - ipykernel
+  - notebook
   - pandas
   - numpy
   - h5py

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -467,3 +467,7 @@ executable, so no manual export is required.
 - All commands assume the development environment created via `./setup_env.sh --dev`
 - Output paths are controlled by `configs/project_paths.yaml`
 - The MATLAB script `process_smoke_video.m` is pre-configured to work with the default paths
+- To preview example frames from both datasets, run `notebooks/orient_plumes.ipynb`:
+  ```bash
+  conda run --prefix ./dev_env jupyter notebook notebooks/orient_plumes.ipynb
+  ```

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
+  - ipykernel
+  - notebook
   - pandas
   - numpy
   - h5py

--- a/notebooks/orient_plumes.ipynb
+++ b/notebooks/orient_plumes.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Orientation Plume Visualisation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import random\n",
+    "import numpy as np\n",
+    "import h5py\n",
+    "import imageio.v2 as imageio\n",
+    "import matplotlib.pyplot as plt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Load datasets (update paths as needed)\n",
+    "h5_path = 'data/10302017_10cms_bounded_2.h5'\n",
+    "video_path = 'data/smoke_video.avi'\n",
+    "with h5py.File(h5_path, 'r') as f:\n",
+    "    plume = f['intensity'][...]\n",
+    "video = imageio.get_reader(video_path)\n",
+    "idx_h5 = random.randrange(plume.shape[0])\n",
+    "idx_vid = random.randrange(len(video))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 4))\n",
+    "axes[0].imshow(plume[idx_h5], cmap='gray')\n",
+    "axes[0].set_title(f'HDF5 Frame {idx_h5}')\n",
+    "axes[1].imshow(video.get_data(idx_vid))\n",
+    "axes[1].set_title(f'Video Frame {idx_vid}')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
   "scipy",
   "pandas",
   "h5py",
+  "ipykernel",
   "pyyaml",
   "matplotlib",
   "loguru",

--- a/tests/test_env_dependencies.py
+++ b/tests/test_env_dependencies.py
@@ -28,3 +28,10 @@ def test_envs_require_imageio_ffmpeg() -> None:
     base_env_text = _read_env("environment.yml")
     assert "imageio-ffmpeg" in dev_env_text
     assert "imageio-ffmpeg" in base_env_text
+
+
+def test_envs_require_ipykernel() -> None:
+    dev_env_text = _read_env("dev-environment.yml")
+    base_env_text = _read_env("environment.yml")
+    assert "ipykernel" in dev_env_text
+    assert "ipykernel" in base_env_text

--- a/tests/test_orient_plumes_notebook.py
+++ b/tests/test_orient_plumes_notebook.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+NOTEBOOK_PATH = Path('notebooks/orient_plumes.ipynb')
+
+
+def test_notebook_exists():
+    assert NOTEBOOK_PATH.exists(), 'Notebook not found'
+
+
+def test_notebook_imports():
+    data = json.loads(NOTEBOOK_PATH.read_text())
+    src = ''.join(''.join(cell.get('source', [])) for cell in data.get('cells', []))
+    assert 'h5py' in src, 'Notebook must import h5py'
+    assert 'imageio' in src, 'Notebook must import imageio'

--- a/tests/test_pyproject_dependencies.py
+++ b/tests/test_pyproject_dependencies.py
@@ -1,0 +1,8 @@
+import tomllib
+
+
+def test_pyproject_includes_ipykernel() -> None:
+    with open("pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+    deps = {dep.split("=")[0] for dep in data.get("project", {}).get("dependencies", [])}
+    assert "ipykernel" in deps


### PR DESCRIPTION
## Summary
- include ipykernel and notebook in Conda environments
- expose ipykernel as a project dependency
- add orientation viewer notebook back to version control
- verify ipykernel via tests

## Testing
- `ruff check tests/test_env_dependencies.py tests/test_pyproject_dependencies.py`
- `pytest tests/test_orient_plumes_notebook.py tests/test_env_dependencies.py tests/test_pyproject_dependencies.py -q`
- `./setup_env.sh --dev` *(fails: wget to repo.anaconda.com blocked)*