### PR TITLE
Parameterize init plotting and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ The `slurm_submit.sh` helper script supports a `-h`/`--help` option that prints
 usage instructions and also logs the calculated array size and selected paths
 when invoked.
 
+## Plotting initialization zones
+
+First generate clean plume configurations using MATLAB:
+
+```bash
+matlab -batch "generate_clean_configs"
+```
+
+Then run the plotting script with the desired config paths:
+
+```bash
+bash run_matlab_safe.sh <<'EOF'
+plot_init_with_plumes('configs/plumes/crimaldi_10cms_bounded.json', ...
+                      'configs/plumes/smoke_1a_backgroundsubtracted.json');
+EOF
+```
+
+This will create `results/init_zones_with_plumes.png`. Remember to execute
+`pytest -q` before committing any changes.
+
 
 ## License
 

--- a/plot_init_with_plumes.m
+++ b/plot_init_with_plumes.m
@@ -1,14 +1,28 @@
+function plot_init_with_plumes(crim_cfg_file, smoke_cfg_file)
 % plot_init_with_plumes.m - Plot initialization zones with actual plume data
 
-fprintf('=== Plotting Initialization Zones with Plume Data ===\n\n');
+if nargin < 1 || isempty(crim_cfg_file)
+    crim_cfg_file = 'configs/plumes/crimaldi_10cms_bounded.json';
+end
+if nargin < 2 || isempty(smoke_cfg_file)
+    smoke_cfg_file = 'configs/plumes/smoke_1a_backgroundsubtracted.json';
+end
+
+fprintf('=== Plotting Initialization Zones with Plume Data ===\n');
+fprintf('Crimaldi config: %s\n', crim_cfg_file);
+fprintf('Smoke config:    %s\n\n', smoke_cfg_file);
 
 %% Load configs
-crim_cfg = jsondecode(fileread('configs/plumes/crimaldi_10cms_bounded.json'));
-smoke_cfg = jsondecode(fileread('configs/plumes/smoke_1a_backgroundsubtracted.json'));
+crim_cfg = jsondecode(fileread(crim_cfg_file));
+smoke_cfg = jsondecode(fileread(smoke_cfg_file));
 
 % Get initialization parameters
 init_x = crim_cfg.simulation.agent_initialization.x_range_cm;
 init_y = crim_cfg.simulation.agent_initialization.y_range_cm;
+success_radius = crim_cfg.simulation.success_radius_cm;
+fprintf('Init X range: [%.1f, %.1f] cm\n', init_x(1), init_x(2));
+fprintf('Init Y range: [%.1f, %.1f] cm\n', init_y(1), init_y(2));
+fprintf('Success radius: %.1f cm\n', success_radius);
 
 %% Load plume data (middle frame)
 fprintf('Loading plume data...\n');
@@ -183,3 +197,4 @@ fprintf('Crimaldi: min=%.3f, max=%.3f, mean=%.3f\n', ...
         min(crim_data(:)), max(crim_data(:)), mean(crim_data(:)));
 fprintf('Smoke: min=%.3f, max=%.3f, mean=%.3f\n', ...
         min(smoke_data(:)), max(smoke_data(:)), mean(smoke_data(:)));
+end

--- a/tests/test_plot_init_script.py
+++ b/tests/test_plot_init_script.py
@@ -1,0 +1,55 @@
+import json
+import subprocess
+from pathlib import Path
+import numpy as np
+import h5py
+
+
+def create_config(path, x_range, y_range, success_radius, h5_path):
+    cfg = {
+        "plume_id": "test",
+        "data_path": {"path": str(h5_path), "dataset_name": "/dataset2"},
+        "spatial": {
+            "resolution": {"width": 4, "height": 4},
+            "mm_per_pixel": 0.1,
+            "arena_bounds": {"x_min": -1, "x_max": 1, "y_min": -1, "y_max": 0}
+        },
+        "temporal": {"frame_rate": 10, "total_frames": 2},
+        "model_params": {"tscale": 0.2, "pxscale": 0.1},
+        "simulation": {
+            "success_radius_cm": success_radius,
+            "duration_seconds": 1,
+            "agent_initialization": {
+                "x_range_cm": x_range,
+                "y_range_cm": y_range,
+                "n_agents_per_job": 1
+            },
+            "source_position": {"x_cm": 0, "y_cm": 0}
+        }
+    }
+    path.write_text(json.dumps(cfg))
+
+
+def test_plot_init_reads_config(tmp_path):
+    h5_file = tmp_path / "plume.h5"
+    with h5py.File(h5_file, "w") as f:
+        f.create_dataset("dataset2", data=np.zeros((4, 4, 2)))
+
+    x_range = [-9, 9]
+    y_range = [-22, -18]
+    radius = 3.3
+
+    crim_cfg = tmp_path / "crim.json"
+    smoke_cfg = tmp_path / "smoke.json"
+    create_config(crim_cfg, x_range, y_range, radius, h5_file)
+    create_config(smoke_cfg, x_range, y_range, radius, h5_file)
+
+    root = Path(__file__).resolve().parents[1]
+    cmd = f"plot_init_with_plumes('{crim_cfg}', '{smoke_cfg}');"
+    result = subprocess.run([
+        'bash', str(root / 'run_matlab_safe.sh')
+    ], input=cmd, text=True, capture_output=True, cwd=root)
+
+    assert str(x_range[0]) in result.stdout
+    assert str(y_range[0]) in result.stdout
+    assert str(radius) in result.stdout


### PR DESCRIPTION
## Summary
- allow `plot_init_with_plumes` to accept config arguments
- log initialization ranges and success radius
- add test that verifies values come from configs
- document config-based plotting workflow in README

## Testing
- `bash setup_env.sh --dev`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'h5py')*

------
https://chatgpt.com/codex/tasks/task_e_684197ee4990832089dd2c6a495f570d