### PR TITLE
Fix duplicate fields in YAML config

### DIFF
--- a/configs/my_complex_plume_loop2min.yaml
+++ b/configs/my_complex_plume_loop2min.yaml
@@ -11,18 +11,5 @@ plotting: 0
 # Number of trials to run
 ntrials: 1
 
-# Type of environment used for simulation
-environment: video
-# Path to the plume video file
-plume_video: data/smoke_1a_orig_backgroundsubtracted.avi
-# Pixels per millimeter conversion factor
-px_per_mm: 6.536
-# Frame rate (Hz)
-frame_rate: 60
-
-plotting: 0
-ntrials: 1
-
-
 # Extended trial – 2 min × 60 fps
 triallength: 7200


### PR DESCRIPTION
## Summary
- remove repeated field definitions in `my_complex_plume_loop2min.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*