### PR TITLE
Add video_h5 path support

### DIFF
--- a/configs/project_paths.yaml.template
+++ b/configs/project_paths.yaml.template
@@ -20,6 +20,7 @@ data:
   crimaldi: "${PROJECT_DIR}/data/10302017_10cms_bounded.hdf5"
   # Video file for analysis
   video: "${PROJECT_DIR}/data/smoke_1a_orig_backgroundsubtracted.avi"
+  video_h5: "${PROJECT_DIR}/data/custom_movie.h5"
 
 # Configuration files
 configs:

--- a/paths.sh
+++ b/paths.sh
@@ -162,6 +162,7 @@ generate_paths_config() {
     # Export PROJECT_DIR for the template
     export PROJECT_DIR="$SCRIPT_DIR"
     export TMPDIR="${TMPDIR:-/tmp}"
+    export VIDEO_H5="${PROJECT_DIR}/data/custom_movie.h5"
     
     # Generate project_paths.yaml from template
     if [ ! -f "$PATHS_TEMPLATE" ]; then

--- a/tests/test_paths_sh_regression.py
+++ b/tests/test_paths_sh_regression.py
@@ -28,7 +28,9 @@ def test_paths_sh_runs_without_syntaxerror(tmp_path):
     )
     assert result.returncode == 0, result.stderr + result.stdout
     assert "SyntaxError" not in result.stderr
-    assert (configs_dir / "project_paths.yaml").exists()
+    config_file = configs_dir / "project_paths.yaml"
+    assert config_file.exists()
+    assert "video_h5:" in config_file.read_text()
 
 
 # Helper for copying files required by paths.sh


### PR DESCRIPTION
## Summary
- add `video_h5` entry in project_paths.yaml template
- export `VIDEO_H5` when generating config
- test that generated config contains `video_h5`

## Testing
- `pytest tests/test_paths_sh_regression.py -vv`