### PR TITLE
Add plume config setup script

### DIFF
--- a/setup_plume_config.py
+++ b/setup_plume_config.py
@@ -1,0 +1,52 @@
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CONFIG_BASE = Path('configs')
+SUBDIR = 'navigation_model'
+CONFIG_NAME = 'navigation_model_default.json'
+
+
+def write_plume_config(
+    plume_file: str,
+    base_dir: Path = CONFIG_BASE,
+    subdir: str = SUBDIR,
+    config_name: str = CONFIG_NAME,
+) -> str:
+    """Write plume file path to JSON configuration and return path."""
+    config_dir = Path(base_dir) / subdir
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / config_name
+    data = {"plume_file": plume_file}
+    with open(config_path, 'w') as fh:
+        json.dump(data, fh, indent=2)
+    logger.info('Wrote plume configuration to %s', config_path)
+    return str(config_path)
+
+
+def main() -> None:
+    """Interactively create a plume configuration file."""
+    logging.basicConfig(level=logging.INFO)
+    default_dir = Path('data/plumes')
+    directory = input(f'Plume directory [{default_dir}]: ').strip() or str(default_dir)
+    plume_dir = Path(directory)
+    files = sorted(plume_dir.glob('*.hdf5'))
+    if files:
+        for idx, file in enumerate(files):
+            print(f'[{idx}] {file}')
+        choice = input('Select plume file by number: ').strip()
+        try:
+            index = int(choice)
+            plume_file = str(files[index])
+        except Exception as exc:  # pragma: no cover - user input errors
+            logger.error('Invalid selection: %s (%s)', choice, exc)
+            return
+    else:
+        plume_file = input('Enter path to plume file: ').strip()
+    write_plume_config(plume_file)
+
+
+if __name__ == '__main__':  # pragma: no cover - manual execution only
+    main()

--- a/tests/test_setup_plume_config.py
+++ b/tests/test_setup_plume_config.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+
+def test_write_plume_config_creates_file(tmp_path):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from setup_plume_config import write_plume_config
+
+    config_dir = tmp_path / "configs"
+    path = write_plume_config("plume.hdf5", base_dir=config_dir)
+    expected = config_dir / "navigation_model" / "navigation_model_default.json"
+
+    assert Path(path) == expected
+    with open(path) as fh:
+        data = json.load(fh)
+    assert data["plume_file"] == "plume.hdf5"


### PR DESCRIPTION
## Summary
- add interactive `setup_plume_config.py` for choosing plume file and writing the config
- include test for the `write_plume_config` function

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684082978ce88320954435b8ea4cbae4