### PR TITLE
Update video looping behavior

### DIFF
--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -23,8 +23,8 @@ function out = run_navigation_cfg(cfg)
 %       (b) plume_metadata – YAML file understood by load_custom_plume
 %
 %   Extra helpers:
-%   • loop:true without triallength → movie will repeat automatically.
-%   • triallength overrides the natural movie length.
+%   • triallength overrides the natural movie length (movie loops automatically
+%     when extended).
 %
 %   Note  The streaming backend is only stubbed in this commit; set
 %         cfg.use_streaming = false (or omit the key) until you replace the
@@ -40,9 +40,8 @@ end
 
 % guard-rail warning for truncated trials
 if isfield(cfg,'environment') && strcmpi(cfg.environment,'video') && ...
-        ~isfield(cfg,'triallength') && ~isfield(cfg,'loop')
-    warning(['Trial will end exactly at movie length. ' ...
-             'Add cfg.loop=true or cfg.triallength to change this.']);
+        ~isfield(cfg,'triallength')
+    warning('Trial will end exactly at movie length. Set cfg.triallength to change this.');
 end
 
 % -------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -124,15 +124,13 @@ Example snippet from `configs/my_complex_plume_config.yaml`:
 px_per_mm: 6.536
 # Frame rate of the video in Hz
 frame_rate: 60
-# Automatically repeat the movie when triallength exceeds its length
-# loop: true
 # Override the movie length with a specific number of frames
 # triallength: 7200
 ```
 
-The optional `loop` flag repeats the movie when `triallength` is longer than the
-source video. Setting `triallength` lets you cut or extend each trial to an
-explicit number of frames.
+When `triallength` exceeds the movie length, the video automatically loops.
+Setting `triallength` lets you cut or extend each trial to an explicit number of
+frames.
 
 
 ## Running Tests

--- a/configs/examples/smoke_plume.yaml
+++ b/configs/examples/smoke_plume.yaml
@@ -18,8 +18,5 @@ plotting: 0
 # Number of trials to run
 ntrials: 1
 
-# Loop the video so it repeats when the end is reached
-loop: true
-
 # Duration of each trial in frames (2 min × 60 fps)
 triallength: 7200

--- a/configs/my_complex_plume_config.yaml
+++ b/configs/my_complex_plume_config.yaml
@@ -12,8 +12,6 @@ plotting: 0
 ntrials: 10
 # Wind speed in arbitrary units
 ws: 1
-# Automatically repeat the movie when triallength exceeds its length
-# loop: true
 
 # Override the movie length with a specific number of frames
 # triallength: 7200

--- a/configs/my_complex_plume_loop2min.yaml
+++ b/configs/my_complex_plume_loop2min.yaml
@@ -24,6 +24,5 @@ plotting: 0
 ntrials: 1
 
 
-# test looping – 2 min × 60 fps
-loop: true
+# Extended trial – 2 min × 60 fps
 triallength: 7200

--- a/tests/test_video_triallength_warning.m
+++ b/tests/test_video_triallength_warning.m
@@ -29,5 +29,5 @@ function testWarningEmitted(testCase)
     run_navigation_cfg(cfg);
     [msg,~] = lastwarn;
     verifyEqual(testCase, msg, ...
-        'Trial truncated to movie length; set cfg.loop=true to repeat.');
+        'Trial will end exactly at movie length. Set cfg.triallength to change this.');
 end


### PR DESCRIPTION
## Summary
- remove references to `loop` flag in configs and docs
- warning now points users to `triallength`
- update test to match new warning text

## Testing
- `pytest -q` *(fails: 18 errors during collection)*