### PR TITLE
Add plume scaling utility

### DIFF
--- a/Code/scale_custom_plume.m
+++ b/Code/scale_custom_plume.m
@@ -1,0 +1,67 @@
+function out_meta = scale_custom_plume(in_meta, out_video, out_meta)
+%SCALE_CUSTOM_PLUME Rescale plume video and update metadata.
+%  OUT_META = SCALE_CUSTOM_PLUME(IN_META, OUT_VIDEO, OUT_META) loads the
+%  plume movie referenced by IN_META, rescales its intensity range to match
+%  the CRIM dataset and saves it to OUT_VIDEO. A copy of the metadata is
+%  written to OUT_META with the output directory and filename updated and
+%  a flag 'scaled_to_crim' set to true. The path to OUT_META is returned.
+%
+%  Example:
+%      scaled_meta = scale_custom_plume('meta.yaml', 'scaled.avi', ...
+%                                       'scaled.yaml');
+%      plume = load_custom_plume(scaled_meta);
+%
+%  See also: load_custom_plume, load_plume_video, plume_intensity_stats,
+%  rescale_plume_range
+
+arguments
+    in_meta (1,:) char
+    out_video (1,:) char
+    out_meta (1,:) char
+end
+
+info = load_config(in_meta);
+video_path = fullfile(info.output_directory, info.output_filename);
+px_per_mm = 1 / info.vid_mm_per_px;
+frame_rate = info.fps;
+
+plume = load_plume_video(video_path, px_per_mm, frame_rate);
+
+stats = plume_intensity_stats();
+scaled = rescale_plume_range(plume.data, stats.CRIM.min, stats.CRIM.max);
+
+% store movie in 0..1 so load_custom_plume rescales correctly
+scaled01 = rescale_plume_range(scaled, 0, 1);
+
+vw = VideoWriter(out_video);
+open(vw);
+for k = 1:size(scaled01, 3)
+    writeVideo(vw, scaled01(:,:,k));
+end
+close(vw);
+
+newInfo = info;
+[out_dir, out_name, out_ext] = fileparts(out_video);
+if isempty(out_dir)
+    out_dir = '.';
+end
+newInfo.output_directory = out_dir;
+newInfo.output_filename = [out_name out_ext];
+newInfo.scaled_to_crim = true;
+
+try
+    if exist('yamlwrite', 'file') == 2
+        yamlwrite(out_meta, newInfo);
+    else
+        fid = fopen(out_meta, 'w');
+        fwrite(fid, jsonencode(newInfo));
+        fclose(fid);
+    end
+catch ME
+    warning('scale_custom_plume:WriteFailed', 'Failed to save YAML: %s', ...
+            ME.message);
+end
+
+out_meta = out_meta;
+end
+

--- a/tests/test_scale_custom_plume.m
+++ b/tests/test_scale_custom_plume.m
@@ -1,0 +1,47 @@
+function tests = test_scale_custom_plume
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir, 'orig.avi'));
+    open(vw);
+    writeVideo(vw, uint8([0 255;128 64]));
+    writeVideo(vw, uint8([255 128;64 0]));
+    close(vw);
+    meta = fullfile(tmpDir, 'meta.yaml');
+    fid = fopen(meta, 'w');
+    fprintf(fid, 'output_directory: %s\n', tmpDir);
+    fprintf(fid, 'output_filename: orig.avi\n');
+    fprintf(fid, 'vid_mm_per_px: 1\n');
+    fprintf(fid, 'fps: 1\n');
+    fprintf(fid, 'extra_field: 42\n');
+    fclose(fid);
+    testCase.TestData.tmpDir = tmpDir;
+    testCase.TestData.meta = meta;
+    testCase.TestData.outVideo = fullfile(tmpDir, 'scaled.avi');
+    testCase.TestData.outMeta = fullfile(tmpDir, 'scaled.yaml');
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir, 's');
+end
+
+function testScalingAndMetadata(testCase)
+    outMeta = scale_custom_plume(testCase.TestData.meta, ...
+                                 testCase.TestData.outVideo, ...
+                                 testCase.TestData.outMeta);
+    verifyEqual(testCase, outMeta, testCase.TestData.outMeta);
+    verifyEqual(testCase, exist(testCase.TestData.outVideo, 'file'), 2);
+    info = load_config(testCase.TestData.outMeta);
+    verifyEqual(testCase, info.output_directory, testCase.TestData.tmpDir);
+    verifyEqual(testCase, info.output_filename, 'scaled.avi');
+    verifyEqual(testCase, info.extra_field, 42);
+    verifyTrue(testCase, info.scaled_to_crim);
+    plume = load_custom_plume(testCase.TestData.outMeta);
+    stats = plume_intensity_stats();
+    verifyEqual(testCase, min(plume.data(:)), stats.CRIM.min, 'AbsTol', 1e-12);
+    verifyEqual(testCase, max(plume.data(:)), stats.CRIM.max, 'AbsTol', 1e-12);
+end


### PR DESCRIPTION
## Summary
- create MATLAB helper to scale a plume video to CRIM stats
- test that scaled metadata and movie can be loaded

## Testing
- `pytest -k scale_custom_plume -q` *(fails: ModuleNotFoundError: No module named 'numpy')*