### PR TITLE
Allow configuring plume path

### DIFF
--- a/Code/get_plume_file.m
+++ b/Code/get_plume_file.m
@@ -1,10 +1,11 @@
 function plume_file = get_plume_file()
-%GET_PLUME_FILE Return plume HDF5 filename from config.json
+%GET_PLUME_FILE Return plume HDF5 filename from configuration
 %   Uses environment variable PLUME_CONFIG to locate the configuration.
 
 config_path = getenv('PLUME_CONFIG');
 if isempty(config_path)
-    config_path = fullfile(fileparts(mfilename('fullpath')),'..','config.json');
+    config_path = fullfile(fileparts(mfilename('fullpath')),'..','configs', ...
+        'navigation_model','navigation_model_default.json');
 end
 fprintf('Loading plume config from %s\n', config_path);
 if ~exist(config_path, 'file')
@@ -15,8 +16,11 @@ end
 
 try
     cfg = jsondecode(fileread(config_path));
-    if isfield(cfg, 'plume_file')
+    if isfield(cfg,'plume_file')
         plume_file = cfg.plume_file;
+        if isfield(cfg,'plume_path') && ~isempty(cfg.plume_path)
+            plume_file = fullfile(cfg.plume_path, plume_file);
+        end
     else
         warning('Invalid config file %s. Using default.', config_path);
         plume_file = '10302017_10cms_bounded.hdf5';

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository accompanies the paper **"Elementary sensory-motor transformation
 - **Code/** – MATLAB scripts for analyzing behavior and running the navigation model. This folder also contains an `import functions feb2017` subfolder for reading binary tracking data produced with the Miniature Manhattan wind tunnels.
 - **Arena 4f/** – Laser cut design files (AI format) and instructions describing how to assemble the behavioral arena.
 - **WalkingArenaLoopLongerIRtime2/** – Arduino sketch for controlling arena lighting, odor valves and camera triggers.
-- **configs/** – Central location for configuration files. Each subproject should store its own files in a subfolder here (e.g. `configs/navigation_model/`, `configs/arduino/`).
+- **configs/** – Central location for configuration files. Each subproject should store its own files in a subfolder here (e.g. `configs/navigation_model/`, `configs/arduino/`). The default plume selection for the navigation model is located at `configs/navigation_model/navigation_model_default.json`.
 - **FlyTracker 3.6.vi**, **Get Frame Timestamp.vi**, **SelectBackground.vi** – LabVIEW VIs used for dSMOKE:
   mean: 0.359
   median: 0.498

--- a/configs/navigation_model/navigation_model_default.json
+++ b/configs/navigation_model/navigation_model_default.json
@@ -1,0 +1,4 @@
+{
+  "plume_file": "10302017_10cms_bounded.hdf5",
+  "plume_path": ""
+}

--- a/plume_config.py
+++ b/plume_config.py
@@ -4,7 +4,12 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config.json')
+DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.dirname(__file__),
+    'configs',
+    'navigation_model',
+    'navigation_model_default.json',
+)
 
 
 def get_config_path() -> str:
@@ -13,7 +18,7 @@ def get_config_path() -> str:
 
 
 def get_plume_file() -> str:
-    """Return the HDF5 plume filename from the configuration."""
+    """Return the full path to the plume file specified in the configuration."""
     config_path = get_config_path()
     logger.debug("Loading config from %s", config_path)
     if not os.path.exists(config_path):
@@ -22,7 +27,14 @@ def get_plume_file() -> str:
     try:
         with open(config_path) as f:
             data = json.load(f)
-        return data.get("plume_file", '10302017_10cms_bounded.hdf5')
+        plume_file = data.get('plume_file', '10302017_10cms_bounded.hdf5')
+        plume_path = data.get('plume_path', '')
+        if plume_path:
+            full_path = os.path.join(plume_path, plume_file)
+            logger.debug("Resolved plume file path: %s", full_path)
+            return full_path
+        logger.debug("Using plume file without path: %s", plume_file)
+        return plume_file
     except Exception as exc:
         logger.error("Invalid config file %s: %s", config_path, exc)
         return '10302017_10cms_bounded.hdf5'

--- a/tests/test_plume_config.py
+++ b/tests/test_plume_config.py
@@ -8,14 +8,27 @@ import pytest
 
 
 def test_get_plume_file_reads_json(tmp_path, monkeypatch):
+    """When PLUME_CONFIG points to a JSON file the path should be used."""
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-    # Write a temporary JSON config file
     temp_config = tmp_path / 'config.json'
     temp_config.write_text('{"plume_file": "custom.hdf5"}')
-
-    # Monkeypatch environment variable to point to temp config
     monkeypatch.setenv('PLUME_CONFIG', str(temp_config))
 
     plume_config = importlib.import_module('plume_config')
     path = plume_config.get_plume_file()
-    assert path == 'custom.hdf5'
+    assert path == "custom.hdf5"
+
+
+def test_get_plume_file_with_path(tmp_path, monkeypatch):
+    """plume_path is prepended when present."""
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    temp_config = tmp_path / 'config.json'
+    temp_config.write_text(
+        '{"plume_file": "custom.hdf5", "plume_path": "' + str(tmp_path) + '"}'
+    )
+    monkeypatch.setenv('PLUME_CONFIG', str(temp_config))
+
+    plume_config = importlib.import_module('plume_config')
+    importlib.reload(plume_config)
+    expected = os.path.join(str(tmp_path), "custom.hdf5")
+    assert plume_config.get_plume_file() == expected


### PR DESCRIPTION
## Summary
- let plume path come from config
- support `plume_path` in MATLAB and Python helpers
- test with and without path override
- document default navigation model config location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f03a6dec48320b25028c984070ac1