### PR TITLE
Add bilateral video plume sampling

### DIFF
--- a/Code/Elifenavmodel_bilateral.m
+++ b/Code/Elifenavmodel_bilateral.m
@@ -284,24 +284,50 @@ for i = 1:triallength
 
         case {'video'}
             tind = mod(i-1, size(plume.data,3)) + 1;
+
             xind = round(10*x(i,:)*plume.px_per_mm)+1;
             yind = round(-10*y(i,:)*plume.px_per_mm)+1;
             out_of_plume = union(union(find(xind<1),find(xind>size(plume.data,2))), ...
                                  union(find(yind<1),find(yind>size(plume.data,1))));
             within = setdiff(1:ntrials,out_of_plume);
             odor(i,out_of_plume) = 0;
-            odorL(i,out_of_plume) = 0;
-            odorR(i,out_of_plume) = 0;
             for it = within
                 odor(i,it) = plume.data(yind(it), xind(it), tind);
-                odorL(i,it) = odor(i,it);
-                odorR(i,it) = odor(i,it);
             end
+
+            xLind = round(10*xL(i,:)*plume.px_per_mm)+1;
+            yLind = round(-10*yL(i,:)*plume.px_per_mm)+1;
+            out_of_plumeL = union(union(find(xLind<1),find(xLind>size(plume.data,2))), ...
+                                   union(find(yLind<1),find(yLind>size(plume.data,1))));
+            withinL = setdiff(1:ntrials,out_of_plumeL);
+            odorL(i,out_of_plumeL) = 0;
+            for it = withinL
+                odorL(i,it) = plume.data(yLind(it), xLind(it), tind);
+            end
+
+            xRind = round(10*xR(i,:)*plume.px_per_mm)+1;
+            yRind = round(-10*yR(i,:)*plume.px_per_mm)+1;
+            out_of_plumeR = union(union(find(xRind<1),find(xRind>size(plume.data,2))), ...
+                                   union(find(yRind<1),find(yRind>size(plume.data,1))));
+            withinR = setdiff(1:ntrials,out_of_plumeR);
+            odorR(i,out_of_plumeR) = 0;
+            for it = withinR
+                odorR(i,it) = plume.data(yRind(it), xRind(it), tind);
+            end
+
             if exist('params','var') && isfield(params,'ws')
                 ws = params.ws;
             else
                 ws = 0;
             end
+    end
+
+    if strcmp(environment,'video') && tind == 1 && i > 1
+        Aon(i,:) = 0;
+        Aoff(i,:) = 0;
+        ON(i,:) = 0;
+        R(i,:) = 0;
+        Rh(i,:) = 0;
     end
 
     % Adaptation

--- a/tests/test_bilateral_video_adaptation_reset.m
+++ b/tests/test_bilateral_video_adaptation_reset.m
@@ -1,0 +1,19 @@
+function tests = test_bilateral_video_adaptation_reset
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testReset(~)
+    plume.data = zeros(1,1,2);
+    plume.data(1,1,1) = 1;
+    plume.px_per_mm = 1;
+    plume.frame_rate = 1;
+    params.kbil = 0;
+    out = Elifenavmodel_bilateral(4,'video',0,1,plume,params);
+    on1 = out.ON(2);
+    on2 = out.ON(4);
+    assert(abs(on1 - on2) < 1e-3, 'ON response should reset when video loops');
+end

--- a/tests/test_bilateral_video_dt_scaling.m
+++ b/tests/test_bilateral_video_dt_scaling.m
@@ -1,0 +1,34 @@
+function tests = test_bilateral_video_dt_scaling
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testDtScaling(~)
+    plume.data = ones(1,1,1);
+    plume.px_per_mm = 1;
+    params.turnbase = 0;
+    params.tsigma = 0;
+    params.kup = 0;
+    params.kdown = 0;
+    params.tmodON = 0;
+    params.tmodOFF = 0;
+    params.vmodON = 0;
+    params.vmodOFF = 0;
+    params.vbase = 10;
+    params.kbil = 0;
+
+    plume.frame_rate = 5;
+    rng(0);
+    out1 = Elifenavmodel_bilateral(plume.frame_rate,'video',0,1,plume,params);
+    dist1 = norm([out1.x(end) out1.y(end)]);
+
+    plume.frame_rate = 10;
+    rng(0);
+    out2 = Elifenavmodel_bilateral(plume.frame_rate,'video',0,1,plume,params);
+    dist2 = norm([out2.x(end) out2.y(end)]);
+
+    assert(abs(dist1 - dist2) < 1e-12, 'displacement per second should be identical');
+end

--- a/tests/test_bilateral_video_sampling.m
+++ b/tests/test_bilateral_video_sampling.m
@@ -1,0 +1,56 @@
+function tests = test_bilateral_video_sampling
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testSampling(~)
+    plume.data = zeros(1,3,1);
+    plume.data(1,1,1) = 2;
+    plume.data(1,2,1) = 1;
+    plume.data(1,3,1) = 3;
+    plume.px_per_mm = 1;
+    plume.frame_rate = 1;
+    params.turnbase = 0;
+    params.tsigma = 0;
+    params.kup = 0;
+    params.kdown = 0;
+    params.tmodON = 0;
+    params.tmodOFF = 0;
+    params.vmodON = 0;
+    params.vmodOFF = 0;
+    params.vbase = 0;
+    params.kbil = 0;
+    params.L = 0.1;
+
+    rng(0);
+    out = Elifenavmodel_bilateral(1,'video',0,1,plume,params);
+    heading0 = out.theta(1) + 90;
+    lx = params.L * cosd(heading0);
+    ly = params.L * sind(heading0);
+    rx = params.L * cosd(heading0 - 180);
+    ry = params.L * sind(heading0 - 180);
+    xind = round(10*0*plume.px_per_mm)+1;
+    yind = round(-10*0*plume.px_per_mm)+1;
+    xLind = round(10*lx*plume.px_per_mm)+1;
+    yLind = round(-10*ly*plume.px_per_mm)+1;
+    xRind = round(10*rx*plume.px_per_mm)+1;
+    yRind = round(-10*ry*plume.px_per_mm)+1;
+    expOdor = 0;
+    if xind >=1 && xind <= size(plume.data,2) && yind >=1 && yind <= size(plume.data,1)
+        expOdor = plume.data(yind,xind,1);
+    end
+    expL = 0;
+    if xLind >=1 && xLind <= size(plume.data,2) && yLind >=1 && yLind <= size(plume.data,1)
+        expL = plume.data(yLind,xLind,1);
+    end
+    expR = 0;
+    if xRind >=1 && xRind <= size(plume.data,2) && yRind >=1 && yRind <= size(plume.data,1)
+        expR = plume.data(yRind,xRind,1);
+    end
+    assert(abs(out.odor(1) - expOdor) < 1e-12);
+    assert(abs(out.odorL(1) - expL) < 1e-12);
+    assert(abs(out.odorR(1) - expR) < 1e-12);
+end

--- a/tests/test_bilateral_video_ws_param.m
+++ b/tests/test_bilateral_video_ws_param.m
@@ -1,0 +1,31 @@
+function tests = test_bilateral_video_ws_param
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function testWsParam(~)
+    plume.data = zeros(1,1,1);
+    plume.px_per_mm = 1;
+    plume.frame_rate = 1;
+    params.turnbase = 0;
+    params.tsigma = 0;
+    params.kup = 0;
+    params.kdown = 1;
+    params.tmodON = 0;
+    params.tmodOFF = 0;
+    params.vmodON = 0;
+    params.vmodOFF = 0;
+    params.vbase = 0;
+    params.kbil = 0;
+    params.ws = 1;
+
+    rng(0);
+    out1 = Elifenavmodel_bilateral(2,'video',0,1,plume,params);
+    params = rmfield(params,'ws');
+    rng(0);
+    out2 = Elifenavmodel_bilateral(2,'video',0,1,plume,params);
+    assert(abs(out1.theta(end) - out2.theta(end)) > 1e-9, 'ws parameter should influence heading');
+end


### PR DESCRIPTION
## Summary
- support separate antenna odor sampling in `Elifenavmodel_bilateral`
- reset adaptation when looping video plumes
- scale video plume parameters using frame rate
- exercise bilateral video model via new tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*
- `make test` *(fails: dev_env/bin/python not found)*