### PR TITLE
Add codec and fps options to rotate_video

### DIFF
--- a/Code/rotate_video.py
+++ b/Code/rotate_video.py
@@ -12,13 +12,25 @@ except Exception:  # pragma: no cover - optional dependency
 logger = logging.getLogger(__name__)
 
 
-def rotate_video_clockwise(input_path: str | Path, output_path: str | Path) -> None:
+def rotate_video_clockwise(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    codec: str = "libx264",
+    fps: float | None = None,
+) -> None:
     """Rotate ``input_path`` 90 degrees clockwise and write to ``output_path``.
 
     Parameters
     ----------
     input_path, output_path : str or Path
         Paths to the input and output video files.
+    codec : str, optional
+        Video codec passed to :func:`imageio.imwrite`.  ``libx264`` is used by
+        default, which should work for most ``.avi`` files.
+    fps : float, optional
+        Frames per second for the output video.  If not provided, the frame rate
+        is copied from ``input_path`` when available, otherwise ``30`` is used.
 
     Examples
     --------
@@ -31,6 +43,16 @@ def rotate_video_clockwise(input_path: str | Path, output_path: str | Path) -> N
     if not frames:
         raise ValueError(f"no frames found in {input_path}")
 
+    if fps is None:
+        try:
+            reader = imageio.get_reader(input_path)
+            try:
+                fps = reader.get_meta_data().get("fps", 30)
+            finally:
+                reader.close()
+        except Exception:  # noqa: BLE001
+            fps = 30
+
     rotated = [frame[::-1].transpose(1, 0, *range(2, frame.ndim)) for frame in frames]
-    imageio.imwrite(output_path, rotated, plugin="pyav")
+    imageio.imwrite(output_path, rotated, plugin="pyav", fps=fps, codec=codec)
     logger.info("Saved rotated video to %s", output_path)

--- a/tests/test_rotate_video.py
+++ b/tests/test_rotate_video.py
@@ -23,3 +23,24 @@ def test_rotate_video_clockwise(tmp_path):
     rotated_frames = list(np.moveaxis(result, -1, 0))
     assert rotated_frames[0].shape == (3, 2)
     assert rotated_frames[1].shape == (3, 2)
+
+
+def test_rotate_video_clockwise_custom_fps(tmp_path):
+    frames = [
+        np.arange(6, dtype=np.uint8).reshape(2, 3),
+        np.arange(6, 12, dtype=np.uint8).reshape(2, 3),
+    ]
+    input_video = tmp_path / "in.avi"
+    output_video = tmp_path / "out.avi"
+
+    imageio = pytest.importorskip("imageio.v3")
+    imageio.imwrite(input_video, frames, plugin="pyav", fps=15)
+
+    rotate_video.rotate_video_clockwise(
+        str(input_video),
+        str(output_video),
+        fps=25,
+    )
+
+    meta = imageio.get_reader(output_video).get_meta_data()
+    assert meta.get("fps") == 25


### PR DESCRIPTION
## Summary
- extend `rotate_video_clockwise` with codec and fps parameters
- preserve input frame rate when rotating videos
- test explicit fps handling

## Testing
- `pre-commit run --files Code/rotate_video.py tests/test_rotate_video.py` *(fails: command not found)*
- `pytest tests/test_rotate_video.py -vv` *(fails: ModuleNotFoundError: No module named 'numpy')*