### PR TITLE
Add help option and logging to slurm_submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ If your Codex environment includes a `setup_env.sh` script, run it with the `--d
 bash setup_env.sh --dev
 ```
 
-Currently this repository does not include automated tests, but the above environment script can be used to install any required dependencies.
+This repository now includes a small pytest suite. After creating the development environment you can run the tests with:
+
+```bash
+pytest -q
+```
+
+The `slurm_submit.sh` helper script supports a `-h`/`--help` option that prints
+usage instructions and also logs the calculated array size and selected paths
+when invoked.
 
 ## License
 

--- a/slurm_submit.sh
+++ b/slurm_submit.sh
@@ -1,6 +1,38 @@
 #!/bin/bash
 
+# ---------------------------------------------------------------------------
+# Submit jobs to SLURM for running olfactory navigation simulations.
+#
+# Usage:
+#   ./slurm_submit.sh [output_file]
+#   ./slurm_submit.sh -h|--help
+#
+# Environment variables:
+#   TRIAL_LENGTH        Duration of each trial in ms (default: 5000)
+#   ENVIRONMENT         Environment name (default: Crimaldi)
+#   OUTPUT_DIR          Directory for output files (default: current dir)
+#   AGENTS_PER_CONDITION Number of agents per condition (default: 1000)
+#   AGENTS_PER_JOB      Number of agents simulated per SLURM task (default: 10)
+#   PARTITION           Cluster partition to use (default: day)
+#   TIME_LIMIT          Wall time limit for each task (default: 6:00:00)
+#   MEM_PER_TASK        Memory per task (default: 64G)
+#   MAX_CONCURRENT      Maximum concurrent tasks in array (default: 100)
+#   EXP_NAME            Name prefix for the job (default: crimaldi)
+#
+# Example:
+#   AGENTS_PER_CONDITION=20 AGENTS_PER_JOB=5 ./slurm_submit.sh job.slurm
+# ---------------------------------------------------------------------------
+
 set -euo pipefail
+
+usage() {
+    sed -n '3,24p' "$0"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 template="$script_dir/slurm_job_template.slurm"
@@ -20,6 +52,10 @@ exp_name="${EXP_NAME:-crimaldi}"
 
 total_jobs=$(( (agents_per_condition + agents_per_job - 1) / agents_per_job * 4 ))
 array_upper=$(( total_jobs - 1 ))
+
+printf 'Using template: %s\n' "$template" >&2
+printf 'Output file will be: %s\n' "$output_file" >&2
+printf 'Calculated total_jobs=%s array_upper=%s\n' "$total_jobs" "$array_upper" >&2
 
 export TRIAL_LENGTH="$trial_length" ENVIRONMENT="$environment" OUTPUT_DIR="$output_dir" \
        AGENTS_PER_JOB="$agents_per_job" PARTITION="$partition" TIME_LIMIT="$time_limit" \

--- a/tests/test_slurm_submit.py
+++ b/tests/test_slurm_submit.py
@@ -31,3 +31,48 @@ def test_slurm_submit_creates_batch_file(tmp_path):
     assert '#SBATCH --array=0-15%100' in content
     assert '#SBATCH --job-name=test_sim' in content
 
+
+def test_slurm_submit_usage_option():
+    root = Path(__file__).resolve().parents[1]
+    script = root / 'slurm_submit.sh'
+
+    result = subprocess.run([
+        'bash', str(script), '-h'
+    ], capture_output=True, text=True, cwd=root)
+
+    assert result.returncode == 0
+    help_text = result.stdout
+    for var in [
+        'TRIAL_LENGTH',
+        'ENVIRONMENT',
+        'OUTPUT_DIR',
+        'AGENTS_PER_CONDITION',
+        'AGENTS_PER_JOB',
+        'PARTITION',
+        'TIME_LIMIT',
+        'MEM_PER_TASK',
+        'MAX_CONCURRENT',
+        'EXP_NAME',
+    ]:
+        assert var in help_text
+
+
+def test_slurm_submit_logs(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    script = root / 'slurm_submit.sh'
+    output = tmp_path / 'job.slurm'
+
+    env = os.environ.copy()
+    env['AGENTS_PER_CONDITION'] = '20'
+    env['AGENTS_PER_JOB'] = '5'
+
+    result = subprocess.run([
+        'bash', str(script), str(output)
+    ], capture_output=True, text=True, cwd=root, env=env, check=True)
+
+    # stderr should contain the computed values and paths
+    stderr = result.stderr
+    assert 'total_jobs' in stderr or 'total jobs' in stderr.lower()
+    assert 'array_upper' in stderr or 'array upper' in stderr.lower()
+    assert str(output) in stderr
+


### PR DESCRIPTION
## Summary
- document pytest usage and help option in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e10b4001c832082f7bdc07594f25a