### PR TITLE
Fix streaming check for bilateral simulations

### DIFF
--- a/Code/run_navigation_cfg.m
+++ b/Code/run_navigation_cfg.m
@@ -82,11 +82,12 @@ elseif isfield(cfg,'plume_video')
     assert(all(isfield(cfg,{'px_per_mm','frame_rate'})), ...
         'px_per_mm and frame_rate are required for video plumes');
 
-    % Auto-enable streaming on SLURM clusters when not specified
-    if ~isfield(cfg,'use_streaming') && isSlurmCluster()
-        if isfield(cfg,'bilateral') && cfg.bilateral
+    % Auto-enable streaming on SLURM clusters when not specified. Bilateral
+    % simulations do not support streaming, so explicitly disable it first.
+    if ~isfield(cfg,'use_streaming')
+        if isfield(cfg,'bilateral') && cfg.bilateral && isSlurmCluster()
             cfg.use_streaming = false;
-        else
+        elseif isSlurmCluster()
             cfg.use_streaming = true;
         end
     end

--- a/tests/test_auto_streaming_bilateral_disabled.m
+++ b/tests/test_auto_streaming_bilateral_disabled.m
@@ -32,6 +32,8 @@ function testNoStreamingError(~)
     catch ME
         assert(~strcmp(ME.identifier,'run_navigation_cfg:BilateralStreamingUnsupported'), ...
             'BilateralStreamingUnsupported should not be thrown');
+        assert(~contains(ME.message,'navigation_model_vec_stream not yet implemented'), ...
+            'Streaming should be disabled when bilateral');
     end
 
     rmdir(tmpDir,'s');


### PR DESCRIPTION
## Summary
- disable auto streaming on SLURM when running bilateral simulations
- test that bilateral streaming does not trigger streaming backend

## Testing
- `./setup_env.sh --dev` *(fails: wget requires network)*
- `make test-matlab` *(fails: no rule for test-matlab)*