### PR TITLE
Fix default sensing mode

### DIFF
--- a/docs/run_batch_job_4000.md
+++ b/docs/run_batch_job_4000.md
@@ -21,7 +21,7 @@ The script accepts configuration via environment variables. Important ones inclu
 
 - `EXPERIMENT_NAME` – subdirectory under `data/raw` for results (`default_experiment` by default).
 - `PLUME_TYPES` – space‑separated list such as `"crimaldi custom"`.
-- `SENSING_MODES` – typically `"bilateral unilateral"`.
+- `SENSING_MODES` – defaults to `"unilateral"`; bilateral runs are temporarily paused.
 - `AGENTS_PER_CONDITION` – total agents to simulate for each plume/sensing pair.
 - `AGENTS_PER_JOB` – number of agents each array task runs.
 - `PLUME_CONFIG` – path to the YAML configuration file.

--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -28,7 +28,7 @@ echo "Starting job ${SLURM_ARRAY_TASK_ID:-0}" > "$JOB_LOG"
 ########################  defaults  ################################
 : ${EXPERIMENT_NAME:=default_experiment}
 : ${PLUME_TYPES:="crimaldi custom"}
-: ${SENSING_MODES:="bilateral unilateral"}
+: ${SENSING_MODES:="unilateral"}  # bilateral runs paused pending review
 : ${AGENTS_PER_CONDITION:=1000}
 : ${AGENTS_PER_JOB:=100}
 : ${PLUME_CONFIG:=configs/my_complex_plume_config.yaml}


### PR DESCRIPTION
## Summary
- default to unilateral sensing mode for batch jobs
- clarify docs about paused bilateral runs

## Testing
- `pre-commit run --files run_batch_job_4000.sh docs/run_batch_job_4000.md` *(fails: command not found)*