### PR TITLE
Fix stray end closing plotting block

### DIFF
--- a/Code/Elifenavmodel_bilateral.m
+++ b/Code/Elifenavmodel_bilateral.m
@@ -520,7 +520,6 @@ if plotting>=2
                 t = (1:length(odor))/15;
         end
     end
-    end
 	color = 'k';
 
     subplot(5,1,1);


### PR DESCRIPTION
## Summary
- remove extra `end` in `Elifenavmodel_bilateral.m`

## Testing
- `matlab -batch "addpath('Code'); results = runtests('tests/test_bilateral_*');"` *(fails: `matlab` not found)*