### PR TITLE
Add opencv-python to dependencies

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - scipy
   - imageio
   - imageio-ffmpeg
+  - opencv-python
   
   # Development tools
   - conda-lock>=2.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - ruff
   - imageio
   - imageio-ffmpeg
+  - opencv-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "pyyaml",
   "matplotlib",
   "loguru",
+  "opencv-python",
 ]
 
 [build-system]

--- a/tests/test_env_dependencies.py
+++ b/tests/test_env_dependencies.py
@@ -28,3 +28,20 @@ def test_envs_require_imageio_ffmpeg() -> None:
     base_env_text = _read_env("environment.yml")
     assert "imageio-ffmpeg" in dev_env_text
     assert "imageio-ffmpeg" in base_env_text
+
+
+def test_envs_require_opencv() -> None:
+    dev_env_text = _read_env("dev-environment.yml")
+    base_env_text = _read_env("environment.yml")
+    assert "opencv-python" in dev_env_text
+    assert "opencv-python" in base_env_text
+
+
+def test_pyproject_requires_opencv() -> None:
+    import tomllib
+
+    with open("pyproject.toml", "rb") as f:
+        project = tomllib.load(f)
+
+    deps: list[str] = project.get("project", {}).get("dependencies", [])
+    assert any(dep.split("==")[0] == "opencv-python" for dep in deps)


### PR DESCRIPTION
## Summary
- include `opencv-python` in base and dev conda environments
- expose new requirement in `pyproject.toml`
- test that both environment files and the Python package metadata list opencv

## Testing
- `bash setup_env.sh --dev` *(fails: wget could not retrieve Miniconda installer)*
- `ruff check tests/test_env_dependencies.py`
- `black tests/test_env_dependencies.py`
- `isort tests/test_env_dependencies.py`
- `mypy tests/test_env_dependencies.py`
- `pre-commit run --files tests/test_env_dependencies.py pyproject.toml environment.yml dev-environment.yml` *(fails: command not found)*
- `pytest tests/test_env_dependencies.py::test_envs_require_opencv tests/test_env_dependencies.py::test_pyproject_requires_opencv -q`