### PR TITLE
Add failing plume registry tests

### DIFF
--- a/tests/test_plume_registry_scale_custom_plume.m
+++ b/tests/test_plume_registry_scale_custom_plume.m
@@ -1,0 +1,40 @@
+function tests = test_plume_registry_scale_custom_plume
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir, 'orig.avi'));
+    open(vw);
+    writeVideo(vw, uint8([0 255; 128 64]));
+    writeVideo(vw, uint8([255 128; 64 0]));
+    close(vw);
+    meta = fullfile(tmpDir, 'meta.yaml');
+    fid = fopen(meta, 'w');
+    fprintf(fid, 'output_directory: %s\n', tmpDir);
+    fprintf(fid, 'output_filename: orig.avi\n');
+    fprintf(fid, 'vid_mm_per_px: 1\n');
+    fprintf(fid, 'fps: 1\n');
+    fclose(fid);
+    testCase.TestData.tmpDir = tmpDir;
+    testCase.TestData.meta = meta;
+    testCase.TestData.outVideo = fullfile(tmpDir, 'scaled.avi');
+    testCase.TestData.outMeta = fullfile(tmpDir, 'scaled.yaml');
+end
+
+function teardownOnce(testCase)
+    rmdir(testCase.TestData.tmpDir, 's');
+end
+
+function testPlumeRegistryUpdated(testCase)
+    scale_custom_plume(testCase.TestData.meta, ...
+                       testCase.TestData.outVideo, ...
+                       testCase.TestData.outMeta);
+    registry = load_yaml(fullfile('configs', 'plume_registry.yaml'));
+    verifyTrue(testCase, isfield(registry, 'scaled.avi'));
+    entry = registry.("scaled.avi");
+    verifyTrue(testCase, isfield(entry, 'min'));
+    verifyTrue(testCase, isfield(entry, 'max'));
+end

--- a/tests/test_plume_registry_video_to_hdf5.py
+++ b/tests/test_plume_registry_video_to_hdf5.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+from Code import rotate_video
+
+
+class _Frame:
+    def __init__(self, data):
+        self.data = data
+        self.ndim = 2
+
+    def reshape(self, *shape):
+        assert shape == (-1,)
+        return self.data
+
+
+def _simple_yaml(path: Path) -> dict:
+    data: dict[str, dict[str, float]] = {}
+    current = None
+    with open(path, "r") as f:
+        for raw in f:
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if not raw.startswith("  "):
+                current = stripped.rstrip(":")
+                data[current] = {}
+            else:
+                k, v = stripped.split(":", 1)
+                data[current][k.strip()] = float(v)
+    return data
+
+
+def test_plume_registry_video_to_hdf5(monkeypatch, tmp_path):
+    frames = [_Frame([0, 1, 2]), _Frame([3, 4, 5])]
+
+    class FakeImageIO:
+        @staticmethod
+        def imiter(path):
+            return frames
+
+    class DummyFile:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def create_dataset(self, name, data):
+            self.data = data
+
+    fake_np = types.SimpleNamespace(concatenate=lambda xs: sum(xs, []))
+    fake_h5py = types.SimpleNamespace(File=DummyFile)
+
+    monkeypatch.setitem(sys.modules, "numpy", fake_np)
+    monkeypatch.setitem(sys.modules, "h5py", fake_h5py)
+    monkeypatch.setattr(rotate_video, "imageio", FakeImageIO)
+
+    rotate_video.video_to_hdf5("in.avi", tmp_path / "out.h5")
+
+    registry_path = Path("configs") / "plume_registry.yaml"
+    registry = _simple_yaml(registry_path)
+    assert "out.h5" in registry
+    assert "min" in registry["out.h5"]
+    assert "max" in registry["out.h5"]


### PR DESCRIPTION
## Summary
- add MATLAB test expecting plume registry update from `scale_custom_plume`
- add Python test expecting plume registry update from `video_to_hdf5`

## Testing
- `pytest tests/test_plume_registry_video_to_hdf5.py -q` *(fails: FileNotFoundError)*