### PR TITLE
Add docs for run_test_batch.sh usage with PLUME_METADATA

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,5 +225,10 @@ export PLUME_METADATA=out_dir/input_meta.yaml
 sbatch run_batch_job_4000.sh # or run_full_batch.sh
 ```
 
+For a quick smoke test use `run_test_batch.sh` instead:
+```bash
+bash run_test_batch.sh
+```
+
 See [docs/run_batch_job_4000.md](docs/run_batch_job_4000.md) for further options.
 

--- a/docs/run_batch_job_4000.md
+++ b/docs/run_batch_job_4000.md
@@ -72,6 +72,13 @@ The array size should equal the total number of jobs computed from `AGENTS_PER_C
 
 Use `run_full_batch.sh` for the standard four‑condition production run or `run_test_batch.sh` for a quick smoke test. Both wrappers export the necessary variables before calling `run_batch_job_4000.sh`.
 
+When `PLUME_METADATA` is exported as shown above, `run_test_batch.sh` submits a short array job for debugging:
+
+```bash
+export PLUME_METADATA=configs/my_plume_meta.yaml
+bash run_test_batch.sh
+```
+
 ## Output
 
 Results are written under `${OUTPUT_BASE}/${EXPERIMENT_NAME}/<plume>_<mode>/<agent>_<seed>` as MATLAB `.mat` files. After MATLAB completes, the script converts each result into CSV and JSON using `export_results`. Processed data are placed under `data/processed` with the same folder hierarchy.


### PR DESCRIPTION
## Summary
- document smoke test wrapper in README
- document metadata usage in run_batch_job_4000 docs

## Testing
- `./setup_env.sh --dev` *(fails: wget could not retrieve miniconda installer)*
- `pytest -k "run_test_batch"` *(fails: module import errors during collection)*