### PR TITLE
Add examples and deduplicate chooseTrialLength

### DIFF
--- a/Code/chooseTrialLength.m
+++ b/Code/chooseTrialLength.m
@@ -3,6 +3,10 @@ function tl = chooseTrialLength(cfg, defaultTL)
 %
 %   TL = CHOOSETRIALLENGTH(CFG, DEFAULTTL) returns CFG.triallength when
 %   it exists and is non-empty; otherwise returns DEFAULTTL.
+%
+%   Example:
+%       cfg.triallength = 150;
+%       tl = chooseTrialLength(cfg, 200);
 
 if isfield(cfg,'triallength') && ~isempty(cfg.triallength)
     tl = cfg.triallength;

--- a/Code/isSlurmCluster.m
+++ b/Code/isSlurmCluster.m
@@ -2,6 +2,11 @@ function tf = isSlurmCluster()
 %ISSLURMCLUSTER  Detect SLURM cluster environment.
 %   TF = ISSLURMCLUSTER() returns true if the SLURM_JOB_ID environment
 %   variable is set, indicating execution under a SLURM scheduler.
+%
+%   Example:
+%       if isSlurmCluster()
+%           disp('Running under SLURM');
+%       end
 
 tf = ~isempty(getenv('SLURM_JOB_ID'));
 end

--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -29,6 +29,10 @@ function out = run_navigation_cfg(cfg)
 %   Note  The streaming backend is only stubbed in this commit; set
 %         cfg.use_streaming = false (or omit the key) until you replace the
 %         placeholder at the bottom of this file.
+%
+%   Example:
+%       cfg = load_config(fullfile('tests','sample_config.yaml'));
+%       out = run_navigation_cfg(cfg);
 
 % -------------------------------------------------------------------------
 % 0. choose which model variant we will call
@@ -118,15 +122,4 @@ else
 end
 end
 % ===== end main function =================================================
-
-
-% ──────────────────────────────────────────────────────────────────────────
-function tl = chooseTrialLength(cfg, defaultTL)
-% Return cfg.triallength if present, otherwise fall back to defaultTL.
-    if isfield(cfg,'triallength') && ~isempty(cfg.triallength)
-        tl = cfg.triallength;
-    else
-        tl = defaultTL;
-    end
-end
 


### PR DESCRIPTION
## Summary
- document typical usage in `run_navigation_cfg`, `isSlurmCluster`, and `chooseTrialLength`
- rely on external `chooseTrialLength` helper

## Testing
- `pre-commit` *(fails: command not found)*
- `matlab -batch "disp('testing')"` *(fails: command not found)*