### PR TITLE
Update plume registry to use filenames

### DIFF
--- a/Code/plume_registry.py
+++ b/Code/plume_registry.py
@@ -56,18 +56,23 @@ def update_plume_registry(
     max_val: float,
     yaml_path: Path = Path("configs/plume_registry.yaml"),
 ) -> None:
-    """Update or insert intensity range for ``path`` in ``yaml_path``."""
+    """Update or insert intensity range for ``path`` in ``yaml_path``.
+
+    The registry uses ``Path(path).name`` as the key so absolute paths are
+    normalised to their filename.
+    """
     registry: Dict[str, Dict[str, Any]] = {}
     if yaml_path.exists():
         with yaml_path.open("r", encoding="utf-8") as fh:
             loaded = yaml.safe_load(fh) or {}
             if isinstance(loaded, dict):
                 registry = loaded
-    entry = registry.get(path)
+    key = Path(path).name
+    entry = registry.get(key)
     if entry:
         min_val = min(float(entry.get("min", min_val)), min_val)
         max_val = max(float(entry.get("max", max_val)), max_val)
-    registry[path] = {"min": float(min_val), "max": float(max_val)}
+    registry[key] = {"min": float(min_val), "max": float(max_val)}
     with yaml_path.open("w", encoding="utf-8") as fh:
         yaml.safe_dump(registry, fh)
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ provided:
   this scaling twice when the plume has already been normalised.
 - [Plume Transformation Utilities](docs/intensity_comparison.md#plume-transformation-utilities) provide scaling and rotation helpers.
 - Intensity ranges for processed plumes are stored in
-  `configs/plume_registry.yaml`; transformation scripts update this file
-  automatically. See
+  `configs/plume_registry.yaml`; each entry is keyed by filename only.
+  Transformation scripts update this file automatically. See
   [Plume Registry](docs/intensity_comparison.md#plume-registry).
 
 Example workflow:

--- a/docs/intensity_comparison.md
+++ b/docs/intensity_comparison.md
@@ -286,12 +286,12 @@ Use these helpers to prepare plume videos for analysis.
 ### Plume Registry
 
 Processed plume files and their intensity ranges are tracked in
-`configs/plume_registry.yaml`. Each entry stores the minimum and maximum values
-used for scaling:
+`configs/plume_registry.yaml`. Each entry is keyed by filename only and stores
+the minimum and maximum values used for scaling:
 
 ```yaml
 # Example entry
-plumes/smoke_scaled.h5:
+smoke_scaled.h5:
   min: 0.1
   max: 3.1
 ```

--- a/tests/test_plume_registry_module.py
+++ b/tests/test_plume_registry_module.py
@@ -43,3 +43,14 @@ def test_load_casts_values_to_float(tmp_path, monkeypatch):
     assert data["plume.h5"]["max"] == 2.0
     assert isinstance(data["plume.h5"]["min"], float)
     assert isinstance(data["plume.h5"]["max"], float)
+
+
+def test_absolute_path_uses_basename(tmp_path):
+    reg_path = tmp_path / "registry.yaml"
+    abs_path = tmp_path / "data" / "plume.h5"
+    abs_path.parent.mkdir()
+    abs_path.write_text("dummy")
+
+    update_plume_registry(str(abs_path), 1.0, 2.0, reg_path)
+    data = load_registry(reg_path)
+    assert "plume.h5" in data


### PR DESCRIPTION
## Summary
- ensure update_plume_registry stores entries keyed by filename
- document filename-only behaviour in docs
- add regression test for absolute paths

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest tests/test_plume_registry_module.py::test_absolute_path_uses_basename -q` *(fails: ModuleNotFoundError: No module named 'h5py')*