### PR TITLE
Add optional PLUME_METADATA support

### DIFF
--- a/tests/test_run_batch_job_4000_plume_metadata.py
+++ b/tests/test_run_batch_job_4000_plume_metadata.py
@@ -1,0 +1,4 @@
+def test_plume_metadata_variable_present():
+    with open("run_batch_job_4000.sh") as f:
+        content = f.read()
+    assert "cfg.plume_metadata = '$PLUME_METADATA';" in content


### PR DESCRIPTION
## Summary
- allow `PLUME_METADATA` override in `run_batch_job_4000.sh`
- convert `PLUME_METADATA` path to absolute during setup
- write `cfg.plume_metadata` to MATLAB script when supplied
- add regression test for new variable

## Testing
- `pytest tests/test_run_batch_job_4000_experiment_name.py tests/test_run_batch_job_4000_plume_metadata.py -q`