### PR TITLE
docs: standardize config locations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository Contribution Guidelines
+
+- Create the development environment using `setup_env.sh --dev` if the script exists.
+- Always run `pytest -q` before committing changes.
+- Place **all** configuration files in the top-level `configs/` directory.
+- Each subproject should keep its configs in its own subfolder under `configs/`.
+- Name config files using snake_case with the subproject prefix, e.g. `navigation_model_default.yaml`.
+- Write SLURM logs to `slurm_logs/<jobname>/` using the `<jobname>_logs` pattern.
+- Use Conventional Commits for commit messages.
+- Prefer verbose logging to aid debugging and understanding of code behaviour.
+- Follow test-driven development; tests should validate results rather than implementation details.

--- a/Code/AGENTS.md
+++ b/Code/AGENTS.md
@@ -1,0 +1,6 @@
+# Navigation Model Guidelines
+
+- Store configuration files for the MATLAB model in `configs/navigation_model/`.
+- Use filenames prefixed with `navigation_model_`.
+- Slurm output logs should go to `slurm_logs/navigation_model/`.
+- Follow the root `AGENTS.md` for environment setup, tests and commit conventions.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository accompanies the paper **"Elementary sensory-motor transformation
 - **Code/** – MATLAB scripts for analyzing behavior and running the navigation model. This folder also contains an `import functions feb2017` subfolder for reading binary tracking data produced with the Miniature Manhattan wind tunnels.
 - **Arena 4f/** – Laser cut design files (AI format) and instructions describing how to assemble the behavioral arena.
 - **WalkingArenaLoopLongerIRtime2/** – Arduino sketch for controlling arena lighting, odor valves and camera triggers.
+- **configs/** – Central location for configuration files. Each subproject should store its own files in a subfolder here (e.g. `configs/navigation_model/`, `configs/arduino/`).
 - **FlyTracker 3.6.vi**, **Get Frame Timestamp.vi**, **SelectBackground.vi** – LabVIEW VIs used for dSMOKE:
   mean: 0.359
   median: 0.498

--- a/WalkingArenaLoopLongerIRtime2/AGENTS.md
+++ b/WalkingArenaLoopLongerIRtime2/AGENTS.md
@@ -1,0 +1,6 @@
+# Arduino Controller Guidelines
+
+- Place configuration files in `configs/arduino/`.
+- Use filenames prefixed with `arduino_`.
+- Any SLURM logs for this project should go to `slurm_logs/arduino/`.
+- Adhere to the root `AGENTS.md` for testing and commit practices.


### PR DESCRIPTION
## Summary
- document config handling and standardized slurm logs in `AGENTS.md`
- add subproject instructions for MATLAB and Arduino code
- note new config directory layout in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e298392dc832092d1f3e2bbe47205