### PR TITLE
Fix auto streaming for bilateral mode

### DIFF
--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -84,7 +84,11 @@ elseif isfield(cfg,'plume_video')
 
     % Auto-enable streaming on SLURM clusters when not specified
     if ~isfield(cfg,'use_streaming') && isSlurmCluster()
-        cfg.use_streaming = true;
+        if isfield(cfg,'bilateral') && cfg.bilateral
+            cfg.use_streaming = false;
+        else
+            cfg.use_streaming = true;
+        end
     end
 
     if isfield(cfg,'use_streaming') && cfg.use_streaming

--- a/tests/test_auto_streaming_bilateral_disabled.m
+++ b/tests/test_auto_streaming_bilateral_disabled.m
@@ -1,0 +1,38 @@
+function tests = test_auto_streaming_bilateral_disabled
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(~)
+    addpath(fullfile(pwd,'Code'));
+end
+
+function teardownEach(~)
+    unsetenv('SLURM_JOB_ID');
+end
+
+function testNoStreamingError(~)
+    tmpDir = tempname;
+    mkdir(tmpDir);
+    vw = VideoWriter(fullfile(tmpDir,'dummy.avi'));
+    open(vw);
+    writeVideo(vw,uint8(zeros(2,2,1)));
+    close(vw);
+
+    setenv('SLURM_JOB_ID','123');
+    cfg.plume_video = fullfile(tmpDir,'dummy.avi');
+    cfg.px_per_mm = 1;
+    cfg.frame_rate = 1;
+    cfg.plotting = 0;
+    cfg.ntrials = 1;
+    cfg.bilateral = true;
+
+    try
+        run_navigation_cfg(cfg);
+        assert(true);
+    catch ME
+        assert(~strcmp(ME.identifier,'run_navigation_cfg:BilateralStreamingUnsupported'), ...
+            'BilateralStreamingUnsupported should not be thrown');
+    end
+
+    rmdir(tmpDir,'s');
+end


### PR DESCRIPTION
## Summary
- add regression test for SLURM auto streaming with bilateral disabled
- disable auto streaming when bilateral mode is active on SLURM

## Testing
- `./setup_env.sh --dev` *(fails: wget could not download Miniconda)*
- `make test-matlab` *(fails: No rule to make target `test-matlab`)*
- `make test` *(fails: missing dev_env Python)*