### PR TITLE
Add video_h5 config and document HDF5 workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,21 @@ the YAML via `load_yaml`.
 - `Code.plume_utils.get_intensity_stats()` resolves the path relative to the
   `Code` directory and parses the YAML using PyYAML (or a minimal fallback
   parser when PyYAML is absent).
+
+### Converting AVI to HDF5
+
+Use `video_to_hdf5` when you need an HDF5 version of the smoke video for
+Python-only pipelines:
+
+```bash
+conda run --prefix ./dev_env python - <<'PY'
+from Code.rotate_video import video_to_hdf5
+video_to_hdf5(
+    "data/smoke_1a_orig_backgroundsubtracted.avi",
+    "data/smoke_1a_orig_backgroundsubtracted.h5",
+)
+PY
+```
+
+Add the resulting path under `data.video_h5` in `configs/project_paths.yaml` so
+all scripts can locate it automatically.

--- a/configs/project_paths.yaml.template
+++ b/configs/project_paths.yaml.template
@@ -20,6 +20,8 @@ data:
   crimaldi: "${PROJECT_DIR}/data/10302017_10cms_bounded.hdf5"
   # Video file for analysis
   video: "${PROJECT_DIR}/data/smoke_1a_orig_backgroundsubtracted.avi"
+  # HDF5 version of the smoke video for Python-only workflows
+  video_h5: "${PROJECT_DIR}/data/smoke_1a_orig_backgroundsubtracted.h5"
 
 # Configuration files
 configs:

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -467,6 +467,11 @@ executable, so no manual export is required.
 - All commands assume the development environment created via `./setup_env.sh --dev`
 - Output paths are controlled by `configs/project_paths.yaml`
 - The MATLAB script `process_smoke_video.m` is pre-configured to work with the default paths
+- See the [README](../README.md#converting-avi-to-hdf5) for instructions on
+  creating an HDF5 movie with `video_to_hdf5`.
+- For batch jobs on HPC systems consult
+  [run_batch_job_4000.md](run_batch_job_4000.md#key-variables) for using
+  `PLUME_METADATA` with HDF5 movies.
 - To preview example frames from both datasets, run `notebooks/orient_plumes.ipynb`:
   ```bash
   conda run --prefix ./dev_env jupyter notebook notebooks/orient_plumes.ipynb

--- a/docs/run_batch_job_4000.md
+++ b/docs/run_batch_job_4000.md
@@ -26,6 +26,8 @@ The script accepts configuration via environment variables. Important ones inclu
 - `AGENTS_PER_JOB` – number of agents each array task runs.
 - `PLUME_CONFIG` – path to the YAML configuration file.
 - `PLUME_VIDEO` – movie used by the simulator.
+- `PLUME_METADATA` – YAML file describing the HDF5 movie when `PLUME_VIDEO`
+  points to an `.h5` file.
 - `OUTPUT_BASE` – parent directory for raw outputs (`data/raw`).
 - `MATLAB_VERSION` – module name used if MATLAB is not on `PATH` (`2023b`).
 - `BYTES_PER_AGENT` – estimated disk usage per agent (defaults to `50000000`).
@@ -35,7 +37,8 @@ The script accepts configuration via environment variables. Important ones inclu
 `run_batch_job_4000.sh` is designed to be submitted as a SLURM array. A minimal submission might look like:
 
 ```bash
-sbatch --array=0-399 --export=ALL,EXPERIMENT_NAME=myrun \
+sbatch --array=0-399 --export=ALL,EXPERIMENT_NAME=myrun,\\
+PLUME_VIDEO=data/smoke_plume.h5,PLUME_METADATA=data/smoke_plume_meta.yaml \
        run_batch_job_4000.sh
 ```
 

--- a/tests/test_load_paths_config_paths_yaml.m
+++ b/tests/test_load_paths_config_paths_yaml.m
@@ -35,6 +35,10 @@ function testPathsExpandedCorrectly(testCase)
         'data', 'smoke_1a_orig_backgroundsubtracted.avi');
     verifyEqual(testCase, cfg.data.video, expVideo);
 
+    expVideoH5 = fullfile(testCase.TestData.tmpRoot, ...
+        'data', 'smoke_1a_orig_backgroundsubtracted.h5');
+    verifyEqual(testCase, cfg.data.video_h5, expVideoH5);
+
     expPlume = fullfile(testCase.TestData.tmpRoot, ...
         'configs', 'my_complex_plume_config.yaml');
     verifyEqual(testCase, cfg.configs.plume, expPlume);

--- a/tests/test_load_paths_config_project_yaml.m
+++ b/tests/test_load_paths_config_project_yaml.m
@@ -35,6 +35,10 @@ function testPathsExpandedCorrectly(testCase)
         'data', 'smoke_1a_orig_backgroundsubtracted.avi');
     verifyEqual(testCase, cfg.data.video, expVideo);
 
+    expVideoH5 = fullfile(testCase.TestData.tmpRoot, ...
+        'data', 'smoke_1a_orig_backgroundsubtracted.h5');
+    verifyEqual(testCase, cfg.data.video_h5, expVideoH5);
+
     expPlume = fullfile(testCase.TestData.tmpRoot, ...
         'configs', 'my_complex_plume_config.yaml');
     verifyEqual(testCase, cfg.configs.plume, expPlume);


### PR DESCRIPTION
## Summary
- document how to convert AVI to HDF5 using `video_to_hdf5`
- reference new `data.video_h5` path in `project_paths.yaml`
- show how to use `PLUME_METADATA` when submitting `run_batch_job_4000.sh`
- cross-link new instructions from intensity comparison docs
- update path loading tests for the new entry

## Testing
- `pre-commit` *(fails: command not found)*
- `python -m pytest tests/test_video_to_hdf5.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*