### PR TITLE
fix: clear cleanup handler in batch job script

### DIFF
--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -138,6 +138,7 @@ find "$RAW_DIR" -name result.mat | while read -r f; do
   out=${f/$RAW_DIR/data\/processed}; out=${out%/result.mat}
   mkdir -p "$out"; echo "try,export_results('$f','$out','Format','both');catch,end" >>"$EXPORT_SCRIPT"
 done
+echo "clear cleanupObj;" >>"$EXPORT_SCRIPT"
 echo "exit" >>"$EXPORT_SCRIPT"
 [[ -s "$EXPORT_SCRIPT" ]] && matlab -nodisplay -nosplash -r "run('$EXPORT_SCRIPT');" || true
 

--- a/tests/test_run_batch_job_4000_cleanup.py
+++ b/tests/test_run_batch_job_4000_cleanup.py
@@ -1,0 +1,11 @@
+import re
+
+def test_cleanup_cleared_before_exit():
+    with open('run_batch_job_4000.sh') as f:
+        content = f.read()
+    # find indexes of clear cleanupObj and exit lines
+    clear_match = re.search(r'echo\s+"clear cleanupObj;"\s*>>\"\$EXPORT_SCRIPT\"', content)
+    exit_match = re.search(r'echo\s+"exit"\s*>>\"\$EXPORT_SCRIPT\"', content)
+    assert clear_match is not None, 'clear cleanupObj line missing'
+    assert exit_match is not None, 'exit line missing'
+    assert clear_match.start() < exit_match.start(), 'clear cleanupObj must come before exit'


### PR DESCRIPTION
## Summary
- clear `cleanupObj` in export script for `run_batch_job_4000.sh`
- add regression test for cleanup command

## Testing
- `./setup_env.sh --dev` *(fails: wget https://repo.anaconda.com/miniconda/...)*
- `pytest tests/test_run_batch_job_4000_cleanup.py tests/test_run_batch_job_bytes_per_agent.py tests/test_run_batch_job_4000_experiment_name.py tests/test_run_batch_job_4000_plume_metadata.py tests/test_run_batch_job_progress_logging.py tests/test_wrappers_endline.py -q`