### PR TITLE
fix: surface MATLAB errors in batch wrapper

### DIFF
--- a/run_batch_job_4000.sh
+++ b/run_batch_job_4000.sh
@@ -118,7 +118,7 @@ cat >>"$MATLAB_SCRIPT"<<MAT
   mkdir(cfg.outputDir);
   R = run_navigation_cfg(cfg);
   save(fullfile(cfg.outputDir,'result.mat'),'R','-v7');
-catch ME, fprintf(2,'Seed %d: %s\\n',$AG,getReport(ME)); end
+ catch ME, fprintf(2,'ERROR: Seed %d: %s\\n',$AG,getReport(ME)); end
 pause(0.05);
 MAT
   PROGRESS=$(( AG * 100 / AGENTS_PER_CONDITION ))
@@ -129,6 +129,11 @@ echo "exit" >>"$MATLAB_SCRIPT"
 
 ########################  run MATLAB  ##############################
 matlab $MATLAB_OPTIONS -r "run('$MATLAB_SCRIPT');" || { echo "MATLAB failed"; exit 1; }
+
+if ! find "$OUTPUT_BASE" -name result.mat | grep -q .; then
+  echo "ERROR: no result.mat produced" >&2
+  exit 1
+fi
 
 ########################  export CSV/JSON  #########################
 # Use conda run -p for any Python commands

--- a/tests/test_run_batch_job_4000_error_exit.py
+++ b/tests/test_run_batch_job_4000_error_exit.py
@@ -1,0 +1,11 @@
+import subprocess
+import shutil
+from pathlib import Path
+
+BASH = shutil.which("bash") or "/bin/bash"
+
+def test_wrapper_exits_nonzero():
+    script = Path(__file__).with_suffix('.sh')
+    result = subprocess.run([BASH, str(script)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Wrapper exited with non-zero" in result.stdout

--- a/tests/test_run_batch_job_4000_error_exit.sh
+++ b/tests/test_run_batch_job_4000_error_exit.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+TMP=$(mktemp -d)
+cp run_batch_job_4000.sh "$TMP/"
+cd "$TMP"
+
+# create stub module command
+cat > module <<'EOS'
+#!/bin/sh
+if [ "$1" = "-t" ] && [ "$2" = "avail" ]; then
+  echo "MATLAB/2023b"
+elif [ "$1" = "load" ]; then
+  exit 0
+else
+  exit 0
+fi
+EOS
+chmod +x module
+
+# create matlab script that reports failure but exits 0
+cat > matlab <<'EOS'
+#!/bin/sh
+echo "Simulated MATLAB failure" >&2
+# no result file created and exit code 0
+exit 0
+EOS
+chmod +x matlab
+
+export PATH="$TMP:$PATH"
+export SLURM_SUBMIT_DIR="$TMP"
+export OUTPUT_BASE="$TMP/out"
+mkdir -p "$OUTPUT_BASE"
+export PLUME_CONFIG="$TMP/config.yaml"
+: > "$PLUME_CONFIG"
+export PLUME_VIDEO=""
+export PLUME_METADATA=""
+export AGENTS_PER_CONDITION=1
+export AGENTS_PER_JOB=1
+export PLUME_TYPES="p"
+export SENSING_MODES="s"
+export MATLAB_OPTIONS=""
+export BYTES_PER_AGENT=1
+
+if ./run_batch_job_4000.sh >run.log 2>&1; then
+  echo "Script succeeded unexpectedly"
+  exit 1
+else
+  echo "Wrapper exited with non-zero as expected"
+  exit 0
+fi


### PR DESCRIPTION
## Summary
- emit MATLAB errors with clear prefix in run_batch_job_4000.sh
- fail fast if MATLAB did not produce any result.mat files
- cover error exit via new shell-based test

## Testing
- `pytest tests/test_run_batch_job_4000_error_exit.py -q`
- `python3 -m pytest -k test_run_batch_job_4000_error_exit -q` *(fails: ModuleNotFoundError: No module named 'loguru')*