### PR TITLE
Skip plume rescale if already scaled

### DIFF
--- a/Code/load_custom_plume.m
+++ b/Code/load_custom_plume.m
@@ -7,10 +7,11 @@ function plume = load_custom_plume(metadata_path)
 %       output_filename  - name of the video file
 %       vid_mm_per_px    - millimeters per pixel for the video
 %       fps              - frame rate of the processed video
+%       scaled_to_crim   - (optional) set true if video is already scaled
 %
 %   The returned structure is the same as produced by LOAD_PLUME_VIDEO. The
-%   plume data is rescaled to the CRIM intensity range using
-%   RESCALE_PLUME_RANGE.
+%   plume data is rescaled to the CRIM intensity range using RESCALE_PLUME_RANGE
+%   unless the optional metadata field 'scaled_to_crim' is true.
 %
 %   Example:
 %       plume = load_custom_plume('meta.yaml');
@@ -23,6 +24,8 @@ frame_rate = info.fps;
 
 plume = load_plume_video(video_path, px_per_mm, frame_rate);
 
-stats = plume_intensity_stats();
-plume.data = rescale_plume_range(plume.data, stats.CRIM.min, stats.CRIM.max);
+if ~isfield(info, 'scaled_to_crim') || ~info.scaled_to_crim
+    stats = plume_intensity_stats();
+    plume.data = rescale_plume_range(plume.data, stats.CRIM.min, stats.CRIM.max);
+end
 end

--- a/tests/test_load_custom_plume_skip_rescale.m
+++ b/tests/test_load_custom_plume_skip_rescale.m
@@ -1,0 +1,34 @@
+function tests = test_load_custom_plume_skip_rescale
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir, 'plume.avi'));
+    open(vw);
+    writeVideo(vw, uint8([0 255; 128 64]));
+    close(vw);
+    meta = fullfile(tmpDir, 'meta.yaml');
+    fid = fopen(meta, 'w');
+    fprintf(fid, 'output_directory: %s\n', tmpDir);
+    fprintf(fid, 'output_filename: plume.avi\n');
+    fprintf(fid, 'vid_mm_per_px: 1\n');
+    fprintf(fid, 'fps: 1\n');
+    fprintf(fid, 'scaled_to_crim: true\n');
+    fclose(fid);
+    testCase.TestData.tmpDir = tmpDir;
+    testCase.TestData.meta = meta;
+    testCase.TestData.video = fullfile(tmpDir, 'plume.avi');
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir, 's');
+end
+
+function testSkipRescaling(testCase)
+    orig = load_plume_video(testCase.TestData.video, 1, 1);
+    plume = load_custom_plume(testCase.TestData.meta);
+    verifyEqual(testCase, plume.data, orig.data);
+end


### PR DESCRIPTION
## Summary
- skip rescaling in `load_custom_plume` when `scaled_to_crim` metadata flag is true
- document optional `scaled_to_crim` field in the help block
- add regression test for skipping rescaling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `matlab -batch "exit"` *(fails: command not found)*
- `pre-commit run --files Code/load_custom_plume.m tests/test_load_custom_plume_skip_rescale.m` *(fails: command not found)*