### PR TITLE
Add PLUME_METADATA forwarding to batch wrappers

### DIFF
--- a/run_full_batch.sh
+++ b/run_full_batch.sh
@@ -30,6 +30,12 @@ export OUTPUT_BASE
 export SLURM_MEM="$MEM_PER_TASK"
 export SLURM_TIME="$TIME_LIMIT"
 export SLURM_ARRAY_CONCURRENT="$MAX_CONCURRENT"
+if [[ -n "${PLUME_METADATA:-}" ]]; then
+    export PLUME_METADATA
+    echo "Using plume metadata: $PLUME_METADATA"
+else
+    echo "Using plume movie   : $PLUME_VIDEO"
+fi
 
 echo "Submitting $TOTAL_JOBS array tasks (4 conditions × $AGENTS_PER_CONDITION agents)…"
 

--- a/run_test_batch.sh
+++ b/run_test_batch.sh
@@ -16,12 +16,20 @@ PLUME_VIDEO="$(pwd)/data/smoke_1a_orig_backgroundsubtracted.avi"
 
 TEST_OUTPUT="test_output/$TEST_NAME"; mkdir -p "$TEST_OUTPUT"
 
+if [[ -n "${PLUME_METADATA:-}" ]]; then
+    DESC="Metadata"
+    PLUME_PATH="$PLUME_METADATA"
+else
+    DESC="Movie"
+    PLUME_PATH="$PLUME_VIDEO"
+fi
+
 echo "🚀 Starting test batch: $TEST_NAME"
 cat <<EOF
 
 Jobs               : $TEST_JOBS
 Agents/condition   : $TEST_AGENTS
-Movie              : $PLUME_VIDEO
+$DESC              : $PLUME_PATH
 Output             : $TEST_OUTPUT
 EOF
 
@@ -34,6 +42,7 @@ AGENTS_PER_JOB=$TEST_AGENTS_PER_JOB,\
 OUTPUT_BASE=$TEST_OUTPUT,\
 PLUME_CONFIG=$PLUME_CONFIG,\
 PLUME_VIDEO=$PLUME_VIDEO,\
+PLUME_METADATA=$PLUME_METADATA,\
 SLURM_PARTITION=$TEST_PARTITION,\
 SLURM_TIME=$TEST_TIME,\
 SLURM_MEM=$TEST_MEM,\

--- a/tests/test_run_full_batch_forward_metadata.py
+++ b/tests/test_run_full_batch_forward_metadata.py
@@ -1,0 +1,10 @@
+def test_run_full_batch_exports_plume_metadata():
+    with open("run_full_batch.sh") as f:
+        content = f.read()
+    assert "export PLUME_METADATA" in content
+
+
+def test_run_full_batch_echoes_plume_file():
+    with open("run_full_batch.sh") as f:
+        content = f.read()
+    assert ("Using plume metadata" in content) or ("Using plume movie" in content)

--- a/tests/test_run_test_batch_forward_metadata.py
+++ b/tests/test_run_test_batch_forward_metadata.py
@@ -1,0 +1,10 @@
+def test_run_test_batch_exports_plume_metadata():
+    with open("run_test_batch.sh") as f:
+        content = f.read()
+    assert "PLUME_METADATA=$PLUME_METADATA" in content
+
+
+def test_run_test_batch_help_echoes_plume_file():
+    with open("run_test_batch.sh") as f:
+        content = f.read()
+    assert "$DESC              : $PLUME_PATH" in content


### PR DESCRIPTION
## Summary
- forward `PLUME_METADATA` env var from `run_full_batch.sh`
- forward `PLUME_METADATA` env var from `run_test_batch.sh`
- show selected plume file in help text
- test that wrappers handle plume metadata

## Testing
- `pytest tests/test_run_full_batch_forward_metadata.py tests/test_run_test_batch_forward_metadata.py tests/test_wrappers_endline.py tests/test_run_test_batch_envsubst.py tests/test_run_batch_job_4000_plume_metadata.py -q`