### PR TITLE
Fix batch export search path

### DIFF
--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -20,7 +20,7 @@ trap cleanup EXIT SIGINT SIGTERM
 
 ########################  directories  #############################
 for d in slurm_out slurm_err data/processed; do mkdir -p "$d"; done
-RAW_DIR="data/raw"; mkdir -p "$RAW_DIR"
+RAW_DIR="$OUTPUT_BASE"; mkdir -p "$RAW_DIR"
 mkdir -p logs
 JOB_LOG="logs/${SLURM_ARRAY_TASK_ID:-0}.log"
 echo "Starting job ${SLURM_ARRAY_TASK_ID:-0}" > "$JOB_LOG"
@@ -134,8 +134,8 @@ matlab $MATLAB_OPTIONS -r "run('$MATLAB_SCRIPT');" || { echo "MATLAB failed"; ex
 
 # MATLAB-based export (kept as is since it's MATLAB-specific)
 EXPORT_SCRIPT=$(mktemp -p "$TMPDIR" export_job_XXXX.m)
-find "$RAW_DIR" -name result.mat | while read -r f; do
-  out=${f/$RAW_DIR/data\/processed}; out=${out%/result.mat}
+find "$OUTPUT_BASE" -name result.mat | while read -r f; do
+  out=${f/$OUTPUT_BASE/data\/processed}; out=${out%/result.mat}
   mkdir -p "$out"; echo "try,export_results('$f','$out','Format','both');catch,end" >>"$EXPORT_SCRIPT"
 done
 echo "clear cleanupObj;" >>"$EXPORT_SCRIPT"

--- a/tests/test_run_batch_job_output_base_export.py
+++ b/tests/test_run_batch_job_output_base_export.py
@@ -1,0 +1,7 @@
+import re
+
+def test_find_uses_output_base():
+    with open('run_batch_job_4000.sh') as f:
+        content = f.read()
+    assert re.search(r'find \"\$OUTPUT_BASE\" -name result.mat', content), (
+        'run_batch_job_4000.sh should search OUTPUT_BASE for result.mat')


### PR DESCRIPTION
## Summary
- sync RAW_DIR with OUTPUT_BASE in run_batch_job_4000.sh
- look for results under OUTPUT_BASE before export
- test that export search uses OUTPUT_BASE

## Testing
- `pytest tests/test_run_batch_job_output_base_export.py -q`
- `pytest -k run_batch_job_output_base_export -q` *(fails: ModuleNotFoundError: No module named 'loguru')*