### PR TITLE
Add codec and fps options to rotate_video

### DIFF
--- a/Code/rotate_video.py
+++ b/Code/rotate_video.py
@@ -12,13 +12,25 @@ except Exception:  # pragma: no cover - optional dependency
 logger = logging.getLogger(__name__)
 
 
-def rotate_video_clockwise(input_path: str | Path, output_path: str | Path) -> None:
+def rotate_video_clockwise(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    codec: str = "libx264",
+    fps: float | None = None,
+) -> None:
     """Rotate ``input_path`` 90 degrees clockwise and write to ``output_path``.
 
     Parameters
     ----------
     input_path, output_path : str or Path
         Paths to the input and output video files.
+    codec : str, optional
+        Video codec passed to :func:`imageio.imwrite`.  ``libx264`` is used by
+        default, which should work for most ``.avi`` files.
+    fps : float, optional
+        Frames per second for the output video.  If not provided, the frame rate
+        is copied from ``input_path`` when available, otherwise ``30`` is used.
 
     Examples
     --------
@@ -31,6 +43,48 @@ def rotate_video_clockwise(input_path: str | Path, output_path: str | Path) -> N
     if not frames:
         raise ValueError(f"no frames found in {input_path}")
 
+    if fps is None:
+        try:
+            reader = imageio.get_reader(input_path)
+            try:
+                fps = reader.get_meta_data().get("fps", 30)
+            finally:
+                reader.close()
+        except Exception:  # noqa: BLE001
+            fps = 30
+
     rotated = [frame[::-1].transpose(1, 0, *range(2, frame.ndim)) for frame in frames]
-    imageio.imwrite(output_path, rotated, plugin="pyav")
+    imageio.imwrite(output_path, rotated, plugin="pyav", fps=fps, codec=codec)
     logger.info("Saved rotated video to %s", output_path)
+
+
+def video_to_hdf5(input_path: str | Path, output_path: str | Path) -> None:
+    """Read ``input_path`` and store the pixel intensities in an HDF5 file.
+
+    Frames from the input video are concatenated into a single one-dimensional
+    array which is saved under the dataset name ``dataset1``.  If frames contain
+    multiple colour channels, only the first channel is used.
+
+    Parameters
+    ----------
+    input_path, output_path : str or Path
+        Paths to the input video and output HDF5 file.
+    """
+
+    if imageio is None:  # pragma: no cover - runtime environment may lack imageio
+        raise ImportError("imageio is required for video_to_hdf5")
+
+    frames = []
+    for frame in imageio.imiter(input_path):
+        arr = frame if frame.ndim == 2 else frame[..., 0]
+        frames.append(arr.reshape(-1))
+
+    if not frames:
+        raise ValueError(f"no frames found in {input_path}")
+
+    import h5py  # imported lazily to avoid mandatory dependency
+    import numpy as np
+
+    data = np.concatenate(frames)
+    with h5py.File(output_path, "w") as f:
+        f.create_dataset("dataset1", data=data)

--- a/tests/test_rotate_video.py
+++ b/tests/test_rotate_video.py
@@ -23,3 +23,24 @@ def test_rotate_video_clockwise(tmp_path):
     rotated_frames = list(np.moveaxis(result, -1, 0))
     assert rotated_frames[0].shape == (3, 2)
     assert rotated_frames[1].shape == (3, 2)
+
+
+def test_rotate_video_clockwise_custom_fps(tmp_path):
+    frames = [
+        np.arange(6, dtype=np.uint8).reshape(2, 3),
+        np.arange(6, 12, dtype=np.uint8).reshape(2, 3),
+    ]
+    input_video = tmp_path / "in.avi"
+    output_video = tmp_path / "out.avi"
+
+    imageio = pytest.importorskip("imageio.v3")
+    imageio.imwrite(input_video, frames, plugin="pyav", fps=15)
+
+    rotate_video.rotate_video_clockwise(
+        str(input_video),
+        str(output_video),
+        fps=25,
+    )
+
+    meta = imageio.get_reader(output_video).get_meta_data()
+    assert meta.get("fps") == 25

--- a/tests/test_video_to_hdf5.py
+++ b/tests/test_video_to_hdf5.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+imageio = pytest.importorskip("imageio.v3")
+h5py = pytest.importorskip("h5py")
+
+from Code import rotate_video
+
+
+def test_video_to_hdf5(tmp_path):
+    frames = np.stack([
+        np.arange(6, dtype=np.uint8).reshape(2, 3),
+        np.arange(6, 12, dtype=np.uint8).reshape(2, 3),
+    ])
+    input_path = tmp_path / "in.avi"
+    output_path = tmp_path / "out.h5"
+    imageio.imwrite(input_path, frames, plugin="pyav", fps=1)
+
+    rotate_video.video_to_hdf5(str(input_path), str(output_path))
+
+    with h5py.File(output_path, "r") as f:
+        data = f["dataset1"][()]
+
+    expected = frames.reshape(-1)
+    assert np.array_equal(data, expected)
+


### PR DESCRIPTION
## Summary
- extend `rotate_video_clockwise` with codec and fps parameters
- preserve input frame rate when rotating videos
- convert AVI files to dataset1 HDF5 arrays
- test explicit fps handling
- test AVI to HDF5 conversion

## Testing
- `pre-commit run --files Code/rotate_video.py tests/test_video_to_hdf5.py tests/test_rotate_video.py` *(fails: conda: command not found)*
- `pytest tests/test_video_to_hdf5.py tests/test_rotate_video.py -vv` *(fails: conda: command not found)*