### PR TITLE
Add diagnostics logging to complete test slurm workflow

### DIFF
--- a/complete_test.slurm
+++ b/complete_test.slurm
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Complete test workflow
+#SBATCH --job-name=complete_test
+#SBATCH --partition=day
+#SBATCH --time=1:00:00
+#SBATCH --mem=8G
+#SBATCH --output=slurm_logs/complete_test/complete_test_logs_%j.out
+#SBATCH --error=slurm_logs/complete_test/complete_test_logs_%j.err
+
+set -euo pipefail
+
+module load MATLAB/2023b
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$PROJECT_DIR"
+mkdir -p slurm_logs/complete_test results
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+echo "Starting complete test at $(date)" | tee "results/diagnostics_${TIMESTAMP}.txt"
+
+echo "=== Generating configs ===" | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+matlab -batch "try, run('generate_clean_configs.m'); catch ME, disp(getReport(ME)); exit(1); end; exit(0);" 2>&1 | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+
+echo "=== Running complete test ===" | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+matlab -batch "try, run('test_both_plumes_complete.m'); catch ME, disp(getReport(ME)); exit(1); end; exit(0);" 2>&1 | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+
+echo "=== Diagnostics ===" | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+ls -lh results | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+
+if compgen -G "results/*.png" > /dev/null; then
+    echo "Plot files:" | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+    ls -1 results/*.png | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+else
+    echo "No plot files found" | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+fi
+
+echo "Finished at $(date)" | tee -a "results/diagnostics_${TIMESTAMP}.txt"
+

--- a/slurm_job_template.slurm
+++ b/slurm_job_template.slurm
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Template SLURM script for navigation model
+
+matlab -batch "navigation_model_vec($TRIAL_LENGTH, '$ENVIRONMENT', 0, $AGENTS_PER_JOB)"

--- a/slurm_submit.sh
+++ b/slurm_submit.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: slurm_submit.sh [OUTPUT_FILE]
+
+Environment variables:
+  TRIAL_LENGTH       Length of each trial
+  ENVIRONMENT        Environment name
+  OUTPUT_DIR         Directory for output
+  AGENTS_PER_CONDITION
+  AGENTS_PER_JOB
+  PARTITION
+  TIME_LIMIT
+  MEM_PER_TASK
+  MAX_CONCURRENT
+  EXP_NAME
+USAGE
+}
+
+if [[ ${1:-} == '-h' || ${1:-} == '--help' ]]; then
+    usage
+    exit 0
+fi
+
+OUTPUT=${1:?"Output path required"}
+
+AGENTS_PER_CONDITION=${AGENTS_PER_CONDITION:-100}
+AGENTS_PER_JOB=${AGENTS_PER_JOB:-10}
+EXP_NAME=${EXP_NAME:-nav}
+PARTITION=${PARTITION:-day}
+TIME_LIMIT=${TIME_LIMIT:-1:00:00}
+MEM_PER_TASK=${MEM_PER_TASK:-4G}
+MAX_CONCURRENT=${MAX_CONCURRENT:-100}
+
+CONDITIONS=4
+JOBS_PER_COND=$(( (AGENTS_PER_CONDITION + AGENTS_PER_JOB -1)/AGENTS_PER_JOB ))
+TOTAL_JOBS=$(( JOBS_PER_COND * CONDITIONS ))
+ARRAY_UPPER=$(( TOTAL_JOBS - 1 ))
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+cat > "$OUTPUT" <<EOF2
+#!/bin/bash
+#SBATCH --job-name=${EXP_NAME}_sim
+#SBATCH --partition=${PARTITION}
+#SBATCH --time=${TIME_LIMIT}
+#SBATCH --mem=${MEM_PER_TASK}
+#SBATCH --array=0-${ARRAY_UPPER}%${MAX_CONCURRENT}
+
+$(cat slurm_job_template.slurm)
+EOF2
+
+{
+    echo "total_jobs=$TOTAL_JOBS"
+    echo "array_upper=$ARRAY_UPPER"
+    echo "output_file=$OUTPUT"
+} >&2
+
+

--- a/tests/test_complete_test_slurm.py
+++ b/tests/test_complete_test_slurm.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+
+
+def test_complete_test_slurm_exists():
+    root = Path(__file__).resolve().parents[1]
+    script = root / 'complete_test.slurm'
+    assert script.is_file()
+
+    text = script.read_text()
+    assert 'generate_clean_configs' in text
+    assert 'test_both_plumes_complete' in text
+    assert '#SBATCH --output=slurm_logs/complete_test/complete_test_logs_%j.out' in text
+
+
+def test_complete_test_slurm_logging():
+    """Check that the script logs diagnostics with a timestamp."""
+    root = Path(__file__).resolve().parents[1]
+    text = (root / 'complete_test.slurm').read_text()
+    assert 'TIMESTAMP=$(date +%Y%m%d_%H%M%S)' in text
+    assert 'diagnostics_${TIMESTAMP}' in text


### PR DESCRIPTION
## Summary
- extend SLURM workflow logging
- capture diagnostics with timestamped files
- test new logging behaviour

## Testing
- `bash setup_env.sh --dev --print`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840c518ff4c8320bd2434a1c2909e64