### PR TITLE
Add HDF5 plume loading

### DIFF
--- a/Code/load_custom_plume.m
+++ b/Code/load_custom_plume.m
@@ -17,11 +17,25 @@ function plume = load_custom_plume(metadata_path)
 
 info = load_config(metadata_path);
 
-video_path = fullfile(info.output_directory, info.output_filename);
 px_per_mm = 1 / info.vid_mm_per_px;
 frame_rate = info.fps;
 
-plume = load_plume_video(video_path, px_per_mm, frame_rate);
+use_h5 = false;
+if isfield(info, 'output_h5')
+    h5_path = fullfile(info.output_directory, info.output_h5);
+    use_h5 = true;
+elseif endsWith(info.output_filename, {'.h5', '.hdf5'}, 'IgnoreCase', true)
+    h5_path = fullfile(info.output_directory, info.output_filename);
+    use_h5 = true;
+else
+    video_path = fullfile(info.output_directory, info.output_filename);
+end
+
+if use_h5
+    plume = load_plume_hdf5(h5_path, px_per_mm, frame_rate);
+else
+    plume = load_plume_video(video_path, px_per_mm, frame_rate);
+end
 
 stats = plume_intensity_stats();
 plume.data = rescale_plume_range(plume.data, stats.CRIM.min, stats.CRIM.max);

--- a/Code/load_plume_hdf5.m
+++ b/Code/load_plume_hdf5.m
@@ -1,0 +1,23 @@
+function plume = load_plume_hdf5(filename, px_per_mm, frame_rate)
+%LOAD_PLUME_HDF5 Load plume data from an HDF5 file.
+%   PLUME = LOAD_PLUME_HDF5(FILENAME, PX_PER_MM, FRAME_RATE) reads the
+%   dataset named 'dataset1' from the specified HDF5 file. The returned
+%   structure contains fields:
+%       data       - numeric array (height x width x frames)
+%       px_per_mm  - pixels per millimeter
+%       frame_rate - frames per second
+%
+%   Example:
+%       plume = load_plume_hdf5('plume.h5', 20, 50);
+
+arguments
+    filename (1,:) char
+    px_per_mm (1,1) double
+    frame_rate (1,1) double
+end
+
+data = h5read(filename, '/dataset1');
+plume.data = double(data);
+plume.px_per_mm = px_per_mm;
+plume.frame_rate = frame_rate;
+end

--- a/tests/test_load_custom_plume_hdf5.m
+++ b/tests/test_load_custom_plume_hdf5.m
@@ -1,0 +1,54 @@
+function tests = test_load_custom_plume_hdf5
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd,'Code'));
+    tmp = tempname;
+    mkdir(tmp);
+    frames(:,:,1) = uint8([0 255;128 64]);
+    frames(:,:,2) = uint8([255 128;64 0]);
+    h5 = fullfile(tmp,'plume.h5');
+    h5create(h5,'/dataset1', size(frames),'Datatype','uint8');
+    h5write(h5,'/dataset1', frames);
+    fid = fopen(fullfile(tmp,'meta.yaml'),'w');
+    fprintf(fid,'output_directory: %s\n',tmp);
+    fprintf(fid,'output_filename: plume.h5\n');
+    fprintf(fid,'vid_mm_per_px: 1\n');
+    fprintf(fid,'fps: 1\n');
+    fclose(fid);
+    testCase.TestData.tmp = tmp;
+    testCase.TestData.meta = fullfile(tmp,'meta.yaml');
+    testCase.TestData.h5 = h5;
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmp,'s');
+end
+
+function testLoadViaFilename(testCase)
+    stats = plume_intensity_stats();
+    plume = load_custom_plume(testCase.TestData.meta);
+    verifySize(testCase, plume.data, [2 2 2]);
+    verifyEqual(testCase, plume.px_per_mm, 1);
+    verifyEqual(testCase, plume.frame_rate, 1);
+    verifyEqual(testCase, min(plume.data(:)), stats.CRIM.min, 'AbsTol',1e-12);
+    verifyEqual(testCase, max(plume.data(:)), stats.CRIM.max, 'AbsTol',1e-12);
+end
+
+function testLoadViaOutputH5(testCase)
+    meta = fullfile(testCase.TestData.tmp,'meta2.yaml');
+    fid = fopen(meta,'w');
+    fprintf(fid,'output_directory: %s\n',testCase.TestData.tmp);
+    fprintf(fid,'output_filename: dummy.avi\n');
+    fprintf(fid,'output_h5: plume.h5\n');
+    fprintf(fid,'vid_mm_per_px: 1\n');
+    fprintf(fid,'fps: 1\n');
+    fclose(fid);
+    stats = plume_intensity_stats();
+    plume = load_custom_plume(meta);
+    verifySize(testCase, plume.data, [2 2 2]);
+    verifyEqual(testCase, min(plume.data(:)), stats.CRIM.min, 'AbsTol',1e-12);
+    verifyEqual(testCase, max(plume.data(:)), stats.CRIM.max, 'AbsTol',1e-12);
+    delete(meta);
+end


### PR DESCRIPTION
## Summary
- read dataset1 from HDF5 files via `load_plume_hdf5`
- switch `load_custom_plume` to use HDF5 loader when metadata specifies an HDF5 file
- test HDF5 loading through new MATLAB tests

## Testing
- `pre-commit run --files Code/load_custom_plume.m Code/load_plume_hdf5.m tests/test_load_custom_plume_hdf5.m` *(fails: command not found)*
- `pytest -k load_custom_plume_hdf5` *(fails: missing numpy)*