### PR TITLE
feat: add registry loader

### DIFF
--- a/Code/plume_registry.py
+++ b/Code/plume_registry.py
@@ -57,3 +57,14 @@ def update_plume_registry(
     registry[path] = {"min": float(min_val), "max": float(max_val)}
     with yaml_path.open("w", encoding="utf-8") as fh:
         yaml.safe_dump(registry, fh)
+
+
+def load_registry(yaml_path: Path = Path("configs/plume_registry.yaml")) -> dict:
+    """Return the contents of ``yaml_path`` or an empty dict if missing."""
+
+    if not yaml_path.exists():
+        return {}
+
+    with yaml_path.open("r", encoding="utf-8") as fh:
+        loaded = yaml.safe_load(fh) or {}
+        return loaded if isinstance(loaded, dict) else {}

--- a/tests/test_plume_registry_module.py
+++ b/tests/test_plume_registry_module.py
@@ -5,29 +5,13 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from Code.plume_registry import update_plume_registry
-
-
-def _simple_load(path: Path) -> dict:
-    data = {}
-    current = None
-    for raw_line in path.read_text().splitlines():
-        stripped = raw_line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if not raw_line.startswith("  "):
-            current = stripped.rstrip(":")
-            data[current] = {}
-        else:
-            key, value = stripped.split(":", 1)
-            data[current][key] = float(value)
-    return data
+from Code.plume_registry import load_registry, update_plume_registry
 
 
 def test_update_creates_entry(tmp_path):
     reg_path = tmp_path / "registry.yaml"
     update_plume_registry("plume.h5", 1.0, 2.0, reg_path)
-    data = _simple_load(reg_path)
+    data = load_registry(reg_path)
     assert data["plume.h5"]["min"] == 1.0
     assert data["plume.h5"]["max"] == 2.0
 
@@ -36,6 +20,11 @@ def test_update_expands_range(tmp_path):
     reg_path = tmp_path / "registry.yaml"
     update_plume_registry("plume.h5", 1.0, 2.0, reg_path)
     update_plume_registry("plume.h5", 0.5, 3.0, reg_path)
-    data = _simple_load(reg_path)
+    data = load_registry(reg_path)
     assert data["plume.h5"]["min"] == 0.5
     assert data["plume.h5"]["max"] == 3.0
+
+
+def test_load_returns_empty_for_missing(tmp_path):
+    reg_path = tmp_path / "missing.yaml"
+    assert load_registry(reg_path) == {}


### PR DESCRIPTION
## Summary
- implement `load_registry` for plume registry helper
- add tests for `load_registry`

## Testing
- `pytest tests/test_plume_registry_module.py -q`
- `pre-commit run --files Code/plume_registry.py tests/test_plume_registry_module.py` *(fails: command not found)*
- `pytest` *(fails: missing `numpy` and other dependencies)*