### PR TITLE
Fix MATLAB options quoting

### DIFF
--- a/tests/test_run_test_batch_matlab_options.py
+++ b/tests/test_run_test_batch_matlab_options.py
@@ -1,0 +1,6 @@
+with open("run_test_batch.sh") as f:
+    content = f.read()
+
+def test_matlab_options_unquoted():
+    assert 'MATLAB_OPTIONS="-nodisplay -nosplash"' not in content
+    assert 'MATLAB_OPTIONS=-nodisplay\\ -nosplash' in content


### PR DESCRIPTION
## Notes
- Add regression test verifying run_test_batch.sh exports MATLAB_OPTIONS without surrounding quotes

## Summary
- ensure MATLAB options are exported as `-nodisplay\ -nosplash`

## Testing
- `bash -n run_test_batch.sh`
- `pytest tests/test_run_test_batch_matlab_options.py -q`
