### PR TITLE
Add plume ingestion pipeline config

### DIFF
--- a/configs/pipeline/pipeline_plumes.json
+++ b/configs/pipeline/pipeline_plumes.json
@@ -1,0 +1,6 @@
+{
+  "plumes": [
+    "crimaldi_10cms_bounded",
+    "smoke_1a_backgroundsubtracted"
+  ]
+}

--- a/run_my_pipeline.sh
+++ b/run_my_pipeline.sh
@@ -10,6 +10,22 @@ echo "Pipeline started at $(date)"
 echo "Project Root: $PROJECT_ROOT"
 echo "--------------------------------------------------"
 
+# Show pipeline configuration
+PIPELINE_CFG="$PROJECT_ROOT/configs/pipeline/pipeline_plumes.json"
+if [ -f "$PIPELINE_CFG" ]; then
+    echo "STEP 0: Plumes configured for pipeline"
+    python3 - <<EOF
+import json
+with open('$PIPELINE_CFG') as f:
+    cfg = json.load(f)
+for plume in cfg.get('plumes', []):
+    print(f' - {plume}')
+EOF
+    echo ""
+else
+    echo "No pipeline config found at $PIPELINE_CFG"
+fi
+
 # Prepare directories
 mkdir -p "$PROJECT_ROOT/results" \
          "$PROJECT_ROOT/logs" \


### PR DESCRIPTION
## Summary
- extend `ingest_plume.py` to update a pipeline configuration
- show configured plumes when running the pipeline
- keep pipeline configs under `configs/pipeline`
- test that ingestion appends to the pipeline file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'h5py')*
- `pytest tests/test_setup_env.py::test_setup_env_usage_option -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ad3076508320b98606671b5a133f