### PR TITLE
refactor: drop unused RAW_DIR variable

### DIFF
--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -20,7 +20,7 @@ trap cleanup EXIT SIGINT SIGTERM
 
 ########################  directories  #############################
 for d in slurm_out slurm_err data/processed; do mkdir -p "$d"; done
-RAW_DIR="$OUTPUT_BASE"; mkdir -p "$RAW_DIR"
+mkdir -p "$OUTPUT_BASE"
 mkdir -p logs
 JOB_LOG="logs/${SLURM_ARRAY_TASK_ID:-0}.log"
 echo "Starting job ${SLURM_ARRAY_TASK_ID:-0}" > "$JOB_LOG"


### PR DESCRIPTION
## Summary
- drop unused `RAW_DIR` variable and create `OUTPUT_BASE` directory directly

## Testing
- `pytest tests/test_run_batch_job_4000_cleanup.py tests/test_run_batch_job_4000_experiment_name.py tests/test_run_batch_job_4000_main_cleanup.py tests/test_run_batch_job_4000_plume_metadata.py tests/test_run_batch_job_output_base_export.py -q`