### PR TITLE
Block bilateral streaming in run_navigation_cfg

### DIFF
--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -88,6 +88,10 @@ elseif isfield(cfg,'plume_video')
     end
 
     if isfield(cfg,'use_streaming') && cfg.use_streaming
+        if isfield(cfg,'bilateral') && cfg.bilateral
+            error('run_navigation_cfg:BilateralStreamingUnsupported', ...
+                  'Bilateral model cannot be run in streaming mode');
+        end
         % ~~~ streaming mode (placeholder implementation) ~~~
         vr = VideoReader(cfg.plume_video);
         tl = chooseTrialLength(cfg, floor(vr.Duration * vr.FrameRate));

--- a/README.md
+++ b/README.md
@@ -237,3 +237,9 @@ bash run_test_batch.sh
 
 See [docs/run_batch_job_4000.md](docs/run_batch_job_4000.md) for further options.
 
+## Roadmap
+
+The project continues to evolve. Upcoming tasks include:
+
+- [ ] Add streaming support for the bilateral navigation model
+

--- a/tests/test_bilateral_streaming_error.m
+++ b/tests/test_bilateral_streaming_error.m
@@ -1,0 +1,33 @@
+function tests = test_bilateral_streaming_error
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    addpath(fullfile(pwd,'Code'));
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir,'stream.avi'));
+    open(vw);
+    writeVideo(vw,uint8(zeros(2,2,1)));
+    close(vw);
+    testCase.TestData.video = fullfile(tmpDir,'stream.avi');
+    testCase.TestData.tmpDir = tmpDir;
+end
+
+function teardownOnce(testCase)
+    if exist(testCase.TestData.tmpDir,'dir')
+        rmdir(testCase.TestData.tmpDir,'s');
+    end
+end
+
+function testErrorIdentifier(testCase)
+    cfg.plume_video = testCase.TestData.video;
+    cfg.px_per_mm = 1;
+    cfg.frame_rate = 1;
+    cfg.plotting = 0;
+    cfg.use_streaming = true;
+    cfg.ntrials = 1;
+    cfg.bilateral = true;
+    f = @() run_navigation_cfg(cfg);
+    verifyError(testCase,f,'run_navigation_cfg:BilateralStreamingUnsupported');
+end


### PR DESCRIPTION
## Summary
- raise error when streaming with bilateral nav model
- add MATLAB test covering the new error
- outline roadmap section to track tasks

## Testing
- `./setup_env.sh --dev` *(fails: conda download blocked)*
- `pre-commit run --files Code/run_navigation_cfg.m tests/test_bilateral_streaming_error.m README.md` *(fails: command not found)*
- `python -m pytest -k ""` *(fails: missing Python deps)*
