### PR TITLE
Add custom plume processing script

### DIFF
--- a/scripts/process_custom_plume.py
+++ b/scripts/process_custom_plume.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Process a custom plume video into rotated, scaled HDF5 with metadata."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from Code.plume_pipeline import video_to_scaled_rotated_h5  # noqa: E402
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except Exception:  # pragma: no cover - minimal YAML writer
+    yaml = None
+
+
+def _write_meta(
+    path: Path, directory: Path, rotated_h5: str, px_per_mm: float, fps: float
+) -> None:
+    mm_per_px = 1 / px_per_mm
+    info = {
+        "output_directory": str(directory),
+        "output_filename": Path(rotated_h5).name,
+        "vid_mm_per_px": mm_per_px,
+        "fps": fps,
+        "scaled_to_crim": True,
+    }
+    if yaml is not None:
+        with path.open("w", encoding="utf-8") as fh:
+            yaml.safe_dump(info, fh)
+    else:  # pragma: no cover - fallback
+        with path.open("w", encoding="utf-8") as fh:
+            for key, value in info.items():
+                fh.write(f"{key}: {value}\n")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Process custom plume video")
+    parser.add_argument("input_video", help="Input AVI video")
+    parser.add_argument("output_dir", help="Directory for output files")
+    parser.add_argument("px_per_mm", type=float, help="Pixels per millimetre")
+    parser.add_argument("frame_rate", type=float, help="Frame rate of video")
+    ns = parser.parse_args(argv)
+
+    in_path = Path(ns.input_video)
+    out_dir = Path(ns.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base = in_path.stem
+
+    raw_h5 = out_dir / f"{base}_raw.h5"
+    scaled_h5 = out_dir / f"{base}_scaled.h5"
+    rotated_h5 = out_dir / f"{base}_rotated.h5"
+
+    video_to_scaled_rotated_h5(in_path, raw_h5, scaled_h5, rotated_h5)
+
+    meta = out_dir / f"{base}_meta.yaml"
+    _write_meta(meta, out_dir, rotated_h5.name, ns.px_per_mm, ns.frame_rate)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_process_custom_plume.py
+++ b/tests/test_process_custom_plume.py
@@ -1,0 +1,65 @@
+import pytest
+from pathlib import Path
+
+np = pytest.importorskip("numpy")
+imageio = pytest.importorskip("imageio.v3")
+h5py = pytest.importorskip("h5py")
+
+from scripts import process_custom_plume
+
+
+def _simple_yaml(path: Path) -> dict:
+    data: dict[str, dict[str, float]] = {}
+    current = None
+    with path.open("r") as f:
+        for raw in f:
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if not raw.startswith("  "):
+                current = stripped.rstrip(":")
+                data[current] = {}
+            else:
+                k, v = stripped.split(":", 1)
+                if current is not None:
+                    data[current][k.strip()] = float(v)
+    return data
+
+
+def test_process_custom_plume(tmp_path):
+    frames = np.stack(
+        [
+            np.arange(6, dtype=np.uint8).reshape(2, 3),
+            np.arange(6, 12, dtype=np.uint8).reshape(2, 3),
+        ]
+    )
+    avi = tmp_path / "input.avi"
+    imageio.imwrite(avi, frames, plugin="pyav", fps=1)
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    process_custom_plume.main([str(avi), str(out_dir), "2", "1"])
+
+    raw_h5 = out_dir / "input_raw.h5"
+    scaled_h5 = out_dir / "input_scaled.h5"
+    rotated_h5 = out_dir / "input_rotated.h5"
+    meta = out_dir / "input_meta.yaml"
+
+    assert raw_h5.is_file()
+    assert scaled_h5.is_file()
+    assert rotated_h5.is_file()
+    assert meta.is_file()
+
+    meta_data = _simple_yaml(meta)
+    assert meta_data["output_directory"] == str(out_dir)
+    assert meta_data["output_filename"] == rotated_h5.name
+    assert meta_data["vid_mm_per_px"] == 0.5
+    assert meta_data["fps"] == 1
+    assert meta_data["scaled_to_crim"]
+
+    reg_path = Path("configs") / "plume_registry.yaml"
+    registry = _simple_yaml(reg_path)
+    assert raw_h5.name in registry
+    assert scaled_h5.name in registry
+    assert rotated_h5.name in registry


### PR DESCRIPTION
## Summary
- add failing test for `process_custom_plume`
- implement `scripts/process_custom_plume.py`

## Testing
- `pre-commit run --files tests/test_process_custom_plume.py` *(fails: command not found)*
- `pytest tests/test_process_custom_plume.py` *(fails: ModuleNotFoundError: No module named 'numpy')*