### PR TITLE
Add template-based sbatch generation

### DIFF
--- a/slurm_job_template.slurm
+++ b/slurm_job_template.slurm
@@ -1,0 +1,10 @@
+#!/bin/bash
+#SBATCH --job-name=${EXP_NAME}_sim
+#SBATCH --partition=${PARTITION}
+#SBATCH --time=${TIME_LIMIT}
+#SBATCH --mem=${MEM_PER_TASK}
+#SBATCH --cpus-per-task=1
+#SBATCH --array=0-${ARRAY_UPPER}%${MAX_CONCURRENT}
+#SBATCH --output=${OUTPUT_DIR}/slurm-%A_%a.out
+
+matlab -nodisplay -r "navigation_model_vec(${TRIAL_LENGTH}, '${ENVIRONMENT}', 0, ${AGENTS_PER_JOB}); exit"

--- a/slurm_submit.sh
+++ b/slurm_submit.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+template="$script_dir/slurm_job_template.slurm"
+output_file="${1:-$script_dir/generated_job.slurm}"
+
+trial_length="${TRIAL_LENGTH:-5000}"
+environment="${ENVIRONMENT:-Crimaldi}"
+output_dir="${OUTPUT_DIR:-$PWD}"
+
+agents_per_condition="${AGENTS_PER_CONDITION:-1000}"
+agents_per_job="${AGENTS_PER_JOB:-10}"
+partition="${PARTITION:-day}"
+time_limit="${TIME_LIMIT:-6:00:00}"
+mem_per_task="${MEM_PER_TASK:-64G}"
+max_concurrent="${MAX_CONCURRENT:-100}"
+exp_name="${EXP_NAME:-crimaldi}"
+
+total_jobs=$(( (agents_per_condition + agents_per_job - 1) / agents_per_job * 4 ))
+array_upper=$(( total_jobs - 1 ))
+
+export TRIAL_LENGTH="$trial_length" ENVIRONMENT="$environment" OUTPUT_DIR="$output_dir" \
+       AGENTS_PER_JOB="$agents_per_job" PARTITION="$partition" TIME_LIMIT="$time_limit" \
+       MEM_PER_TASK="$mem_per_task" MAX_CONCURRENT="$max_concurrent" EXP_NAME="$exp_name" \
+       ARRAY_UPPER="$array_upper"
+
+>&2 echo "Writing SLURM script to $output_file with $total_jobs array task(s)"
+
+envsubst < "$template" > "$output_file"
+cat "$output_file"

--- a/tests/test_slurm_submit.py
+++ b/tests/test_slurm_submit.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+
+def test_template_exists():
+    root = Path(__file__).resolve().parents[1]
+    template = root / 'slurm_job_template.slurm'
+
+    assert template.is_file()
+
+    content = template.read_text()
+    assert 'navigation_model_vec' in content
+
+
+def test_slurm_submit_creates_batch_file(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    script = root / 'slurm_submit.sh'
+    output = tmp_path / 'job.slurm'
+
+    env = os.environ.copy()
+    env['AGENTS_PER_CONDITION'] = '20'
+    env['AGENTS_PER_JOB'] = '5'
+    env['EXP_NAME'] = 'test'
+
+    subprocess.run(['bash', str(script), str(output)], capture_output=True, text=True, cwd=root, env=env, check=True)
+
+    assert output.is_file()
+    content = output.read_text()
+    assert '#SBATCH --array=0-15%100' in content
+    assert '#SBATCH --job-name=test_sim' in content
+


### PR DESCRIPTION
## Summary
- add SBATCH template and rewrite `slurm_submit.sh` to fill it using `envsubst`
- update tests for new file generation behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e09144c5c832097a54d6b5787e4aa