### PR TITLE
Add plume info setup script

### DIFF
--- a/setup_plume_info.py
+++ b/setup_plume_info.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Interactive setup for plume configuration files.
+
+This script requests the user to provide the file paths for the smoke and
+Crimaldi plume datasets. Configuration files are then generated in the
+specified directory (default: configs/plumes) with hard coded frame rates
+and pixel sizes.
+"""
+import argparse
+import json
+import logging
+from pathlib import Path
+
+
+SMOKE_FPS = 60
+SMOKE_MM_PER_PIXEL = 0.153
+CRIMALDI_FPS = 15
+CRIMALDI_MM_PER_PIXEL = 0.74
+DATASET_NAME = "/dataset2"
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def ask_path(prompt: str) -> str:
+    """Prompt the user for a path."""
+    try:
+        return input(prompt).strip()
+    except EOFError:
+        return ""
+
+
+def write_config(path: Path, plume_file: str, mm_per_pixel: float, fps: int) -> None:
+    """Write a simple JSON configuration."""
+    data = {
+        "plume_file": plume_file,
+        "dataset_name": DATASET_NAME,
+        "mm_per_pixel": mm_per_pixel,
+        "frame_rate": fps,
+    }
+    path.write_text(json.dumps(data, indent=2))
+    logger.info("Wrote %s", path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate plume configuration files")
+    parser.add_argument("--smoke-file", help="Path to smoke plume HDF5 file")
+    parser.add_argument("--crimaldi-file", help="Path to crimaldi plume HDF5 file")
+    parser.add_argument("--config-dir", default="configs/plumes", help="Directory for output configs")
+    args = parser.parse_args()
+
+    config_dir = Path(args.config_dir)
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    smoke_file = args.smoke_file or ask_path("Path to smoke plume file: ")
+    crimaldi_file = args.crimaldi_file or ask_path("Path to crimaldi plume file: ")
+
+    logger.info("Smoke file: %s", smoke_file)
+    logger.info("Crimaldi file: %s", crimaldi_file)
+
+    write_config(config_dir / "plumes_smoke_info.json", smoke_file, SMOKE_MM_PER_PIXEL, SMOKE_FPS)
+    write_config(config_dir / "plumes_crimaldi_info.json", crimaldi_file, CRIMALDI_MM_PER_PIXEL, CRIMALDI_FPS)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_setup_plume_info.py
+++ b/tests/test_setup_plume_info.py
@@ -1,0 +1,31 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_setup_plume_info_creates_configs(tmp_path):
+    script = Path(__file__).resolve().parents[1] / 'setup_plume_info.py'
+    smoke_file = tmp_path / 'smoke.h5'
+    crimaldi_file = tmp_path / 'crimaldi.h5'
+    smoke_file.write_text('dummy')
+    crimaldi_file.write_text('dummy')
+    config_dir = tmp_path / 'configs'
+    config_dir.mkdir()
+
+    subprocess.run([
+        'python', str(script),
+        '--smoke-file', str(smoke_file),
+        '--crimaldi-file', str(crimaldi_file),
+        '--config-dir', str(config_dir)
+    ], check=True)
+
+    smoke_config = json.loads((config_dir / 'plumes_smoke_info.json').read_text())
+    crimaldi_config = json.loads((config_dir / 'plumes_crimaldi_info.json').read_text())
+
+    assert smoke_config['plume_file'] == str(smoke_file)
+    assert smoke_config['mm_per_pixel'] == 0.153
+    assert smoke_config['frame_rate'] == 60
+
+    assert crimaldi_config['plume_file'] == str(crimaldi_file)
+    assert crimaldi_config['mm_per_pixel'] == 0.74
+    assert crimaldi_config['frame_rate'] == 15


### PR DESCRIPTION
## Summary
- add setup_plume_info.py to create basic plume configuration files
- add tests for setup_plume_info

## Testing
- `bash setup_env.sh --dev`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408aa448608320bb083fb8703beb30