### PR TITLE
feat: register custom plume videos

### DIFF
--- a/Code/update_plume_registry.m
+++ b/Code/update_plume_registry.m
@@ -1,0 +1,53 @@
+function update_plume_registry(path, min_val, max_val, yamlPath)
+%UPDATE_PLUME_REGISTRY Update intensity range registry.
+%   UPDATE_PLUME_REGISTRY(PATH, MIN_VAL, MAX_VAL) stores the provided
+%   intensity range for PATH in the plume registry YAML file. If an
+%   existing entry is found, the stored range is expanded to encompass
+%   the new values. The default registry file is
+%   'configs/plume_registry.yaml' relative to the repository root.
+%
+%   Example:
+%       update_plume_registry('plume.h5', 0, 1.2);
+%
+%   See also: load_yaml
+
+arguments
+    path (1,:) char
+    min_val (1,1) double
+    max_val (1,1) double
+    yamlPath (1,:) char = defaultYaml()
+end
+
+if exist(yamlPath, 'file')
+    registry = load_yaml(yamlPath);
+else
+    registry = struct();
+end
+
+if isfield(registry, path)
+    entry = registry.(path);
+    min_val = min(double(entry.min), min_val);
+    max_val = max(double(entry.max), max_val);
+end
+
+registry.(path) = struct('min', double(min_val), 'max', double(max_val));
+
+try
+    if exist('yamlwrite', 'file') == 2
+        yamlwrite(yamlPath, registry);
+    else
+        fid = fopen(yamlPath, 'w');
+        fwrite(fid, jsonencode(registry));
+        fclose(fid);
+    end
+catch ME
+    warning('update_plume_registry:WriteFailed', ...
+        'Failed to save registry: %s', ME.message);
+end
+end
+
+function p = defaultYaml
+thisDir = fileparts(mfilename('fullpath'));
+rootDir = fileparts(thisDir);
+p = fullfile(rootDir, 'configs', 'plume_registry.yaml');
+end

--- a/tests/test_plume_registry_scale_custom_plume.m
+++ b/tests/test_plume_registry_scale_custom_plume.m
@@ -35,6 +35,15 @@ function testPlumeRegistryUpdated(testCase)
     registry = load_yaml(fullfile('configs', 'plume_registry.yaml'));
     verifyTrue(testCase, isfield(registry, 'scaled.avi'));
     entry = registry.("scaled.avi");
-    verifyTrue(testCase, isfield(entry, 'min'));
-    verifyTrue(testCase, isfield(entry, 'max'));
+    stats = plume_intensity_stats();
+    verifyEqual(testCase, entry.min, stats.CRIM.min, 'AbsTol', 1e-12);
+    verifyEqual(testCase, entry.max, stats.CRIM.max, 'AbsTol', 1e-12);
+    verifyTrue(testCase, isfield(registry, 'orig.avi'));
+    plume = load_plume_video(fullfile(testCase.TestData.tmpDir, 'orig.avi'), 1, 1);
+    scaled = rescale_plume_range(plume.data, stats.CRIM.min, stats.CRIM.max);
+    expMin = min(scaled(:));
+    expMax = max(scaled(:));
+    origEntry = registry.("orig.avi");
+    verifyEqual(testCase, origEntry.min, expMin, 'AbsTol', 1e-12);
+    verifyEqual(testCase, origEntry.max, expMax, 'AbsTol', 1e-12);
 end

--- a/tests/test_scale_custom_plume.m
+++ b/tests/test_scale_custom_plume.m
@@ -44,4 +44,11 @@ function testScalingAndMetadata(testCase)
     stats = plume_intensity_stats();
     verifyEqual(testCase, min(plume.data(:)), stats.CRIM.min, 'AbsTol', 1e-12);
     verifyEqual(testCase, max(plume.data(:)), stats.CRIM.max, 'AbsTol', 1e-12);
+
+    registry = load_yaml(fullfile('configs', 'plume_registry.yaml'));
+    verifyEqual(testCase, registry.("scaled.avi").min, stats.CRIM.min, 'AbsTol', 1e-12);
+    verifyEqual(testCase, registry.("scaled.avi").max, stats.CRIM.max, 'AbsTol', 1e-12);
+    verifyTrue(testCase, isfield(registry, 'orig.avi'));
+    verifyEqual(testCase, registry.("orig.avi").min, stats.CRIM.min, 'AbsTol', 1e-12);
+    verifyEqual(testCase, registry.("orig.avi").max, stats.CRIM.max, 'AbsTol', 1e-12);
 end


### PR DESCRIPTION
## Summary
- record plume intensity ranges in `scale_custom_plume`
- expose `update_plume_registry` helper for MATLAB
- verify registry entries in scale_custom_plume tests

## Testing
- `pytest -k scale_custom_plume -q` *(fails: ModuleNotFoundError: No module named 'loguru')*