### PR TITLE
Add video rotation utility

### DIFF
--- a/Code/__init__.py
+++ b/Code/__init__.py
@@ -7,3 +7,4 @@ Run the analysis pipeline::
     from Code.main_analysis import run_pipeline
     run_pipeline("configs/example_analysis.yaml")
 """
+from .rotate_video import rotate_video_clockwise

--- a/Code/rotate_video.py
+++ b/Code/rotate_video.py
@@ -1,0 +1,36 @@
+"""Video rotation utilities."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+try:
+    import imageio.v3 as imageio
+except Exception:  # pragma: no cover - optional dependency
+    imageio = None
+
+logger = logging.getLogger(__name__)
+
+
+def rotate_video_clockwise(input_path: str | Path, output_path: str | Path) -> None:
+    """Rotate ``input_path`` 90 degrees clockwise and write to ``output_path``.
+
+    Parameters
+    ----------
+    input_path, output_path : str or Path
+        Paths to the input and output video files.
+
+    Examples
+    --------
+    >>> rotate_video_clockwise('in.avi', 'out.avi')
+    """
+    if imageio is None:  # pragma: no cover - runtime environment may lack imageio
+        raise ImportError("imageio is required for rotate_video_clockwise")
+
+    frames = list(imageio.imread(input_path, plugin="pyav"))
+    if not frames:
+        raise ValueError(f"no frames found in {input_path}")
+
+    rotated = [frame[::-1].transpose(1, 0, *range(2, frame.ndim)) for frame in frames]
+    imageio.imwrite(output_path, rotated, plugin="pyav")
+    logger.info("Saved rotated video to %s", output_path)

--- a/tests/test_rotate_video.py
+++ b/tests/test_rotate_video.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+from Code import rotate_video
+
+def test_rotate_video_clockwise(tmp_path):
+    # Create a dummy 2x3 video with two frames using numpy
+    frames = [
+        np.arange(6, dtype=np.uint8).reshape(2, 3),
+        np.arange(6, 12, dtype=np.uint8).reshape(2, 3),
+    ]
+    input_video = tmp_path / "in.avi"
+    output_video = tmp_path / "out.avi"
+
+    imageio = pytest.importorskip("imageio.v3")
+    imageio.imwrite(input_video, frames, plugin="pyav")
+
+    rotate_video.rotate_video_clockwise(str(input_video), str(output_video))
+
+    result = imageio.imread(output_video, plugin="pyav")
+    assert result.shape == (2, 3, 2)
+    # Rotated frames should have shape 3x2
+    rotated_frames = list(np.moveaxis(result, -1, 0))
+    assert rotated_frames[0].shape == (3, 2)
+    assert rotated_frames[1].shape == (3, 2)


### PR DESCRIPTION
## Summary
- add script to rotate video 90 degrees clockwise
- expose rotation in package init
- add regression test for rotating small video

## Testing
- `pytest tests/test_rotate_video.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
