### PR TITLE
Update canonical HDF5 filename

### DIFF
--- a/configs/project_paths.yaml.template
+++ b/configs/project_paths.yaml.template
@@ -17,7 +17,7 @@ scripts:
 # Data files
 data:
   # Crimaldi HDF5 data file
-  crimaldi: "${PROJECT_DIR}/data/10302017_10cms_bounded_2.h5"
+  crimaldi: "${PROJECT_DIR}/data/10302017_10cms_bounded.hdf5"
   # Video file for analysis
   video: "${PROJECT_DIR}/data/smoke_1a_bgsub_raw.avi"
 

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -147,11 +147,11 @@ Follow these steps to run a simple comparison using the bundled datasets.
 
    ```bash
    conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
-       CRIM data/10302017_10cms_bounded_2.h5 \
+      CRIM data/10302017_10cms_bounded.hdf5 \
        SMOKE process_smoke_video.m
    ```
 
-   The smoke video is located at `data/smoke_1a_bgsub_raw.avi` and the Crimaldi HDF5 file at `data/10302017_10cms_bounded_2.h5`.
+   The smoke video is located at `data/smoke_1a_bgsub_raw.avi` and the Crimaldi HDF5 file at `data/10302017_10cms_bounded.hdf5`.
 
 
 ### Comparing a Video Plume to Crimaldi
@@ -182,7 +182,7 @@ Run the comparison using the development environment:
 
 ```bash
 conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
-    CRIM data/10302017_10cms_bounded_2.h5 \
+    CRIM data/10302017_10cms_bounded.hdf5 \
     SMOKE process_smoke_video.m
 ```
 
@@ -217,7 +217,7 @@ Example:
 ```bash
 conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
     SMOKE data/smoke_1a_bgsub_raw.avi \
-    CRIM data/10302017_10cms_bounded_2.h5 \
+    CRIM data/10302017_10cms_bounded.hdf5 \
     --pure-python
 ```
 
@@ -233,7 +233,7 @@ For example, running the command without a detected MATLAB might look like:
 
 ```bash
 conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
-    CRIM data/10302017_10cms_bounded_2.h5 \
+    CRIM data/10302017_10cms_bounded.hdf5 \
     SMOKE process_smoke_video.m
 ```
 
@@ -247,7 +247,7 @@ or pass it explicitly:
 
 ```bash
 conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
-    CRIM data/10302017_10cms_bounded_2.h5 \
+    CRIM data/10302017_10cms_bounded.hdf5 \
     SMOKE process_smoke_video.m \
     --matlab_exec /path/to/matlab
 ```
@@ -259,7 +259,7 @@ from `configs/project_paths.yaml` if available.
 
 ```bash
 conda run --prefix ./dev_env python scripts/run_intensity_batch.py \
-    data/10302017_10cms_bounded_2.h5 process_smoke_video.m
+    data/10302017_10cms_bounded.hdf5 process_smoke_video.m
 ```
 
 
@@ -299,7 +299,7 @@ source ./paths.sh
 
 # Then run the comparison
 conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
-    CRIM data/10302017_10cms_bounded_2.h5 \
+    CRIM data/10302017_10cms_bounded.hdf5 \
     SMOKE video_script.m \
     ${MATLAB_EXEC:+--matlab_exec "$MATLAB_EXEC"}
 ```
@@ -309,7 +309,7 @@ path explicitly:
 
 ```bash
 conda run --prefix ./dev_env python -m Code.compare_intensity_stats \
-    CRIM data/10302017_10cms_bounded_2.h5 \
+    CRIM data/10302017_10cms_bounded.hdf5 \
     SMOKE video_script.m \
     --matlab_exec /path/to/matlab
 ```

--- a/notebooks/orient_plumes.ipynb
+++ b/notebooks/orient_plumes.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "source": [
     "# Load datasets (update paths as needed)\n",
-    "h5_path = 'data/10302017_10cms_bounded_2.h5'\n",
+    "h5_path = 'data/10302017_10cms_bounded.hdf5'\n",
     "video_path = 'data/smoke_video.avi'\n",
     "with h5py.File(h5_path, 'r') as f:\n",
     "    plume = f['intensity'][...]\n",


### PR DESCRIPTION
## Summary
- use `10302017_10cms_bounded.hdf5` in config template
- update docs to reference new file name
- modify example notebook accordingly

## Testing
- `./setup_env.sh --dev` *(fails: wget: unable to resolve host)*
- `pre-commit` *(fails: command not found)*