### PR TITLE
Add update_plume_registry utility

### DIFF
--- a/Code/update_plume_registry.m
+++ b/Code/update_plume_registry.m
@@ -1,0 +1,78 @@
+function update_plume_registry(file, minVal, maxVal, yamlPath)
+%UPDATE_PLUME_REGISTRY Insert or update plume intensity range.
+%   UPDATE_PLUME_REGISTRY(FILE, MINVAL, MAXVAL) updates the plume registry
+%   entry for FILE in the default registry YAML file. If FILE already
+%   exists, the stored range is expanded to include MINVAL and MAXVAL.
+%   UPDATE_PLUME_REGISTRY(..., YAMLPATH) specifies a custom registry file.
+%
+%   The registry is stored in YAML when the YAML toolbox is available.
+%   Otherwise, JSON encoding is used as a fallback.
+
+arguments
+    file (1,:) char
+    minVal (1,1) double
+    maxVal (1,1) double
+    yamlPath (1,:) char = defaultRegistryPath()
+end
+
+% Load existing registry if possible
+registry = struct();
+if exist(yamlPath, 'file') == 2
+    try
+        if exist('load_yaml', 'file') == 2
+            registry = load_yaml(yamlPath);
+        else
+            fid = fopen(yamlPath, 'r');
+            if fid ~= -1
+                txt = fread(fid, '*char')';
+                fclose(fid);
+                registry = jsondecode(txt);
+            end
+        end
+    catch ME %#ok<NASGU>
+        registry = struct();
+    end
+end
+
+if ~isstruct(registry)
+    registry = struct();
+end
+
+% Update or insert entry
+if isfield(registry, file)
+    entry = registry.(file);
+    if isfield(entry, 'min')
+        minVal = min(minVal, double(entry.min));
+    end
+    if isfield(entry, 'max')
+        maxVal = max(maxVal, double(entry.max));
+    end
+end
+registry.(file) = struct('min', minVal, 'max', maxVal);
+
+% Ensure directory exists
+[yDir,~] = fileparts(yamlPath);
+if ~isempty(yDir) && ~exist(yDir, 'dir')
+    mkdir(yDir);
+end
+
+% Save registry
+try
+    if exist('yamlwrite', 'file') == 2
+        yamlwrite(yamlPath, registry);
+    else
+        fid = fopen(yamlPath, 'w');
+        fwrite(fid, jsonencode(registry));
+        fclose(fid);
+    end
+catch ME
+    warning('update_plume_registry:WriteFailed', ...
+            'Failed to save registry: %s', ME.message);
+end
+end
+
+function p = defaultRegistryPath
+thisDir = fileparts(mfilename('fullpath'));
+rootDir = fileparts(thisDir);
+p = fullfile(rootDir, 'configs', 'plume_registry.yaml');
+end

--- a/tests/test_update_plume_registry.m
+++ b/tests/test_update_plume_registry.m
@@ -1,0 +1,29 @@
+function tests = test_update_plume_registry
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    testCase.TestData.yml = [tempname '.yaml'];
+end
+
+function teardownOnce(testCase)
+    if exist(testCase.TestData.yml, 'file')
+        delete(testCase.TestData.yml);
+    end
+end
+
+function testCreatesEntry(testCase)
+    update_plume_registry('file.h5', 1, 2, testCase.TestData.yml);
+    data = load_yaml(testCase.TestData.yml);
+    verifyEqual(testCase, data.("file.h5").min, 1);
+    verifyEqual(testCase, data.("file.h5").max, 2);
+end
+
+function testExpandsRange(testCase)
+    update_plume_registry('file.h5', 1, 2, testCase.TestData.yml);
+    update_plume_registry('file.h5', 0.5, 3, testCase.TestData.yml);
+    data = load_yaml(testCase.TestData.yml);
+    verifyEqual(testCase, data.("file.h5").min, 0.5);
+    verifyEqual(testCase, data.("file.h5").max, 3);
+end


### PR DESCRIPTION
## Summary
- add `update_plume_registry.m` for maintaining plume intensity registry
- test creation and update logic in `test_update_plume_registry.m`

## Testing
- `pytest -q tests/test_plume_registry_module.py tests/test_plume_registry_video_to_hdf5.py` *(fails: FileNotFoundError)*
- `matlab -batch "..."` *(fails: command not found)*