### PR TITLE
Add custom plume and sensing list support

### DIFF
--- a/Code/load_experiment_config.m
+++ b/Code/load_experiment_config.m
@@ -21,6 +21,7 @@ if ~exist(config_file, 'file')
     error('Configuration file not found: %s', config_file);
 end
 
+
 % Load YAML configuration
 try
     yaml_cfg = load_yaml(config_file);
@@ -31,6 +32,19 @@ end
 % Convert YAML structure to MATLAB struct
 cfg = struct(yaml_cfg);
 
+% Ensure experiment struct exists before mapping fields
+if ~isfield(cfg, 'experiment') || ~isstruct(cfg.experiment)
+    cfg.experiment = struct();
+end
+
+% Map legacy plume and sensing fields onto experiment settings
+if isfield(cfg, 'plumes')
+    cfg.experiment.plume_types = cfg.plumes;
+end
+if isfield(cfg, 'sensing_modes')
+    cfg.experiment.sensing_modes = cfg.sensing_modes;
+end
+
 % Apply any overrides from varargin
 for i = 1:2:length(varargin)
     field = varargin{i};
@@ -39,11 +53,6 @@ for i = 1:2:length(varargin)
     else
         warning('Unknown configuration field: %s', field);
     end
-end
-
-% Set default values for required fields
-if ~isfield(cfg, 'experiment') || ~isstruct(cfg.experiment)
-    cfg.experiment = struct();
 end
 
 % Set default experiment values

--- a/tests/test_batch_job_custom_lists.m
+++ b/tests/test_batch_job_custom_lists.m
@@ -1,0 +1,23 @@
+function tests = test_batch_job_custom_lists
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd, 'Code'));
+end
+
+function testPlumeAndSensingOverride(testCase)
+    tmp = [tempname '.yaml'];
+    fid = fopen(tmp, 'w');
+    fprintf(fid, 'plumes:\n  - foo\n  - bar\n');
+    fprintf(fid, 'sensing_modes:\n  - sniff\n');
+    fclose(fid);
+    cleanup = onCleanup(@() delete(tmp));
+
+    cfg = load_experiment_config(tmp);
+
+    verifyEqual(testCase, cfg.experiment.plume_types, {'foo', 'bar'});
+    verifyEqual(testCase, cfg.experiment.sensing_modes, {'sniff'});
+    verifyEqual(testCase, cfg.experiment.num_plumes, 2);
+    verifyEqual(testCase, cfg.experiment.num_sensing, 1);
+end


### PR DESCRIPTION
## Summary
- allow overriding plume and sensing defaults in `load_experiment_config`
- cover overriding behaviour with new MATLAB test

## Testing
- `./setup_env.sh --dev` *(fails: wget could not download Miniconda)*
- `make test` *(fails: dev_env/bin/python not found)*