### PR TITLE
Add video handling to bilateral navigation model

### DIFF
--- a/tests/test_run_navigation_cfg.m
+++ b/tests/test_run_navigation_cfg.m
@@ -42,3 +42,19 @@ function testBilateralConfig(~)
     end
 
 end
+
+function testVideoBilateral(~)
+    cfg.environment = 'video';
+    cfg.plume_video = 'video.avi';
+    cfg.px_per_mm = 10;
+    cfg.frame_rate = 50;
+    cfg.plotting = 0;
+    cfg.ntrials = 1;
+    cfg.bilateral = true;
+    try
+        run_navigation_cfg(cfg);
+        assert(true);
+    catch
+        assert(false, 'run_navigation_cfg failed on video bilateral config');
+    end
+end


### PR DESCRIPTION
## Summary
- extend `Elifenavmodel_bilateral` to accept video plumes via `varargin`
- parse new inputs when environment is `video`
- scale parameters by plume frame rate
- support video environment in main loop and time calculations
- test video bilateral config in `run_navigation_cfg`

## Testing
- `pre-commit run --files Code/Elifenavmodel_bilateral.m tests/test_run_navigation_cfg.m` *(fails: command not found)*
- `make test` *(fails: missing dev_env Python)*