### PR TITLE
Fix plume registry duplicate load function

### DIFF
--- a/Code/plume_registry.py
+++ b/Code/plume_registry.py
@@ -72,12 +72,3 @@ def update_plume_registry(
         yaml.safe_dump(registry, fh)
 
 
-def load_registry(yaml_path: Path = Path("configs/plume_registry.yaml")) -> dict:
-    """Return the contents of ``yaml_path`` or an empty dict if missing."""
-
-    if not yaml_path.exists():
-        return {}
-
-    with yaml_path.open("r", encoding="utf-8") as fh:
-        loaded = yaml.safe_load(fh) or {}
-        return loaded if isinstance(loaded, dict) else {}

--- a/tests/test_plume_registry_module.py
+++ b/tests/test_plume_registry_module.py
@@ -28,3 +28,18 @@ def test_update_expands_range(tmp_path):
 def test_load_returns_empty_for_missing(tmp_path):
     reg_path = tmp_path / "missing.yaml"
     assert load_registry(reg_path) == {}
+
+
+def test_load_casts_values_to_float(tmp_path, monkeypatch):
+    reg_path = tmp_path / "registry.yaml"
+    reg_path.write_text("plume.h5:\n  min: 1\n  max: 2\n")
+
+    def fake_load(_fh):
+        return {"plume.h5": {"min": 1, "max": 2}}
+
+    monkeypatch.setattr("Code.plume_registry.yaml.safe_load", fake_load)
+    data = load_registry(reg_path)
+    assert data["plume.h5"]["min"] == 1.0
+    assert data["plume.h5"]["max"] == 2.0
+    assert isinstance(data["plume.h5"]["min"], float)
+    assert isinstance(data["plume.h5"]["max"], float)


### PR DESCRIPTION
## Summary
- add regression test for load_registry to ensure float output
- remove duplicate load_registry implementation

## Testing
- `pytest tests/test_plume_registry_module.py -q`