### PR TITLE
feat(slurm): add log directives

### DIFF
--- a/slurm_submit.sh
+++ b/slurm_submit.sh
@@ -40,7 +40,9 @@ JOBS_PER_COND=$(( (AGENTS_PER_CONDITION + AGENTS_PER_JOB -1)/AGENTS_PER_JOB ))
 TOTAL_JOBS=$(( JOBS_PER_COND * CONDITIONS ))
 ARRAY_UPPER=$(( TOTAL_JOBS - 1 ))
 
-mkdir -p "$(dirname "$OUTPUT")"
+LOG_DIR="slurm_logs/${EXP_NAME}"
+
+mkdir -p "$(dirname "$OUTPUT")" "$LOG_DIR"
 
 cat > "$OUTPUT" <<EOF2
 #!/bin/bash
@@ -48,6 +50,8 @@ cat > "$OUTPUT" <<EOF2
 #SBATCH --partition=${PARTITION}
 #SBATCH --time=${TIME_LIMIT}
 #SBATCH --mem=${MEM_PER_TASK}
+#SBATCH --output=${LOG_DIR}/${EXP_NAME}_logs_%A_%a.out
+#SBATCH --error=${LOG_DIR}/${EXP_NAME}_logs_%A_%a.err
 #SBATCH --array=0-${ARRAY_UPPER}%${MAX_CONCURRENT}
 
 $(cat slurm_job_template.slurm)

--- a/tests/test_slurm_submit.py
+++ b/tests/test_slurm_submit.py
@@ -30,6 +30,8 @@ def test_slurm_submit_creates_batch_file(tmp_path):
     content = output.read_text()
     assert '#SBATCH --array=0-15%100' in content
     assert '#SBATCH --job-name=test_sim' in content
+    assert '#SBATCH --output=slurm_logs/test/test_logs_%A_%a.out' in content
+    assert '#SBATCH --error=slurm_logs/test/test_logs_%A_%a.err' in content
 
 
 def test_slurm_submit_usage_option():


### PR DESCRIPTION
## Summary
- add log directory creation and output/error directives
- ensure new logs are tested

## Testing
- `setup_env.sh --dev` *(fails: conda not found)*
- `pytest -q` *(fails: matlab not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c9c736988320a00a60dc84b7844d