### PR TITLE
Add plume pipeline

### DIFF
--- a/Code/__init__.py
+++ b/Code/__init__.py
@@ -8,5 +8,6 @@ Run the analysis pipeline::
     run_pipeline("configs/example_analysis.yaml")
 """
 from .rotate_video import rotate_video_clockwise
+from .plume_pipeline import video_to_scaled_rotated_h5
 
-__all__ = ["rotate_video_clockwise"]
+__all__ = ["rotate_video_clockwise", "video_to_scaled_rotated_h5"]

--- a/Code/plume_pipeline.py
+++ b/Code/plume_pipeline.py
@@ -1,0 +1,90 @@
+"""Helpers to convert and transform plume videos.
+
+This module provides a convenience function
+:func:`video_to_scaled_rotated_h5` that converts an AVI file to HDF5,
+scales the intensities to match the Crimaldi range, and rotates the
+frames 90 degrees clockwise. All intermediate results are stored in
+HDF5 files and registered via :func:`Code.plume_registry.update_plume_registry`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from .plume_registry import update_plume_registry
+from .plume_utils import rescale_to_crim_range
+from .rotate_video import video_to_hdf5
+
+__all__ = ["video_to_scaled_rotated_h5", "scale_hdf5_to_crim_range", "rotate_hdf5_clockwise"]
+
+
+def _read_shape(dset: h5py.Dataset) -> tuple[int, int, int]:
+    """Return (height, width, frames) from ``dset`` attributes."""
+    height = int(dset.attrs["height"])
+    width = int(dset.attrs["width"])
+    frames = int(dset.attrs["frames"])
+    return height, width, frames
+
+
+def scale_hdf5_to_crim_range(input_path: str | Path, output_path: str | Path) -> None:
+    """Scale ``input_path`` to the Crimaldi intensity range and write ``output_path``."""
+    with h5py.File(input_path, "r") as f:
+        dset = f["dataset1"]
+        data = dset[()]
+        height, width, frames = _read_shape(dset)
+
+    scaled = rescale_to_crim_range(np.asarray(data, dtype=float))
+    with h5py.File(output_path, "w") as f:
+        out = f.create_dataset("dataset1", data=scaled)
+        out.attrs.update(height=height, width=width, frames=frames)
+
+    update_plume_registry(str(output_path), float(scaled.min()), float(scaled.max()))
+
+
+def rotate_hdf5_clockwise(input_path: str | Path, output_path: str | Path) -> None:
+    """Rotate plume data in ``input_path`` 90° clockwise and save to ``output_path``."""
+    with h5py.File(input_path, "r") as f:
+        dset = f["dataset1"]
+        data = dset[()]
+        height, width, frames = _read_shape(dset)
+
+    frames_arr = np.reshape(data, (frames, height, width))
+    rotated = np.array([np.rot90(frame, k=-1) for frame in frames_arr])
+    with h5py.File(output_path, "w") as f:
+        out = f.create_dataset("dataset1", data=rotated.reshape(-1))
+        out.attrs.update(height=width, width=height, frames=frames)
+
+    update_plume_registry(str(output_path), float(rotated.min()), float(rotated.max()))
+
+
+def video_to_scaled_rotated_h5(
+    avi_path: str | Path,
+    raw_h5: str | Path,
+    scaled_h5: str | Path,
+    rotated_h5: str | Path,
+) -> None:
+    """Full pipeline: AVI → HDF5 → scaled → rotated."""
+    video_to_hdf5(avi_path, raw_h5)
+
+    with h5py.File(raw_h5, "r+") as f:
+        dset = f["dataset1"]
+        # determine shape if missing
+        if not {"height", "width", "frames"} <= set(dset.attrs):
+            raise ValueError("missing shape information in raw HDF5 file")
+        height, width, frames = _read_shape(dset)
+        data = dset[()]
+    scaled = rescale_to_crim_range(np.asarray(data, dtype=float))
+    with h5py.File(scaled_h5, "w") as f:
+        out = f.create_dataset("dataset1", data=scaled)
+        out.attrs.update(height=height, width=width, frames=frames)
+    update_plume_registry(str(scaled_h5), float(scaled.min()), float(scaled.max()))
+
+    frames_arr = np.reshape(scaled, (frames, height, width))
+    rotated = np.array([np.rot90(frame, k=-1) for frame in frames_arr])
+    with h5py.File(rotated_h5, "w") as f:
+        out = f.create_dataset("dataset1", data=rotated.reshape(-1))
+        out.attrs.update(height=width, width=height, frames=frames)
+    update_plume_registry(str(rotated_h5), float(rotated.min()), float(rotated.max()))

--- a/tests/test_code_init_exports.py
+++ b/tests/test_code_init_exports.py
@@ -5,3 +5,4 @@ def test_rotate_video_clockwise_in_all():
     package = importlib.import_module("Code")
     assert hasattr(package, "__all__"), "package should define __all__"
     assert "rotate_video_clockwise" in package.__all__, "rotate_video_clockwise should be re-exported"
+    assert "video_to_scaled_rotated_h5" in package.__all__, "video_to_scaled_rotated_h5 should be re-exported"

--- a/tests/test_video_plume_pipeline.py
+++ b/tests/test_video_plume_pipeline.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pytest
+from pathlib import Path
+
+from Code import plume_pipeline, plume_utils
+
+imageio = pytest.importorskip("imageio.v3")
+h5py = pytest.importorskip("h5py")
+
+
+def _simple_yaml(path: Path) -> dict:
+    data: dict[str, dict[str, float]] = {}
+    current = None
+    with path.open("r") as f:
+        for raw in f:
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if not raw.startswith("  "):
+                current = stripped.rstrip(":")
+                data[current] = {}
+            else:
+                k, v = stripped.split(":", 1)
+                data[current][k.strip()] = float(v)
+    return data
+
+
+def test_video_plume_pipeline(tmp_path):
+    frames = np.stack([
+        np.arange(6, dtype=np.uint8).reshape(2, 3),
+        np.arange(6, 12, dtype=np.uint8).reshape(2, 3),
+    ])
+    avi = tmp_path / "in.avi"
+    imageio.imwrite(avi, frames, plugin="pyav", fps=1)
+
+    raw_h5 = tmp_path / "raw.h5"
+    scaled_h5 = tmp_path / "scaled.h5"
+    rotated_h5 = tmp_path / "rotated.h5"
+
+    plume_pipeline.video_to_scaled_rotated_h5(
+        str(avi), str(raw_h5), str(scaled_h5), str(rotated_h5)
+    )
+
+    with h5py.File(raw_h5, "r") as f:
+        raw = f["dataset1"][()]
+        attrs = dict(f["dataset1"].attrs)
+    assert np.array_equal(raw, frames.reshape(-1))
+    assert attrs["height"] == 2
+    assert attrs["width"] == 3
+    assert attrs["frames"] == 2
+
+    stats = plume_utils.get_intensity_stats()
+    with h5py.File(scaled_h5, "r") as f:
+        scaled = f["dataset1"][()]
+    assert pytest.approx(stats["CRIM"]["min"], rel=1e-6) == float(scaled.min())
+    assert pytest.approx(stats["CRIM"]["max"], rel=1e-6) == float(scaled.max())
+
+    with h5py.File(rotated_h5, "r") as f:
+        rotated = f["dataset1"][()]
+        attrs_rot = dict(f["dataset1"].attrs)
+
+    scaled_frames = plume_utils.rescale_to_crim_range(frames.reshape(-1)).reshape(frames.shape)
+    expected_rot = np.stack([np.rot90(f, -1) for f in scaled_frames]).reshape(-1)
+    assert np.array_equal(rotated, expected_rot)
+    assert attrs_rot["height"] == 3
+    assert attrs_rot["width"] == 2
+    assert attrs_rot["frames"] == 2
+
+    reg_path = Path("configs") / "plume_registry.yaml"
+    registry = _simple_yaml(reg_path)
+    assert raw_h5.name in registry
+    assert scaled_h5.name in registry
+    assert rotated_h5.name in registry
+


### PR DESCRIPTION
## Summary
- add failing tests for pipeline
- implement pipeline functions to convert, scale, and rotate plume HDF5
- export new pipeline in package
- store video shape metadata during HDF5 conversion

## Testing
- `ruff check Code/plume_pipeline.py Code/rotate_video.py Code/__init__.py tests/test_video_plume_pipeline.py tests/test_code_init_exports.py`
- `pytest -q tests/test_video_plume_pipeline.py tests/test_code_init_exports.py` *(fails: ModuleNotFoundError: No module named 'numpy')*