### PR TITLE
Implement agent error logging and batch summary

### DIFF
--- a/Code/run_agent_simulation.m
+++ b/Code/run_agent_simulation.m
@@ -74,10 +74,16 @@ try
     
     % Clear large variables to save memory
     clear result sim_cfg;
-    
+
 catch ME
-    error('Error in simulation (agent %d, seed %d): %s', ...
-          agent_id, seed, getReport(ME));
+    log_file = fullfile(output_dir, 'error.log');
+    fid = fopen(log_file, 'w');
+    if fid ~= -1
+        fprintf(fid, '%s', getReport(ME, 'extended', 'hyperlinks', 'off'));
+        fclose(fid);
+    end
+    fprintf('Error in simulation (agent %d): %s\n', agent_id, ME.message);
+    return;
 end
 
 % Add a small pause to prevent file system overload

--- a/Code/run_batch_job.m
+++ b/Code/run_batch_job.m
@@ -61,5 +61,26 @@ else
     end
 end
 
+% Collect error logs
+error_logs = {};
+for agent_id = start_agent:end_agent
+    plume_idx = mod((job_id - 1) ./ cfg.experiment.jobs_per_condition, cfg.experiment.num_plumes) + 1;
+    sensing_idx = mod(floor((job_id - 1) ./ cfg.experiment.jobs_per_condition ./ cfg.experiment.num_plumes), cfg.experiment.num_sensing) + 1;
+    plume_name = cfg.experiment.plume_types{plume_idx};
+    sensing_name = cfg.experiment.sensing_modes{sensing_idx};
+    seed = sum(double(plume_name)) + sum(double(sensing_name)) + agent_id;
+    agent_dir = cfg.get_output_dir(plume_name, sensing_name, agent_id, seed);
+    log_file = fullfile(agent_dir, 'error.log');
+    if exist(log_file, 'file')
+        error_logs{end+1} = log_file; %#ok<AGROW>
+    end
+end
+
 fprintf('Batch job %d completed (agents %d-%d)\n', job_id, start_agent, end_agent);
+if ~isempty(error_logs)
+    fprintf('Errors occurred for %d agents:\n', numel(error_logs));
+    fprintf('  %s\n', error_logs{:});
+else
+    fprintf('No errors detected for this batch.\n');
+end
 end

--- a/tests/test_run_batch_job_error_logging.m
+++ b/tests/test_run_batch_job_error_logging.m
@@ -1,0 +1,60 @@
+function tests = test_run_batch_job_error_logging
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd, 'Code'));
+    stubDir = tempname;
+    mkdir(stubDir);
+
+    %% load_experiment_config stub
+    fid = fopen(fullfile(stubDir, 'load_experiment_config.m'), 'w');
+    fprintf(fid, ['function cfg = load_experiment_config(~)\n', ...
+        'cfg.experiment.plume_types = {''p1''};\n', ...
+        'cfg.experiment.sensing_modes = {''s1''};\n', ...
+        'cfg.experiment.jobs_per_condition = 1;\n', ...
+        'cfg.experiment.num_plumes = 1;\n', ...
+        'cfg.experiment.num_sensing = 1;\n', ...
+        'cfg.experiment.output_base = ''%s'';\n', ...
+        'cfg.get_output_dir = @(~,~,a,~) fullfile(''%s'', sprintf(''agent%d'', a));\n', ...
+        'cfg.plume_config = fullfile(''tests'', ''sample_config.yaml'');\n', ...
+        'end'], stubDir, stubDir);
+    fclose(fid);
+
+    %% load_config stub
+    fid = fopen(fullfile(stubDir, 'load_config.m'), 'w');
+    fprintf(fid, ['function cfg = load_config(~)\n', ...
+        'cfg.bilateral = false;\n', ...
+        'end']);
+    fclose(fid);
+
+    %% run_navigation_cfg stub
+    fid = fopen(fullfile(stubDir, 'run_navigation_cfg.m'), 'w');
+    fprintf(fid, ['function out = run_navigation_cfg(cfg)\n', ...
+        'if contains(cfg.outputDir, ''agent1'')\n', ...
+        '    error(''SimFail:Test'', ''intentional error'');\n', ...
+        'end\n', ...
+        'out.result = true;\n', ...
+        'end']);
+    fclose(fid);
+
+    addpath(stubDir);
+    testCase.TestData.stubDir = stubDir;
+    cfgPath = fullfile(stubDir, 'dummy.yaml');
+    fid = fopen(cfgPath, 'w'); fclose(fid);
+    testCase.TestData.cfgPath = cfgPath;
+end
+
+function teardownOnce(testCase)
+    rmpath(testCase.TestData.stubDir);
+    rmdir(testCase.TestData.stubDir, 's');
+end
+
+function testLogsCreatedAndBatchContinues(testCase)
+    out = evalc('run_batch_job(testCase.TestData.cfgPath, 1, 1, 2, false)');
+    errFile = fullfile(testCase.TestData.stubDir, 'agent1', 'error.log');
+    resultFile = fullfile(testCase.TestData.stubDir, 'agent2', 'result.mat');
+    verifyTrue(testCase, isfile(errFile), 'Error log should be created');
+    verifyTrue(testCase, isfile(resultFile), 'Second agent should finish');
+    verifyNotEmpty(testCase, regexp(out, 'Error', 'once'), 'Batch summary missing');
+end


### PR DESCRIPTION
## Summary
- add a failing test for batch job error logging
- log errors to `error.log` in `run_agent_simulation`
- aggregate error logs and show a summary from `run_batch_job`

## Testing
- `./setup_env.sh --dev` *(fails: wget unable to fetch Miniconda)*
- `pytest tests/test_run_batch_job_error_logging.m -q` *(fails: test file not collected due to missing plugin and dependencies)*