### PR TITLE
Add output path logging to batch job

### DIFF
--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -114,6 +114,7 @@ cat >>"$MATLAB_SCRIPT"<<MAT
   cfg.randomSeed  = $SEED;
   cfg.ntrials=1; cfg.plotting=0;
   cfg.outputDir   = '$OUT_DIR';
+  fprintf('Saving results to %s\n', cfg.outputDir);
   mkdir(cfg.outputDir);
   R = run_navigation_cfg(cfg);
   save(fullfile(cfg.outputDir,'result.mat'),'R','-v7');

--- a/tests/test_run_batch_job_logs_output_dir.py
+++ b/tests/test_run_batch_job_logs_output_dir.py
@@ -1,0 +1,8 @@
+import os
+
+def test_logs_output_directory():
+    with open('run_batch_job_4000.sh') as f:
+        content = f.read()
+    assert "fprintf('Saving results to %s\\n', cfg.outputDir);" in content, (
+        'run_batch_job_4000.sh should log output directory in MATLAB script'
+    )


### PR DESCRIPTION
## Summary
- log `cfg.outputDir` inside the MATLAB script generated by `run_batch_job_4000.sh`
- add regression test for output directory logging

## Testing
- `bash -n run_batch_job_4000.sh`
- `pytest tests/test_run_batch_job_logs_output_dir.py -q`
