### PR TITLE
feat: update video utilities with plume registry integration

### DIFF
--- a/Code/plume_registry.py
+++ b/Code/plume_registry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
 try:  # pragma: no cover - fallback if PyYAML is unavailable
     import yaml  # type: ignore
@@ -35,6 +35,19 @@ except ModuleNotFoundError:  # pragma: no cover - minimal YAML support
         safe_load=lambda fh: _minimal_load(Path(fh.name)),
         safe_dump=lambda obj, fh: _minimal_dump(obj, fh),
     )
+
+
+def load_registry(yaml_path: Path = Path("configs/plume_registry.yaml")) -> Dict[str, Dict[str, float]]:
+    """Return the plume intensity registry as a dictionary."""
+    if yaml_path.exists():
+        with yaml_path.open("r", encoding="utf-8") as fh:
+            loaded = yaml.safe_load(fh) or {}
+            if isinstance(loaded, dict):
+                return {
+                    k: {"min": float(v.get("min", 0.0)), "max": float(v.get("max", 0.0))}
+                    for k, v in loaded.items()
+                }
+    return {}
 
 
 def update_plume_registry(

--- a/Code/rotate_video.py
+++ b/Code/rotate_video.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from .plume_registry import load_registry, update_plume_registry
+
 try:
     import imageio.v3 as imageio
 except Exception:  # pragma: no cover - optional dependency
@@ -43,6 +45,19 @@ def rotate_video_clockwise(
     if not frames:
         raise ValueError(f"no frames found in {input_path}")
 
+    registry = load_registry()
+    entry = registry.get(str(input_path))
+    if entry is None:
+        min_val = float(frames[0].min())
+        max_val = float(frames[0].max())
+        for frame in frames[1:]:
+            min_val = min(min_val, float(frame.min()))
+            max_val = max(max_val, float(frame.max()))
+        update_plume_registry(str(input_path), min_val, max_val)
+    else:
+        min_val = float(entry.get("min", 0.0))
+        max_val = float(entry.get("max", 0.0))
+
     if fps is None:
         try:
             reader = imageio.get_reader(input_path)
@@ -56,6 +71,7 @@ def rotate_video_clockwise(
     rotated = [frame[::-1].transpose(1, 0, *range(2, frame.ndim)) for frame in frames]
     imageio.imwrite(output_path, rotated, plugin="pyav", fps=fps, codec=codec)
     logger.info("Saved rotated video to %s", output_path)
+    update_plume_registry(str(output_path), min_val, max_val)
 
 
 def video_to_hdf5(input_path: str | Path, output_path: str | Path) -> None:
@@ -78,13 +94,28 @@ def video_to_hdf5(input_path: str | Path, output_path: str | Path) -> None:
     if imageio is None:  # pragma: no cover - runtime environment may lack imageio
         raise ImportError("imageio is required for video_to_hdf5")
 
+    registry = load_registry()
+    entry = registry.get(str(input_path))
     frames = []
+    min_val = None
+    max_val = None
     for frame in imageio.imiter(input_path):
         arr = frame if frame.ndim == 2 else frame[..., 0]
         frames.append(arr.reshape(-1))
+        if entry is None:
+            vmin = float(arr.min())
+            vmax = float(arr.max())
+            min_val = vmin if min_val is None else min(min_val, vmin)
+            max_val = vmax if max_val is None else max(max_val, vmax)
 
     if not frames:
         raise ValueError(f"no frames found in {input_path}")
+
+    if entry is not None:
+        min_val = float(entry.get("min", 0.0))
+        max_val = float(entry.get("max", 0.0))
+    else:
+        update_plume_registry(str(input_path), float(min_val), float(max_val))
 
     import h5py  # imported lazily to avoid mandatory dependency
     import numpy as np
@@ -92,3 +123,4 @@ def video_to_hdf5(input_path: str | Path, output_path: str | Path) -> None:
     data = np.concatenate(frames)
     with h5py.File(output_path, "w") as f:
         f.create_dataset("dataset1", data=data)
+    update_plume_registry(str(output_path), float(min_val), float(max_val))

--- a/tests/test_rotate_video.py
+++ b/tests/test_rotate_video.py
@@ -1,7 +1,25 @@
 import numpy as np
 import pytest
+from pathlib import Path
 
 from Code import rotate_video
+
+
+def _simple_yaml(path: Path) -> dict:
+    data: dict[str, dict[str, float]] = {}
+    current = None
+    with open(path, "r") as f:
+        for raw in f:
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if not raw.startswith("  "):
+                current = stripped.rstrip(":")
+                data[current] = {}
+            else:
+                k, v = stripped.split(":", 1)
+                data[current][k.strip()] = float(v)
+    return data
 
 def test_rotate_video_clockwise(tmp_path):
     # Create a dummy 2x3 video with two frames using numpy
@@ -24,6 +42,10 @@ def test_rotate_video_clockwise(tmp_path):
     assert rotated_frames[0].shape == (3, 2)
     assert rotated_frames[1].shape == (3, 2)
 
+    registry_path = Path("configs") / "plume_registry.yaml"
+    registry = _simple_yaml(registry_path)
+    assert output_video.name in registry
+
 
 def test_rotate_video_clockwise_custom_fps(tmp_path):
     frames = [
@@ -44,3 +66,7 @@ def test_rotate_video_clockwise_custom_fps(tmp_path):
 
     meta = imageio.get_reader(output_video).get_meta_data()
     assert meta.get("fps") == 25
+
+    registry_path = Path("configs") / "plume_registry.yaml"
+    registry = _simple_yaml(registry_path)
+    assert output_video.name in registry


### PR DESCRIPTION
## Summary
- implement `load_registry` helper to read `plume_registry.yaml`
- update `rotate_video_clockwise` and `video_to_hdf5` to reuse registry
- expand tests for updated registry behaviour

## Testing
- `./setup_env.sh --dev` *(fails: Miniconda download blocked)*
- `pytest tests/test_rotate_video.py::test_rotate_video_clockwise -q` *(fails: found no collectors)*
- `pre-commit run --files Code/rotate_video.py Code/plume_registry.py tests/test_rotate_video.py tests/test_video_to_hdf5.py` *(fails: command not found)*