### PR TITLE
fix: clear cleanup handler in batch job script

### DIFF
--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -122,7 +122,8 @@ pause(0.05);
 MAT
   PROGRESS=$(( AG * 100 / AGENTS_PER_CONDITION ))
   echo "Progress: ${PROGRESS}%" >> "$JOB_LOG"
-done
+  done
+echo "clear cleanupObj;" >>"$MATLAB_SCRIPT"
 echo "exit" >>"$MATLAB_SCRIPT"
 
 ########################  run MATLAB  ##############################

--- a/tests/test_run_batch_job_4000_main_cleanup.py
+++ b/tests/test_run_batch_job_4000_main_cleanup.py
@@ -1,0 +1,10 @@
+import re
+
+def test_main_cleanup_cleared_before_exit():
+    with open('run_batch_job_4000.sh') as f:
+        content = f.read()
+    clear_match = re.search(r'echo\s+"clear cleanupObj;"\s*>>\"\$MATLAB_SCRIPT\"', content)
+    exit_match = re.search(r'echo\s+"exit"\s*>>\"\$MATLAB_SCRIPT\"', content)
+    assert clear_match is not None, 'clear cleanupObj line missing before exit in main script'
+    assert exit_match is not None, 'exit line missing in main script'
+    assert clear_match.start() < exit_match.start(), 'clear cleanupObj must precede exit'

--- a/tests/test_wrappers_endline.py
+++ b/tests/test_wrappers_endline.py
@@ -3,7 +3,7 @@ import unittest
 
 class TestWrapperEndsWithNewline(unittest.TestCase):
     def test_wrapper_ends_with_newline(self):
-        for fname in ["run_full_batch.sh", "run_test_batch.sh"]:
+        for fname in ["run_full_batch.sh", "run_test_batch.sh", "run_batch_job_4000.sh"]:
             with open(fname, "rb") as f:
                 content = f.read()
             self.assertTrue(


### PR DESCRIPTION
## Summary
- ensure batch cleanup object is cleared before exit
- verify newline for run_batch_job_4000.sh
- add regression tests

## Testing
- `pytest tests/test_run_batch_job_4000_main_cleanup.py tests/test_run_batch_job_4000_cleanup.py tests/test_wrappers_endline.py -q`