### PR TITLE
Improve plume registry update

### DIFF
--- a/Code/update_plume_registry.m
+++ b/Code/update_plume_registry.m
@@ -1,46 +1,16 @@
-function update_plume_registry(path, min_val, max_val, yamlPath)
-%UPDATE_PLUME_REGISTRY Update intensity range registry.
-%   UPDATE_PLUME_REGISTRY(PATH, MIN_VAL, MAX_VAL) stores the provided
-%   intensity range for PATH in the plume registry YAML file. If an
-%   existing entry is found, the stored range is expanded to encompass
-%   the new values. The default registry file is
-%   'configs/plume_registry.yaml' relative to the repository root.
+function update_plume_registry(file, minVal, maxVal, yamlPath)
+%UPDATE_PLUME_REGISTRY Insert or update intensity range for a plume file.
+%   update_plume_registry(FILE, MINVAL, MAXVAL) records the intensity range
+%   for FILE inside the plume registry. If an entry already exists, the
+%   stored range is expanded to include the new MINVAL and MAXVAL.
+%   update_plume_registry(..., YAMLPATH) writes to the specified registry
+%   file. The default registry lives under configs/plume_registry.yaml at
+%   the repository root.
 %
 %   Example:
 %       update_plume_registry('plume.h5', 0, 1.2);
 %
 %   See also: load_yaml
-
-arguments
-    path (1,:) char
-    min_val (1,1) double
-    max_val (1,1) double
-    yamlPath (1,:) char = defaultYaml()
-end
-
-if exist(yamlPath, 'file')
-    registry = load_yaml(yamlPath);
-else
-    registry = struct();
-end
-
-if isfield(registry, path)
-    entry = registry.(path);
-    min_val = min(double(entry.min), min_val);
-    max_val = max(double(entry.max), max_val);
-end
-
-registry.(path) = struct('min', double(min_val), 'max', double(max_val));
-
-function update_plume_registry(file, minVal, maxVal, yamlPath)
-%UPDATE_PLUME_REGISTRY Insert or update plume intensity range.
-%   UPDATE_PLUME_REGISTRY(FILE, MINVAL, MAXVAL) updates the plume registry
-%   entry for FILE in the default registry YAML file. If FILE already
-%   exists, the stored range is expanded to include MINVAL and MAXVAL.
-%   UPDATE_PLUME_REGISTRY(..., YAMLPATH) specifies a custom registry file.
-%
-%   The registry is stored in YAML when the YAML toolbox is available.
-%   Otherwise, JSON encoding is used as a fallback.
 
 arguments
     file (1,:) char
@@ -49,30 +19,18 @@ arguments
     yamlPath (1,:) char = defaultRegistryPath()
 end
 
-% Load existing registry if possible
-registry = struct();
+% Load existing registry or start new
 if exist(yamlPath, 'file') == 2
     try
-        if exist('load_yaml', 'file') == 2
-            registry = load_yaml(yamlPath);
-        else
-            fid = fopen(yamlPath, 'r');
-            if fid ~= -1
-                txt = fread(fid, '*char')';
-                fclose(fid);
-                registry = jsondecode(txt);
-            end
-        end
-    catch ME %#ok<NASGU>
+        registry = load_yaml(yamlPath);
+    catch
         registry = struct();
     end
-end
-
-if ~isstruct(registry)
+else
     registry = struct();
 end
 
-% Update or insert entry
+% Update or insert the entry
 if isfield(registry, file)
     entry = registry.(file);
     if isfield(entry, 'min')
@@ -82,15 +40,15 @@ if isfield(registry, file)
         maxVal = max(maxVal, double(entry.max));
     end
 end
-registry.(file) = struct('min', minVal, 'max', maxVal);
+registry.(file) = struct('min', double(minVal), 'max', double(maxVal));
 
-% Ensure directory exists
-[yDir,~] = fileparts(yamlPath);
+% Ensure destination directory exists
+[yDir, ~] = fileparts(yamlPath);
 if ~isempty(yDir) && ~exist(yDir, 'dir')
     mkdir(yDir);
 end
 
-% Save registry
+% Save registry back to disk
 try
     if exist('yamlwrite', 'file') == 2
         yamlwrite(yamlPath, registry);
@@ -105,8 +63,7 @@ catch ME
 end
 end
 
-function p = defaultYaml
-
+function p = defaultRegistryPath
 thisDir = fileparts(mfilename('fullpath'));
 rootDir = fileparts(thisDir);
 p = fullfile(rootDir, 'configs', 'plume_registry.yaml');

--- a/tests/test_update_plume_registry.m
+++ b/tests/test_update_plume_registry.m
@@ -15,6 +15,7 @@ end
 
 function testCreatesEntry(testCase)
     update_plume_registry('file.h5', 1, 2, testCase.TestData.yml);
+    verifyEqual(testCase, exist(testCase.TestData.yml, 'file') == 2, true);
     data = load_yaml(testCase.TestData.yml);
     verifyEqual(testCase, data.("file.h5").min, 1);
     verifyEqual(testCase, data.("file.h5").max, 2);


### PR DESCRIPTION
## Summary
- simplify `update_plume_registry` to use a single function
- check file creation in the unit test

## Testing
- `pytest -k update_plume_registry -v` *(fails: ModuleNotFoundError: No module named 'loguru')*