### PR TITLE
chore(env): install opencv via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ vary.
 environment so the `--pure-python` option works without any extra
 installation when reading ``.avi`` files.
 
+`opencv-python` is installed via pip from PyPI rather than conda, ensuring the
+latest precompiled wheels are used.
+
 See [docs/intensity_comparison.md](docs/intensity_comparison.md#initial-setup)
 for a detailed explanation of the path setup process.
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -16,12 +16,12 @@ dependencies:
   - scipy
   - imageio
   - imageio-ffmpeg
-  - opencv-python
-  
   # Development tools
   - conda-lock>=2.0.0
   - pre-commit
   - pip
+  - pip:
+      - opencv-python
   - pytest
   - pytest-cov
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,6 @@ dependencies:
   - ruff
   - imageio
   - imageio-ffmpeg
-  - opencv-python
+  - pip
+  - pip:
+      - opencv-python


### PR DESCRIPTION
## Summary
- install `opencv-python` from pip in `environment.yml`
- install `opencv-python` from pip in `dev-environment.yml`
- document pip installation method in README

## Testing
- `./setup_env.sh --dev` *(fails: wget to download Miniconda)*
- `make test` *(fails: dev_env/bin/python not found)*