### PR TITLE
Fix plume registry to store original range

### DIFF
--- a/Code/scale_custom_plume.m
+++ b/Code/scale_custom_plume.m
@@ -26,6 +26,9 @@ px_per_mm = 1 / info.vid_mm_per_px;
 frame_rate = info.fps;
 
 plume = load_plume_video(video_path, px_per_mm, frame_rate);
+% Store the original intensity range before any rescaling
+origMin = min(plume.data(:));
+origMax = max(plume.data(:));
 
 stats = plume_intensity_stats();
 scaled = rescale_plume_range(plume.data, stats.CRIM.min, stats.CRIM.max);
@@ -38,7 +41,7 @@ else
     registry = struct();
 end
 if ~isfield(registry, info.output_filename)
-    update_plume_registry(info.output_filename, min(scaled(:)), max(scaled(:)), registry_path);
+    update_plume_registry(info.output_filename, origMin, origMax, registry_path);
 end
 
 % store movie in 0..1 so load_custom_plume rescales correctly

--- a/tests/test_plume_registry_scale_custom_plume.m
+++ b/tests/test_plume_registry_scale_custom_plume.m
@@ -40,9 +40,9 @@ function testPlumeRegistryUpdated(testCase)
     verifyEqual(testCase, entry.max, stats.CRIM.max, 'AbsTol', 1e-12);
     verifyTrue(testCase, isfield(registry, 'orig.avi'));
     plume = load_plume_video(fullfile(testCase.TestData.tmpDir, 'orig.avi'), 1, 1);
-    scaled = rescale_plume_range(plume.data, stats.CRIM.min, stats.CRIM.max);
-    expMin = min(scaled(:));
-    expMax = max(scaled(:));
+    % Original range should be stored without rescaling
+    expMin = min(plume.data(:));
+    expMax = max(plume.data(:));
     origEntry = registry.("orig.avi");
     verifyEqual(testCase, origEntry.min, expMin, 'AbsTol', 1e-12);
     verifyEqual(testCase, origEntry.max, expMax, 'AbsTol', 1e-12);


### PR DESCRIPTION
## Summary
- expect registry to keep original range in test
- store original min/max in `scale_custom_plume`
- document original range storage

## Testing
- `pytest -k plume_registry_scale_custom_plume` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files Code/scale_custom_plume.m tests/test_plume_registry_scale_custom_plume.m` *(fails: command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.