### PR TITLE
Clarify path handling in plume pipeline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ conda run --prefix ./dev_env python -m scripts.run_plume_pipeline \
 - `Code/` – MATLAB and Python modules
 - `configs/` – configuration templates
 - `data/` – raw and processed datasets
+  - Processed files can live outside this repository as long as you provide the
+    correct paths in your configuration files or on the command line.
 - `docs/` – project documentation
 
 For citations and metadata, see `CITATION.cff` and `codemeta.json`.

--- a/docs/plume_pipeline.md
+++ b/docs/plume_pipeline.md
@@ -22,7 +22,9 @@ conda run --prefix ./dev_env python -m scripts.run_plume_pipeline \
 ```
 
 The script creates the three HDF5 files and updates
-`configs/plume_registry.yaml` with their intensity ranges.
+`configs/plume_registry.yaml` with their intensity ranges. Input and output
+arguments may be either relative or absolute paths. When absolute paths are
+supplied, the registry records only the base filename so entries remain portable.
 
 ## Python API
 

--- a/scripts/run_plume_pipeline.py
+++ b/scripts/run_plume_pipeline.py
@@ -3,7 +3,9 @@
 
 This script converts an AVI video to HDF5, rescales intensities to the
 Crimaldi range, rotates frames 90° clockwise, and updates the plume
-registry. Paths are given relative to the repository root.
+registry. Paths may be absolute or relative to the repository root. When
+absolute paths are provided, only the base filename is recorded in
+``configs/plume_registry.yaml``.
 
 Example
 -------


### PR DESCRIPTION
## Summary
- clarify that run_plume_pipeline accepts absolute paths
- mention registry stores only basenames
- note that processed files may live outside the repo

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: 18 errors during collection)*