### PR TITLE
Improve logging and fix view_results

### DIFF
--- a/plume_config.py
+++ b/plume_config.py
@@ -5,24 +5,34 @@ import logging
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config.json')
+DEFAULT_PLUME_FILE = '10302017_10cms_bounded.hdf5'
 
 
 def get_config_path() -> str:
     """Return the path to the configuration file."""
-    return os.environ.get('PLUME_CONFIG', DEFAULT_CONFIG_PATH)
+    path = os.environ.get('PLUME_CONFIG', DEFAULT_CONFIG_PATH)
+    if path == DEFAULT_CONFIG_PATH:
+        logger.debug('PLUME_CONFIG not set; using default %s', path)
+    else:
+        logger.debug('Using config path from PLUME_CONFIG: %s', path)
+    return path
 
 
 def get_plume_file() -> str:
     """Return the HDF5 plume filename from the configuration."""
     config_path = get_config_path()
-    logger.debug("Loading config from %s", config_path)
+    logger.debug('Loading config from %s', config_path)
     if not os.path.exists(config_path):
-        logger.warning("Config file %s not found. Using default filename.", config_path)
-        return '10302017_10cms_bounded.hdf5'
+        logger.warning('Config file %s not found. Using default filename.', config_path)
+        logger.debug('Default plume file: %s', DEFAULT_PLUME_FILE)
+        return DEFAULT_PLUME_FILE
     try:
         with open(config_path) as f:
             data = json.load(f)
-        return data.get("plume_file", '10302017_10cms_bounded.hdf5')
+        plume_file = data.get('plume_file', DEFAULT_PLUME_FILE)
+        logger.debug('Plume file from config: %s', plume_file)
+        return plume_file
     except Exception as exc:
-        logger.error("Invalid config file %s: %s", config_path, exc)
-        return '10302017_10cms_bounded.hdf5'
+        logger.error('Invalid config file %s: %s', config_path, exc)
+        logger.debug('Default plume file: %s', DEFAULT_PLUME_FILE)
+        return DEFAULT_PLUME_FILE

--- a/tests/test_plume_config.py
+++ b/tests/test_plume_config.py
@@ -1,21 +1,28 @@
 import os
 import importlib
 import sys
+import logging
 
 import pytest
 
 
-
-
 def test_get_plume_file_reads_json(tmp_path, monkeypatch):
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-    # Write a temporary JSON config file
     temp_config = tmp_path / 'config.json'
     temp_config.write_text('{"plume_file": "custom.hdf5"}')
-
-    # Monkeypatch environment variable to point to temp config
     monkeypatch.setenv('PLUME_CONFIG', str(temp_config))
 
     plume_config = importlib.import_module('plume_config')
     path = plume_config.get_plume_file()
     assert path == 'custom.hdf5'
+
+
+def test_get_plume_file_missing_config(tmp_path, monkeypatch, caplog):
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    missing = tmp_path / 'missing.json'
+    monkeypatch.setenv('PLUME_CONFIG', str(missing))
+    plume_config = importlib.import_module('plume_config')
+    with caplog.at_level(logging.DEBUG):
+        path = plume_config.get_plume_file()
+    assert path == '10302017_10cms_bounded.hdf5'
+    assert any('not found' in rec.getMessage() for rec in caplog.records)

--- a/tests/test_view_results.py
+++ b/tests/test_view_results.py
@@ -1,0 +1,13 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import types
+import logging
+from view_results import analyze_results
+
+
+def test_analyze_results_handles_iterable(caplog):
+    out = types.SimpleNamespace(successrate=[0.5])
+    with caplog.at_level(logging.INFO):
+        rate = analyze_results(out)
+    assert rate == 0.5
+    assert any('Success rate:' in rec.getMessage() for rec in caplog.records)

--- a/view_results.py
+++ b/view_results.py
@@ -1,0 +1,39 @@
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PLUME_FILE = '10302017_10cms_bounded.hdf5'
+
+
+def analyze_results(out: Any) -> float | None:
+    """Return success rate from results and log it."""
+    success = getattr(out, 'successrate', None)
+    if success is None:
+        logger.info('No success rate available')
+        return None
+
+    try:
+        import numpy as np  # type: ignore
+    except Exception:  # pragma: no cover - numpy may not be installed
+        np = None  # type: ignore
+
+    if np is not None and isinstance(success, np.ndarray):
+        rate = float(success.mean()) if success.size > 1 else float(success.item())
+    elif not isinstance(success, (float, int)) and hasattr(success, '__iter__'):
+        rate = float(list(success)[0])
+    else:
+        rate = float(success)
+
+    logger.info('Success rate: %.1f%%', rate * 100)
+    return rate
+
+
+if __name__ == '__main__':  # pragma: no cover - manual use
+    logging.basicConfig(level=logging.INFO)
+    import argparse
+    parser = argparse.ArgumentParser(description='Analyze navigation results')
+    parser.add_argument('success', type=float, nargs='?', help='Success rate value')
+    args = parser.parse_args()
+    dummy = type('Out', (), {'successrate': args.success})
+    analyze_results(dummy)


### PR DESCRIPTION
## Summary
- log success rate correctly in view_results
- add verbose debug logs in plume_config
- test handling of success rate lists
- test default plume config path handling

## Testing
- `pytest tests/test_view_results.py tests/test_plume_config.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f0f73cf008320ad2b2d40a0d42b1e