### PR TITLE
Fix config loading in navigation_model_vec

### DIFF
--- a/Code/navigation_model_vec.m
+++ b/Code/navigation_model_vec.m
@@ -71,21 +71,49 @@ else
     triallength = double(triallength);
 end
 
-% Scaling factors
+% Scaling factors and plume configuration
 
-tscale = 15/50; %15Hz/50Hz ratio to convert parameters for the plume data (parameters are expressed in samples at 50 Hz in this code)
-pxscale = 0.74; %mm/pixel ratio to convert pixels from the plume data to actual mm
+tscale = 15/50;  % Default 15Hz/50Hz ratio
+pxscale = 0.74;  % Default mm/pixel ratio
 
-% Override with config values for Crimaldi
+% Initialize plume_config with defaults
+plume_config = struct();
+plume_config.frame_rate = 15;
+
+% Load the correct config for Crimaldi environment
 if strcmpi(environment, 'Crimaldi') || strcmpi(environment, 'crimaldi')
     try
-        [plume_filename, plume_config] = get_plume_file();
-        tscale = plume_config.time_scale_50hz;
-        pxscale = plume_config.pixel_scale;
-        fprintf('Loaded config: %.1f Hz, %.3f mm/px\n', plume_config.frame_rate, pxscale);
-    catch
-        fprintf('Config failed, using defaults\n');
-        plume_config.frame_rate = 15;
+        % Determine which config to load based on environment variable
+        env_plume = getenv('MATLAB_PLUME_FILE');
+
+        if contains(env_plume, 'smoke')
+            % Smoke plume
+            cfg = jsondecode(fileread('configs/plumes/smoke_1a_backgroundsubtracted.json'));
+            plume_filename = env_plume;
+        else
+            % Crimaldi plume (default)
+            cfg = jsondecode(fileread('configs/plumes/crimaldi_10cms_bounded.json'));
+            plume_filename = cfg.data_path.path;
+        end
+
+        % Extract values from config
+        plume_config.frame_rate = cfg.temporal.frame_rate;
+        tscale = cfg.temporal.frame_rate / 50.0;
+        pxscale = cfg.spatial.mm_per_pixel;
+        plume_config.dataset_name = cfg.data_path.dataset_name;
+
+        % Use model_params if available
+        if isfield(cfg, 'model_params')
+            tscale = cfg.model_params.tscale;
+            pxscale = cfg.model_params.pxscale;
+        end
+
+        fprintf('Loaded config: %.1f Hz, tscale=%.3f, pxscale=%.3f\n', ...
+                plume_config.frame_rate, tscale, pxscale);
+
+    catch ME
+        fprintf('Config loading failed: %s\n', ME.message);
+        plume_filename = 'data/plumes/10302017_10cms_bounded.hdf5';
     end
 end
 
@@ -229,8 +257,13 @@ ws=1;
 
 % Load plume file once before the simulation loop
 if strcmpi(environment, 'Crimaldi') || strcmpi(environment, 'crimaldi')
-    plume_filename = get_plume_file();
-    dataset_name = '/dataset2';  % or get from config
+    if exist('plume_filename', 'var')
+        dataset_name = plume_config.dataset_name;
+        fprintf('Using dataset: %s\n', dataset_name);
+    else
+        plume_filename = get_plume_file();
+        dataset_name = '/dataset2';
+    end
 end
 
 for i = 1:triallength
@@ -247,7 +280,7 @@ for i = 1:triallength
             odor(i,out_of_plume)=0;
             %this will be vectorizable if the dataset is loaded into memory
             for it=within
-                odor(i,it)=max(0,h5read(plume_filename,'/dataset2',[xind(it) yind(it) tind],[1 1 1])); % Draws odor concentration for the current position and time
+                odor(i,it)=max(0,h5read(plume_filename, dataset_name,[xind(it) yind(it) tind],[1 1 1])); % Draws odor concentration for the current position and time
             end
         case {'openloopslope','openlooppulse15','openlooppulse','openlooppulsewb15','openlooppulsewb'}
             odor(i,:) = odormax*OLodorlib.(environment).data(i);

--- a/tests/test_navigation_model_config.py
+++ b/tests/test_navigation_model_config.py
@@ -1,0 +1,33 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def run_model(env):
+    root = Path(__file__).resolve().parents[1]
+    script = "out = navigation_model_vec(10, 'Crimaldi', 0, 1);"
+    result = subprocess.run([
+        'bash', str(root / 'run_matlab_safe.sh')
+    ], input=script, text=True, capture_output=True, cwd=root, env=env)
+    return result
+
+
+def test_navigation_model_default_crimaldi():
+    env = os.environ.copy()
+    env.pop('MATLAB_PLUME_FILE', None)
+    result = run_model(env)
+    assert result.returncode == 0
+    assert 'Loaded config:' in result.stdout
+    assert '15.0' in result.stdout
+
+
+def test_navigation_model_smoke_config():
+    root = Path(__file__).resolve().parents[1]
+    cfg = json.loads((root / 'configs' / 'plumes' / 'smoke_1a_backgroundsubtracted.json').read_text())
+    env = os.environ.copy()
+    env['MATLAB_PLUME_FILE'] = cfg['data_path']['path']
+    result = run_model(env)
+    assert result.returncode == 0
+    assert 'Loaded config:' in result.stdout
+    assert '60.0' in result.stdout


### PR DESCRIPTION
## Summary
- add tests covering environment-based config selection for `navigation_model_vec`
- align `navigation_model_vec` config handling with `Elifenavmodel_bilateral`

## Testing
- `pytest -q` *(fails: matlab and slurm tools not present)*

------
https://chatgpt.com/codex/tasks/task_e_6840c47187288320a465367dba05f0d5